### PR TITLE
Standardize CI/CD Node.js version to v24

### DIFF
--- a/.github/workflows/validate-calculations.yml
+++ b/.github/workflows/validate-calculations.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run validation tests
         run: node tests/validate-arena-calculations.js

--- a/.github/workflows/validate-g6-encoding.yml
+++ b/.github/workflows/validate-g6-encoding.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run G6 encoding validation tests
         run: node tests/validate-g6-encoding.js


### PR DESCRIPTION
Update both validation workflows to use Node.js v24 (active LTS) for consistency. This aligns with PR #1's upgrade and ensures all CI/CD tests run on the same Node.js version.

- validate-calculations.yml: v20 → v24
- validate-g6-encoding.yml: v20 → v24