### PR TITLE
Add pattern selection dropdown for folder uploads

### DIFF
--- a/icon_generator.html
+++ b/icon_generator.html
@@ -323,6 +323,14 @@
                         <div class="help-text">Select a folder like <code>G6_2x10</code> to auto-detect arena</div>
                     </div>
 
+                    <!-- Pattern file dropdown - shown after folder selection -->
+                    <div id="folder-pattern-select" class="control-group" style="display: none;">
+                        <label>Select Pattern from Folder</label>
+                        <select id="folder-pattern-dropdown">
+                            <option value="">-- Select a pattern --</option>
+                        </select>
+                    </div>
+
                     <div class="control-group">
                         <label>Or Generate Test Pattern</label>
                         <div class="test-pattern-grid">
@@ -455,7 +463,7 @@
         </div>
 
         <footer>
-            <p>Pattern Icon Generator v0.9 | 2026-02-02 10:44 ET</p>
+            <p>Pattern Icon Generator v0.9 | 2026-02-02 16:46 ET</p>
             <p><a href="index.html">← Back to Tools</a></p>
         </footer>
     </div>
@@ -465,6 +473,7 @@
         let currentArenaConfig = null;
         let currentIconDataURL = null;
         let currentFilename = null;
+        let folderPatFiles = null; // Store .pat files from folder selection
 
         // Initialize - wait for modules to load
         function init() {
@@ -567,6 +576,9 @@
             // Folder input
             document.getElementById('folder-input').addEventListener('change', handleFolderSelect);
 
+            // Folder pattern dropdown
+            document.getElementById('folder-pattern-dropdown').addEventListener('change', handleFolderPatternSelect);
+
             // Arena override dropdown
             document.getElementById('arena-select').addEventListener('change', handleArenaOverride);
 
@@ -606,7 +618,7 @@
             }
         }
 
-        async function handleFolderSelect(event) {
+        function handleFolderSelect(event) {
             const files = event.target.files;
             if (!files || files.length === 0) return;
 
@@ -615,21 +627,56 @@
 
             if (patFiles.length === 0) {
                 alert('No .pat files found in the selected folder');
+                document.getElementById('folder-pattern-select').style.display = 'none';
                 return;
             }
 
-            // Show file picker dialog for which pattern to load
-            const fileNames = patFiles.map(f => f.name);
-            const selectedName = patFiles.length === 1 ? patFiles[0].name :
-                prompt('Multiple .pat files found. Enter the filename to load:\n\n' + fileNames.join('\n'));
+            // Store files for later loading
+            folderPatFiles = patFiles;
 
-            if (!selectedName) return;
+            // Sort files alphabetically
+            patFiles.sort((a, b) => a.name.localeCompare(b.name));
 
-            const selectedFile = patFiles.find(f => f.name === selectedName);
-            if (!selectedFile) {
-                alert('File not found: ' + selectedName);
-                return;
+            // Populate dropdown
+            const dropdown = document.getElementById('folder-pattern-dropdown');
+            dropdown.innerHTML = '<option value="">-- Select a pattern --</option>';
+
+            patFiles.forEach((file, index) => {
+                const option = document.createElement('option');
+                option.value = index;
+                option.textContent = file.name;
+                dropdown.appendChild(option);
+            });
+
+            // Show the dropdown
+            document.getElementById('folder-pattern-select').style.display = 'block';
+
+            // Try to detect arena from folder name (first file's path)
+            const firstFilePath = patFiles[0].webkitRelativePath || patFiles[0].name;
+            const arenaResult = inferArenaFromPath(firstFilePath);
+
+            if (arenaResult) {
+                updateArenaDisplay(arenaResult.name, arenaResult.config);
+                currentArenaConfig = arenaResult.config.arena;
+            } else {
+                // Show warning but let user continue - they can select arena manually later
+                showArenaError(firstFilePath);
+                document.getElementById('arena-override').style.display = 'block';
             }
+
+            // If only one file, auto-select it
+            if (patFiles.length === 1) {
+                dropdown.value = '0';
+                handleFolderPatternSelect({ target: dropdown });
+            }
+        }
+
+        async function handleFolderPatternSelect(event) {
+            const index = event.target.value;
+            if (index === '' || !folderPatFiles) return;
+
+            const selectedFile = folderPatFiles[parseInt(index)];
+            if (!selectedFile) return;
 
             try {
                 const arrayBuffer = await selectedFile.arrayBuffer();
@@ -641,12 +688,14 @@
 
                 console.log('Folder file path:', filepath); // Debug
 
-                // Try to infer arena from the path (folder name now available!)
+                // Try to infer arena from the path (folder name or filename)
                 const arenaResult = inferArenaFromPath(filepath);
 
                 if (!arenaResult) {
                     showArenaError(filepath);
                     showArenaOverride(patternData);
+                    // Still update pattern UI
+                    updatePatternUI(patternData, selectedFile.name);
                     return;
                 }
 


### PR DESCRIPTION
## Summary
Refactored the folder selection workflow to use a dropdown menu instead of a prompt dialog for choosing which .pat file to load when multiple files are present in a folder.

## Key Changes
- Added a new "Select Pattern from Folder" dropdown that appears after folder selection
- Converted `handleFolderSelect()` from async to sync function, splitting pattern loading into separate `handleFolderPatternSelect()` handler
- Dropdown is populated with all .pat files found in the selected folder, sorted alphabetically
- Auto-selects and loads the pattern if only one .pat file is found in the folder
- Improved arena detection to work with the new dropdown workflow
- Arena detection now happens immediately after folder selection, before pattern file selection
- Updated timestamp in footer (v0.9 | 2026-02-02 16:46 ET)

## Implementation Details
- Added `folderPatFiles` variable to store .pat files from folder selection for later access
- Dropdown shows file names as options with index values for tracking
- Arena override section now displays if arena cannot be auto-detected from folder path
- Pattern UI updates even when arena detection fails, allowing users to manually select arena
- Maintains backward compatibility with single-file folder selections through auto-selection

https://claude.ai/code/session_01TYAc66n5YanUfWmER5C9hu