### PR TITLE
Fix partial arena rendering: radial lines only at boundaries, R/L sym…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Interactive 3D visualization of cylindrical arenas:
 
 **[Launch Arena 3D View →](https://reiserlab.github.io/webDisplayTools/arena_3d_viewer.html)**
 
+### Pattern Icon Generator 🚧 In Development
+Generate top-down cylindrical view icons from arena patterns:
+- Single-frame and multi-frame motion blur rendering
+- Configurable perspective (inner radius 0.1-0.75)
+- Multiple background options (dark, white, transparent)
+- Supports full and partial arena configurations
+- PNG export for documentation and UI thumbnails
+
+**[Launch Pattern Icon Generator →](https://reiserlab.github.io/webDisplayTools/icon_generator.html)**
+
 ### Multi-Panel Patterns 🚧 Coming Soon
 Full-arena pattern design with animation support. Export to GIF/video for documentation.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,19 +42,18 @@
 - **If this shows uniform medium green, GS16 value range is still wrong**
 
 ### Test 4: Partial Arena (White Background)
-**Expected:** Gap with radial lines, NO green in gap area
-- Green appears on ~288° (8 of 10 columns)
-- Gap of ~72° (2 missing columns)
-- Radial lines connecting inner/outer at gap boundaries
+**Expected:** Gap with radial lines ONLY at boundaries, NO green in gap area
+- Green appears on ~252° (7 of 10 columns)
+- Gap of ~108° (3 missing columns: 0,1,2)
+- **CRITICAL**: Only 2 radial lines at gap boundaries (start and end), NOT multiple lines throughout
 - **CRITICAL**: WHITE background visible in gap area (NOT green!)
 - **If gap is filled with green, columns_installed is not being respected**
-- Gap orientation: columns 0 and 9 missing (bottom area)
-- **Note**: R/L symmetry may need adjustment (gap should ideally be centered at bottom)
+- Gap orientation: Centered at bottom for R/L symmetry
 
 ### Test 5: Partial Arena (Dark Background)
 **Expected:** Same as Test 4 but with dark background
 - Dark background visible in gap area
-- Gap clearly delineated by radial lines
+- Only 2 radial lines at gap boundaries (start/end)
 
 ## Bugs That Were Fixed
 

--- a/icon_generator.html
+++ b/icon_generator.html
@@ -420,7 +420,7 @@
         </div>
 
         <footer>
-            <p>Pattern Icon Generator v0.3 | 2026-02-01 11:28 ET</p>
+            <p>Pattern Icon Generator v0.4 | 2026-02-01 14:52 ET</p>
             <p><a href="index.html">← Back to Tools</a></p>
         </footer>
     </div>

--- a/js/icon-generator.js
+++ b/js/icon-generator.js
@@ -282,32 +282,27 @@ function renderCylindricalIcon(frameData, patternData, arenaConfig, opts) {
         ctx.strokeStyle = '#2d3640';  // border color
         ctx.lineWidth = 1;
 
+        // Find gap boundaries (transitions between installed and missing columns)
         for (let colIdx = 0; colIdx < numCols; colIdx++) {
-            if (!installedSet.has(colIdx)) {
-                // Draw radial lines for missing columns
-                let angle1, angle2;
+            const isCurrentInstalled = installedSet.has(colIdx);
+            const nextIdx = (colIdx + 1) % numCols;
+            const isNextInstalled = installedSet.has(nextIdx);
+
+            // Draw line only at transitions (installed -> missing or missing -> installed)
+            if (isCurrentInstalled !== isNextInstalled) {
+                let angle;
                 if (columnOrder === 'cw') {
-                    angle1 = BASE_OFFSET_RAD - colIdx * alpha;
-                    angle2 = BASE_OFFSET_RAD - (colIdx + 1) * alpha;
+                    angle = BASE_OFFSET_RAD - (colIdx + 1) * alpha;
                 } else {
-                    angle1 = BASE_OFFSET_RAD + colIdx * alpha;
-                    angle2 = BASE_OFFSET_RAD + (colIdx + 1) * alpha;
+                    angle = BASE_OFFSET_RAD + (colIdx + 1) * alpha;
                 }
 
-                // Draw line at start of gap
+                // Draw radial line at boundary
                 ctx.beginPath();
-                ctx.moveTo(centerX + innerRadius * Math.cos(angle1),
-                          centerY + innerRadius * Math.sin(angle1));
-                ctx.lineTo(centerX + outerRadius * Math.cos(angle1),
-                          centerY + outerRadius * Math.sin(angle1));
-                ctx.stroke();
-
-                // Draw line at end of gap
-                ctx.beginPath();
-                ctx.moveTo(centerX + innerRadius * Math.cos(angle2),
-                          centerY + innerRadius * Math.sin(angle2));
-                ctx.lineTo(centerX + outerRadius * Math.cos(angle2),
-                          centerY + outerRadius * Math.sin(angle2));
+                ctx.moveTo(centerX + innerRadius * Math.cos(angle),
+                          centerY + innerRadius * Math.sin(angle));
+                ctx.lineTo(centerX + outerRadius * Math.cos(angle),
+                          centerY + outerRadius * Math.sin(angle));
                 ctx.stroke();
             }
         }

--- a/test_generate_icons.html
+++ b/test_generate_icons.html
@@ -207,7 +207,7 @@
             console.error('Test 3 failed:', error);
         }
 
-        // Test 4: Partial arena (8 of 10 columns)
+        // Test 4: Partial arena (7 of 10 columns - R/L symmetric gap at bottom)
         try {
             console.log('Test 4: Partial arena');
             const specs = PANEL_SPECS['G6'];
@@ -230,7 +230,7 @@
                 generation: 'G6',
                 num_rows: 2,
                 num_cols: 10,
-                columns_installed: [1,2,3,4,5,6,7,8],  // Missing columns 0 and 9
+                columns_installed: [3,4,5,6,7,8,9],  // Missing columns 0,1,2 (gap at bottom, R/L symmetric)
                 column_order: 'cw'
             };
 
@@ -243,7 +243,7 @@
                 showGaps: true
             });
 
-            addIcon('Test 4: Partial Arena (8 of 10 cols, white bg)', dataURL, 'test4_partial_white.png');
+            addIcon('Test 4: Partial Arena (7 of 10 cols, gap at bottom, white bg)', dataURL, 'test4_partial_white.png');
         } catch (error) {
             console.error('Test 4 failed:', error);
         }
@@ -271,7 +271,7 @@
                 generation: 'G6',
                 num_rows: 2,
                 num_cols: 10,
-                columns_installed: [1,2,3,4,5,6,7,8],
+                columns_installed: [3,4,5,6,7,8,9],  // Missing columns 0,1,2
                 column_order: 'cw'
             };
 


### PR DESCRIPTION
…metric gap

Critical fixes for partial arena display:
1. Radial lines now only drawn at gap boundaries (transitions between installed/missing)
   - Was drawing lines for every missing column
   - Now only draws 2 lines: one at start of gap, one at end
   - Much cleaner visualization

2. Test cases updated for R/L symmetric gap at bottom
   - Changed from columns [1-8] (missing 0,9) to [3-9] (missing 0,1,2)
   - Creates single contiguous 108° gap centered at bottom
   - Properly demonstrates R/L symmetry

3. Updated README.md to document Pattern Icon Generator
   - Added feature list and description
   - Marked as "In Development"

4. Updated TESTING.md to match new behavior
   - Documents 2-line boundary expectation
   - Updated test case descriptions

Version bumped to v0.4 | 2026-02-01 14:52 ET

https://claude.ai/code/session_0162zsZjsoDQdnYSLmhTG5sq