### PR TITLE
Fix grating pattern discontinuity on CCW arenas

### DIFF
--- a/arena_3d_viewer.html
+++ b/arena_3d_viewer.html
@@ -1437,7 +1437,12 @@
 
         function getLEDBrightness(px, py, colIndex, numCols, totalPixelsH) {
             const totalAzimuthPixels = numCols * totalPixelsH;
-            const globalPixelX = ((colIndex * totalPixelsH + px) + state.phaseOffset + totalAzimuthPixels) % totalAzimuthPixels;
+            // For CCW mode, mirror the pixel index within each panel
+            // to ensure grating tiles correctly when columns are placed clockwise
+            const effectivePx = (state.arena && state.arena.column_order === 'ccw')
+                ? (totalPixelsH - 1 - px)
+                : px;
+            const globalPixelX = ((colIndex * totalPixelsH + effectivePx) + state.phaseOffset + totalAzimuthPixels) % totalAzimuthPixels;
 
             if (state.pattern === 'allOn') {
                 return 1.0;


### PR DESCRIPTION
Mirror pixel index within panels for CCW mode to ensure grating and sine patterns tile correctly when columns are placed clockwise. Fixes issue #5 item 2 (grating for G4.1 CCW looks weird).

https://claude.ai/code/session_01KtGcBe6C8i6Mvg9NBNpSkx