### PR TITLE
fall back to web when maDisplayTool is not a sibling

### DIFF
--- a/js/arena-configs.js
+++ b/js/arena-configs.js
@@ -1,7 +1,7 @@
 /**
  * Arena Configurations
  * Auto-generated from maDisplayTools/configs/arenas/
- * Last updated: 2026-02-05T04:51:33.254Z
+ * Last updated: 2026-02-11T13:29:21.223Z
  *
  * DO NOT EDIT MANUALLY - regenerate with: node scripts/generate-arena-configs.js
  */
@@ -199,9 +199,9 @@ const GENERATIONS = {
 
 // Arena ID registry — per-generation namespaces (from maDisplayTools/configs/arena_registry/index.yaml)
 const ARENA_REGISTRY = {
-    'G4':   { 1: 'G4_4x12', 2: 'G4_3x12of18' },
-    'G4.1': { 1: 'G41_2x12_cw' },
-    'G6':   { 1: 'G6_2x10', 2: 'G6_2x8of10', 3: 'G6_3x12of18' }
+    'G4':    { 1: 'G4_4x12', 2: 'G4_3x12of18' },
+    'G4.1':  { 1: 'G41_2x12_cw' },
+    'G6':    { 1: 'G6_2x10', 2: 'G6_2x8of10', 3: 'G6_3x12of18' }
 };
 
 /**

--- a/js/arena-configs.js
+++ b/js/arena-configs.js
@@ -1,7 +1,7 @@
 /**
  * Arena Configurations
  * Auto-generated from maDisplayTools/configs/arenas/
- * Last updated: 2026-01-30T15:23:37.594Z
+ * Last updated: 2026-02-05T04:51:33.254Z
  *
  * DO NOT EDIT MANUALLY - regenerate with: node scripts/generate-arena-configs.js
  */
@@ -66,6 +66,19 @@ const STANDARD_CONFIGS = {
       "orientation": "normal",
       "column_order": "cw",
       "angle_offset_deg": -60
+    }
+  },
+  "G6_3x16_full": {
+    "label": "G6 (3×16) - 360°",
+    "description": "G6 arena, 3 rows × 16 columns",
+    "arena": {
+      "generation": "G6",
+      "num_rows": 3,
+      "num_cols": 16,
+      "columns_installed": null,
+      "orientation": "normal",
+      "column_order": "cw",
+      "angle_offset_deg": 0
     }
   },
   "G41_2x12_ccw": {

--- a/js/arena-configs.js
+++ b/js/arena-configs.js
@@ -1,7 +1,7 @@
 /**
  * Arena Configurations
  * Auto-generated from maDisplayTools/configs/arenas/
- * Last updated: 2026-02-11T13:29:21.223Z
+ * Last updated: 2026-02-11T13:35:39.006Z
  *
  * DO NOT EDIT MANUALLY - regenerate with: node scripts/generate-arena-configs.js
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,36 @@
 {
     "name": "web-display-tools",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "web-display-tools",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "devDependencies": {
+                "js-yaml": "^4.1.1",
                 "prettier": "^3.8.1"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
         "test": "node tests/validate-arena-calculations.js",
         "validate": "node tests/validate-arena-calculations.js",
         "format": "prettier --write \"**/*.js\"",
-        "format:check": "prettier --check \"**/*.js\""
+        "format:check": "prettier --check \"**/*.js\"",
+        "generate:configs": "node scripts/generate-arena-configs.js"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "author": "Reiser Lab",
     "license": "MIT",
     "devDependencies": {
+        "js-yaml": "^4.1.1",
         "prettier": "^3.8.1"
     }
 }

--- a/scripts/generate-arena-configs.js
+++ b/scripts/generate-arena-configs.js
@@ -7,13 +7,21 @@
  * Usage:
  *   node scripts/generate-arena-configs.js [config-dir]
  *
- * If config-dir is not specified, looks for:
- *   1. temp_configs/ (CI/CD fetched configs)
- *   2. ../maDisplayTools/configs/arenas/ (local development)
+ * Config sources (in order of priority):
+ *   1. Command-line argument path
+ *   2. temp_configs/ (CI/CD fetched configs)
+ *   3. ../maDisplayTools/configs/arenas/ (local development)
+ *   4. GitHub: reiserlab/maDisplayTools feature/g6-tools branch (fallback download)
  */
 
 const fs = require('fs');
 const path = require('path');
+const https = require('https');
+
+// GitHub configuration for fallback download
+const GITHUB_REPO = 'reiserlab/maDisplayTools';
+const GITHUB_BRANCH = 'feature/g6-tools';
+const GITHUB_CONFIG_PATH = 'configs/arenas';
 
 // Simple YAML parser for our arena config format
 function parseYAML(yamlText) {
@@ -48,7 +56,7 @@ function parseYAML(yamlText) {
                 if (arrayContent.trim() === '') {
                     currentSection[key] = [];
                 } else {
-                    currentSection[key] = arrayContent.split(',').map(v => {
+                    currentSection[key] = arrayContent.split(',').map((v) => {
                         v = v.trim();
                         const num = parseFloat(v);
                         return isNaN(num) ? v.replace(/^"|"$/g, '') : num;
@@ -101,7 +109,7 @@ function generateLabel(parsed) {
     if (columnsInstalled && Array.isArray(columnsInstalled)) {
         // columns_installed is always column indices (0-indexed)
         const installedCols = columnsInstalled.length;
-        const coverageDeg = Math.round(360 * installedCols / cols);
+        const coverageDeg = Math.round((360 * installedCols) / cols);
         coverage = `${coverageDeg}°`;
     }
 
@@ -111,78 +119,151 @@ function generateLabel(parsed) {
     return `${gen}${orderSuffix} (${rows}×${cols}) - ${coverage}`;
 }
 
-// Find config directory
-function findConfigDir() {
+/**
+ * Make an HTTPS GET request and return the response body
+ * @param {string} url - URL to fetch
+ * @returns {Promise<string>} Response body
+ */
+function httpsGet(url) {
+    return new Promise((resolve, reject) => {
+        const options = {
+            headers: {
+                'User-Agent': 'webDisplayTools-config-generator'
+            }
+        };
+
+        https
+            .get(url, options, (res) => {
+                // Handle redirects
+                if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                    httpsGet(res.headers.location).then(resolve).catch(reject);
+                    return;
+                }
+
+                if (res.statusCode !== 200) {
+                    reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
+                    return;
+                }
+
+                let data = '';
+                res.on('data', (chunk) => (data += chunk));
+                res.on('end', () => resolve(data));
+                res.on('error', reject);
+            })
+            .on('error', reject);
+    });
+}
+
+/**
+ * Fetch the list of YAML files from GitHub API
+ * @returns {Promise<Array<{name: string, download_url: string}>>}
+ */
+async function fetchGitHubFileList() {
+    const apiUrl = `https://api.github.com/repos/${GITHUB_REPO}/contents/${GITHUB_CONFIG_PATH}?ref=${GITHUB_BRANCH}`;
+    console.log(`  Fetching file list from GitHub API...`);
+
+    const response = await httpsGet(apiUrl);
+    const files = JSON.parse(response);
+
+    // Filter for YAML files only
+    return files
+        .filter((f) => f.type === 'file' && (f.name.endsWith('.yaml') || f.name.endsWith('.yml')))
+        .map((f) => ({
+            name: f.name,
+            download_url: f.download_url
+        }));
+}
+
+/**
+ * Download YAML files from GitHub to a temporary directory
+ * @returns {Promise<string>} Path to temp directory with downloaded files
+ */
+async function downloadFromGitHub() {
+    console.log(`Downloading configs from GitHub: ${GITHUB_REPO}@${GITHUB_BRANCH}`);
+
+    // Create temp directory
+    const tempDir = path.join(process.cwd(), 'temp_configs');
+    if (!fs.existsSync(tempDir)) {
+        fs.mkdirSync(tempDir, { recursive: true });
+    }
+
+    // Get list of YAML files
+    const files = await fetchGitHubFileList();
+
+    if (files.length === 0) {
+        throw new Error('No YAML files found in GitHub repository');
+    }
+
+    console.log(`  Found ${files.length} YAML files`);
+
+    // Download each file
+    for (const file of files) {
+        console.log(`  Downloading: ${file.name}`);
+        const content = await httpsGet(file.download_url);
+        fs.writeFileSync(path.join(tempDir, file.name), content);
+    }
+
+    console.log(`  Downloaded to: ${tempDir}`);
+    return tempDir;
+}
+
+/**
+ * Find config directory, downloading from GitHub if necessary
+ * @returns {Promise<string>} Path to config directory
+ */
+async function findConfigDir() {
     // Check command line argument
     if (process.argv[2]) {
-        return process.argv[2];
+        const argDir = process.argv[2];
+        if (fs.existsSync(argDir)) {
+            return argDir;
+        }
+        console.error(`Warning: Specified directory not found: ${argDir}`);
     }
 
     // Check for CI/CD fetched configs
     const ciDir = path.join(process.cwd(), 'temp_configs');
     if (fs.existsSync(ciDir)) {
-        return ciDir;
+        const yamlFiles = fs
+            .readdirSync(ciDir)
+            .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+        if (yamlFiles.length > 0) {
+            console.log('Using existing temp_configs/ directory');
+            return ciDir;
+        }
     }
 
     // Check for local maDisplayTools
     const localDir = path.join(process.cwd(), '..', 'maDisplayTools', 'configs', 'arenas');
     if (fs.existsSync(localDir)) {
-        return localDir;
+        const yamlFiles = fs
+            .readdirSync(localDir)
+            .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+        if (yamlFiles.length > 0) {
+            console.log('Using local maDisplayTools configs');
+            return localDir;
+        }
     }
 
-    console.error('Error: Could not find config directory.');
-    console.error('Provide path as argument or ensure temp_configs/ or ../maDisplayTools/configs/arenas/ exists.');
-    process.exit(1);
-}
-
-// Main
-function main() {
-    const configDir = findConfigDir();
-    const outputFile = path.join(process.cwd(), 'js', 'arena-configs.js');
-
-    console.log(`Reading configs from: ${configDir}`);
-
-    const configs = {};
-    const files = fs.readdirSync(configDir).filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
-
-    if (files.length === 0) {
-        console.error('Error: No YAML files found in config directory.');
+    // Fallback: download from GitHub
+    console.log('Local configs not found, downloading from GitHub...');
+    try {
+        return await downloadFromGitHub();
+    } catch (err) {
+        console.error(`Error downloading from GitHub: ${err.message}`);
+        console.error('\nCould not find config directory. Options:');
+        console.error(
+            '  1. Provide path as argument: node scripts/generate-arena-configs.js <path>'
+        );
+        console.error('  2. Ensure ../maDisplayTools/configs/arenas/ exists locally');
+        console.error('  3. Check network connection for GitHub download');
         process.exit(1);
     }
+}
 
-    for (const file of files) {
-        const content = fs.readFileSync(path.join(configDir, file), 'utf8');
-        const parsed = parseYAML(content);
-        const name = file.replace(/\.ya?ml$/, '');
-
-        configs[name] = {
-            label: generateLabel(parsed),
-            description: parsed.description || '',
-            arena: parsed.arena
-        };
-
-        console.log(`  Parsed: ${name} -> ${configs[name].label}`);
-    }
-
-    // Sort configs by generation then by name
-    const sortedConfigs = {};
-    const sortOrder = ['G6', 'G4.1', 'G4', 'G3'];
-
-    Object.keys(configs)
-        .sort((a, b) => {
-            const genA = configs[a].arena?.generation || '';
-            const genB = configs[b].arena?.generation || '';
-            const orderA = sortOrder.indexOf(genA);
-            const orderB = sortOrder.indexOf(genB);
-            if (orderA !== orderB) return orderA - orderB;
-            return a.localeCompare(b);
-        })
-        .forEach(key => {
-            sortedConfigs[key] = configs[key];
-        });
-
-    // Generate output
-    const output = `/**
+// Generate the output JavaScript file
+function generateOutput(sortedConfigs) {
+    return `/**
  * Arena Configurations
  * Auto-generated from maDisplayTools/configs/arenas/
  * Last updated: ${new Date().toISOString()}
@@ -253,7 +334,70 @@ function getConfigsByGeneration() {
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = { STANDARD_CONFIGS, PANEL_SPECS, getConfig, getConfigsByGeneration };
 }
+
+// Browser global export (for non-module scripts)
+if (typeof window !== 'undefined') {
+    window.STANDARD_CONFIGS = STANDARD_CONFIGS;
+    window.PANEL_SPECS = PANEL_SPECS;
+    window.getConfig = getConfig;
+    window.getConfigsByGeneration = getConfigsByGeneration;
+}
+
+// ES6 module export
+export { STANDARD_CONFIGS, PANEL_SPECS, getConfig, getConfigsByGeneration };
 `;
+}
+
+// Main
+async function main() {
+    const configDir = await findConfigDir();
+    const outputFile = path.join(process.cwd(), 'js', 'arena-configs.js');
+
+    console.log(`Reading configs from: ${configDir}`);
+
+    const configs = {};
+    const files = fs
+        .readdirSync(configDir)
+        .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+
+    if (files.length === 0) {
+        console.error('Error: No YAML files found in config directory.');
+        process.exit(1);
+    }
+
+    for (const file of files) {
+        const content = fs.readFileSync(path.join(configDir, file), 'utf8');
+        const parsed = parseYAML(content);
+        const name = file.replace(/\.ya?ml$/, '');
+
+        configs[name] = {
+            label: generateLabel(parsed),
+            description: parsed.description || '',
+            arena: parsed.arena
+        };
+
+        console.log(`  Parsed: ${name} -> ${configs[name].label}`);
+    }
+
+    // Sort configs by generation then by name
+    const sortedConfigs = {};
+    const sortOrder = ['G6', 'G4.1', 'G4', 'G3'];
+
+    Object.keys(configs)
+        .sort((a, b) => {
+            const genA = configs[a].arena?.generation || '';
+            const genB = configs[b].arena?.generation || '';
+            const orderA = sortOrder.indexOf(genA);
+            const orderB = sortOrder.indexOf(genB);
+            if (orderA !== orderB) return orderA - orderB;
+            return a.localeCompare(b);
+        })
+        .forEach((key) => {
+            sortedConfigs[key] = configs[key];
+        });
+
+    // Generate output
+    const output = generateOutput(sortedConfigs);
 
     // Ensure js/ directory exists
     const jsDir = path.dirname(outputFile);
@@ -265,4 +409,7 @@ if (typeof module !== 'undefined' && module.exports) {
     console.log(`\nGenerated ${outputFile} with ${Object.keys(sortedConfigs).length} configs`);
 }
 
-main();
+main().catch((err) => {
+    console.error('Error:', err.message);
+    process.exit(1);
+});

--- a/scripts/generate-arena-configs.js
+++ b/scripts/generate-arena-configs.js
@@ -22,6 +22,7 @@ const https = require('https');
 const GITHUB_REPO = 'reiserlab/maDisplayTools';
 const GITHUB_BRANCH = 'feature/g6-tools';
 const GITHUB_CONFIG_PATH = 'configs/arenas';
+const GITHUB_REGISTRY_PATH = 'configs/arena_registry';
 
 // Simple YAML parser for our arena config format
 function parseYAML(yamlText) {
@@ -91,6 +92,116 @@ function parseYAML(yamlText) {
     }
 
     return config;
+}
+
+/**
+ * Parse generations.yaml — maps numeric IDs to generation info
+ * Format: top-level "generations:" section with numeric keys (0, 1, 2, ...)
+ * each containing { name, panel_size, deprecated? }
+ */
+function parseGenerationsYAML(yamlText) {
+    const generations = {};
+    let currentId = null;
+
+    for (const line of yamlText.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+
+        // Match generation ID line (2-space indent, numeric key only)
+        const idMatch = line.match(/^  (\d+):$/);
+        if (idMatch) {
+            currentId = parseInt(idMatch[1]);
+            generations[currentId] = {};
+            continue;
+        }
+
+        // Non-numeric key at 2-space indent (e.g., "  6-7:") — reset context
+        if (line.match(/^  \S+:/) && !line.match(/^    /)) {
+            currentId = null;
+            continue;
+        }
+
+        // Match property under a generation (4-space indent)
+        if (currentId !== null) {
+            const propMatch = line.match(/^    (\w+):\s*(.+?)(?:\s*#.*)?$/);
+            if (propMatch) {
+                const key = propMatch[1];
+                let value = propMatch[2].trim();
+
+                if (value === 'null') value = null;
+                else if (value === 'true') value = true;
+                else if (value === 'false') value = false;
+                else if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+                else if (!isNaN(parseFloat(value))) value = parseFloat(value);
+
+                generations[currentId][key] = value;
+                continue;
+            }
+        }
+
+        // Non-indented lines reset context (e.g., "generations:" header, "version: 1")
+        if (!line.startsWith(' ')) {
+            currentId = null;
+        }
+    }
+
+    return generations;
+}
+
+/**
+ * Parse index.yaml — maps generation keys to arena ID→name mappings
+ * Format: top-level generation keys (G4, G41, G6) with numeric sub-keys
+ * Uses generations data to map YAML keys (G41) to canonical names (G4.1)
+ */
+function parseRegistryIndexYAML(yamlText, generations) {
+    const registry = {};
+
+    // Build mapping from YAML-safe keys (G41) to canonical names (G4.1)
+    const yamlKeyToName = {};
+    for (const gen of Object.values(generations)) {
+        if (gen.name) {
+            yamlKeyToName[gen.name] = gen.name;
+            yamlKeyToName[gen.name.replace('.', '')] = gen.name;
+        }
+    }
+
+    let currentGen = null;
+
+    for (const line of yamlText.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+
+        // Match generation section header (top-level key, no value)
+        const genMatch = line.match(/^(\w[\w.]*):$/);
+        if (genMatch) {
+            const yamlKey = genMatch[1];
+            const canonicalName = yamlKeyToName[yamlKey];
+            if (canonicalName) {
+                currentGen = canonicalName;
+                registry[currentGen] = {};
+            } else {
+                currentGen = null;
+            }
+            continue;
+        }
+
+        // Match arena ID → name mapping (indented)
+        if (currentGen) {
+            const arenaMatch = line.match(/^\s+(\d+):\s*(\S+)/);
+            if (arenaMatch) {
+                const arenaId = parseInt(arenaMatch[1]);
+                const arenaName = arenaMatch[2];
+                registry[currentGen][arenaId] = arenaName;
+            }
+        }
+
+        // Top-level key:value lines (like "version: 1") reset context
+        if (!line.startsWith(' ') && !line.match(/^(\w[\w.]*):$/)) {
+            currentGen = null;
+        }
+    }
+
+    return registry;
 }
 
 // Generate human-readable label from config
@@ -261,8 +372,115 @@ async function findConfigDir() {
     }
 }
 
+/**
+ * Download registry files (generations.yaml, index.yaml) from GitHub
+ * @param {string} targetDir - Parent directory to create arena_registry/ in
+ * @returns {Promise<string>} Path to registry directory
+ */
+async function downloadRegistryFromGitHub(targetDir) {
+    const registryDir = path.join(targetDir, 'arena_registry');
+    if (!fs.existsSync(registryDir)) {
+        fs.mkdirSync(registryDir, { recursive: true });
+    }
+
+    const baseUrl = `https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}/${GITHUB_REGISTRY_PATH}`;
+    const files = ['generations.yaml', 'index.yaml'];
+
+    for (const file of files) {
+        console.log(`  Downloading: arena_registry/${file}`);
+        const content = await httpsGet(`${baseUrl}/${file}`);
+        fs.writeFileSync(path.join(registryDir, file), content);
+    }
+
+    return registryDir;
+}
+
+/**
+ * Parse registry files from a directory
+ * @param {string} dir - Directory containing generations.yaml and index.yaml
+ * @returns {{generations: Object, arenaRegistry: Object}}
+ */
+function parseRegistryFiles(dir) {
+    const genText = fs.readFileSync(path.join(dir, 'generations.yaml'), 'utf8');
+    const idxText = fs.readFileSync(path.join(dir, 'index.yaml'), 'utf8');
+
+    const generations = parseGenerationsYAML(genText);
+    const arenaRegistry = parseRegistryIndexYAML(idxText, generations);
+
+    return { generations, arenaRegistry };
+}
+
+/**
+ * Load registry data (generations + arena index) from local files or GitHub
+ * @param {string} configDir - The arena configs directory (used to find sibling registry dir)
+ * @returns {Promise<{generations: Object, arenaRegistry: Object}>}
+ */
+async function loadRegistryData(configDir) {
+    // Candidate directories for registry files
+    const candidates = [
+        // Sibling to configDir (local maDisplayTools: configs/arenas/ → configs/arena_registry/)
+        path.join(configDir, '..', 'arena_registry'),
+        // Subdirectory of configDir (temp_configs/ → temp_configs/arena_registry/)
+        path.join(configDir, 'arena_registry'),
+        // Absolute local path
+        path.join(process.cwd(), '..', 'maDisplayTools', 'configs', 'arena_registry')
+    ];
+
+    for (const dir of candidates) {
+        const genFile = path.join(dir, 'generations.yaml');
+        const idxFile = path.join(dir, 'index.yaml');
+        if (fs.existsSync(genFile) && fs.existsSync(idxFile)) {
+            console.log(`Reading registry from: ${dir}`);
+            return parseRegistryFiles(dir);
+        }
+    }
+
+    // Fallback: download from GitHub
+    console.log('Registry files not found locally, downloading from GitHub...');
+    try {
+        const registryDir = await downloadRegistryFromGitHub(configDir);
+        return parseRegistryFiles(registryDir);
+    } catch (err) {
+        console.error(`Error downloading registry from GitHub: ${err.message}`);
+        console.error('\nCould not find registry files (generations.yaml, index.yaml). Options:');
+        console.error('  1. Ensure ../maDisplayTools/configs/arena_registry/ exists locally');
+        console.error('  2. Check network connection for GitHub download');
+        process.exit(1);
+    }
+}
+
+/**
+ * Format GENERATIONS object as JavaScript source
+ */
+function formatGenerationsJS(generations) {
+    const ids = Object.keys(generations).map(Number).sort((a, b) => a - b);
+    const lines = ids.map((id) => {
+        const gen = generations[id];
+        const props = [`name: '${gen.name}'`, `panel_size: ${gen.panel_size}`];
+        if (gen.deprecated) props.push('deprecated: true');
+        return `    ${id}: { ${props.join(', ')} }`;
+    });
+    return `{\n${lines.join(',\n')}\n}`;
+}
+
+/**
+ * Format ARENA_REGISTRY object as JavaScript source
+ */
+function formatArenaRegistryJS(registry) {
+    const lines = Object.entries(registry).map(([gen, arenas]) => {
+        const arenaEntries = Object.entries(arenas)
+            .sort(([a], [b]) => parseInt(a) - parseInt(b))
+            .map(([id, name]) => `${id}: '${name}'`);
+        const padding = ' '.repeat(Math.max(1, 6 - gen.length));
+        return `    '${gen}':${padding}{ ${arenaEntries.join(', ')} }`;
+    });
+    return `{\n${lines.join(',\n')}\n}`;
+}
+
 // Generate the output JavaScript file
-function generateOutput(sortedConfigs) {
+function generateOutput(sortedConfigs, registryData) {
+    const { generations, arenaRegistry } = registryData;
+
     return `/**
  * Arena Configurations
  * Auto-generated from maDisplayTools/configs/arenas/
@@ -272,6 +490,60 @@ function generateOutput(sortedConfigs) {
  */
 
 const STANDARD_CONFIGS = ${JSON.stringify(sortedConfigs, null, 2)};
+
+// Generation ID registry (from maDisplayTools/configs/arena_registry/generations.yaml)
+const GENERATIONS = ${formatGenerationsJS(generations)};
+
+// Arena ID registry — per-generation namespaces (from maDisplayTools/configs/arena_registry/index.yaml)
+const ARENA_REGISTRY = ${formatArenaRegistryJS(arenaRegistry)};
+
+/**
+ * Get generation name from ID
+ * @param {number} id - Generation ID (0-7)
+ * @returns {string} Generation name or 'unknown'
+ */
+function getGenerationName(id) {
+    return GENERATIONS[id] ? GENERATIONS[id].name : 'unknown';
+}
+
+/**
+ * Get generation ID from name
+ * @param {string} name - Generation name (e.g., 'G6', 'G4.1')
+ * @returns {number} Generation ID or 0
+ */
+function getGenerationId(name) {
+    for (const [id, gen] of Object.entries(GENERATIONS)) {
+        if (gen.name === name) return parseInt(id);
+    }
+    return 0;
+}
+
+/**
+ * Get arena config name from generation and arena ID
+ * @param {string} generation - Generation name (e.g., 'G6', 'G4')
+ * @param {number} arenaId - Arena ID
+ * @returns {string|null} Arena config name or null
+ */
+function getArenaName(generation, arenaId) {
+    const genRegistry = ARENA_REGISTRY[generation];
+    if (!genRegistry) return null;
+    return genRegistry[arenaId] || null;
+}
+
+/**
+ * Get arena ID from generation and config name
+ * @param {string} generation - Generation name (e.g., 'G6', 'G4')
+ * @param {string} arenaName - Arena config name (e.g., 'G6_2x10')
+ * @returns {number} Arena ID or 0
+ */
+function getArenaId(generation, arenaName) {
+    const genRegistry = ARENA_REGISTRY[generation];
+    if (!genRegistry) return 0;
+    for (const [id, name] of Object.entries(genRegistry)) {
+        if (name === arenaName) return parseInt(id);
+    }
+    return 0;
+}
 
 // Panel specifications by generation
 const PANEL_SPECS = {
@@ -332,19 +604,33 @@ function getConfigsByGeneration() {
 
 // Export for both browser and Node.js
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { STANDARD_CONFIGS, PANEL_SPECS, getConfig, getConfigsByGeneration };
+    module.exports = {
+        STANDARD_CONFIGS, PANEL_SPECS, GENERATIONS, ARENA_REGISTRY,
+        getConfig, getConfigsByGeneration,
+        getGenerationName, getGenerationId, getArenaName, getArenaId
+    };
 }
 
 // Browser global export (for non-module scripts)
 if (typeof window !== 'undefined') {
     window.STANDARD_CONFIGS = STANDARD_CONFIGS;
     window.PANEL_SPECS = PANEL_SPECS;
+    window.GENERATIONS = GENERATIONS;
+    window.ARENA_REGISTRY = ARENA_REGISTRY;
     window.getConfig = getConfig;
     window.getConfigsByGeneration = getConfigsByGeneration;
+    window.getGenerationName = getGenerationName;
+    window.getGenerationId = getGenerationId;
+    window.getArenaName = getArenaName;
+    window.getArenaId = getArenaId;
 }
 
 // ES6 module export
-export { STANDARD_CONFIGS, PANEL_SPECS, getConfig, getConfigsByGeneration };
+export {
+    STANDARD_CONFIGS, PANEL_SPECS, GENERATIONS, ARENA_REGISTRY,
+    getConfig, getConfigsByGeneration,
+    getGenerationName, getGenerationId, getArenaName, getArenaId
+};
 `;
 }
 
@@ -396,8 +682,12 @@ async function main() {
             sortedConfigs[key] = configs[key];
         });
 
+    // Load registry data (generations + arena index)
+    const registryData = await loadRegistryData(configDir);
+    console.log(`  Loaded ${Object.keys(registryData.generations).length} generations, ${Object.values(registryData.arenaRegistry).reduce((n, g) => n + Object.keys(g).length, 0)} arena registry entries`);
+
     // Generate output
-    const output = generateOutput(sortedConfigs);
+    const output = generateOutput(sortedConfigs, registryData);
 
     // Ensure js/ directory exists
     const jsDir = path.dirname(outputFile);


### PR DESCRIPTION
The generate-arena-config.js script assumes, that maDisplayTools lives in a sibling folder. If this isn't the case, this new version downloads the most recent version from github. Possibly this could be the default?

If I run this right now, I get one more arena: G6_3x16_full