### PR TITLE
v3 Experiment Designer — v0.1 Viewer (parallel page beta)

### DIFF
--- a/.github/workflows/validate-protocol-roundtrip.yml
+++ b/.github/workflows/validate-protocol-roundtrip.yml
@@ -4,19 +4,30 @@ on:
   push:
     paths:
       - 'experiment_designer.html'
+      - 'experiment_designer_v3.html'
       - 'js/protocol-yaml.js'
+      - 'js/protocol-yaml-v3.js'
       - 'js/plugin-registry.js'
       - 'tests/test-protocol-roundtrip.js'
+      - 'tests/test-protocol-roundtrip-v3.js'
       - 'tests/generate-roundtrip-protocol.js'
       - 'tests/fixtures/v2_*.yaml'
+      - 'tests/fixtures/v3_*.yaml'
+      - 'package.json'
       - '.github/workflows/validate-protocol-roundtrip.yml'
   pull_request:
     paths:
       - 'experiment_designer.html'
+      - 'experiment_designer_v3.html'
       - 'js/protocol-yaml.js'
+      - 'js/protocol-yaml-v3.js'
       - 'js/plugin-registry.js'
       - 'tests/test-protocol-roundtrip.js'
+      - 'tests/test-protocol-roundtrip-v3.js'
       - 'tests/generate-roundtrip-protocol.js'
+      - 'tests/fixtures/v2_*.yaml'
+      - 'tests/fixtures/v3_*.yaml'
+      - 'package.json'
   workflow_dispatch:
 
 jobs:
@@ -32,13 +43,19 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Run protocol roundtrip tests
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Run v2 protocol roundtrip tests
         run: node tests/test-protocol-roundtrip.js
 
-      - name: Generate roundtrip YAML (smoke test)
+      - name: Run v3 protocol roundtrip tests
+        run: node tests/test-protocol-roundtrip-v3.js
+
+      - name: Generate v2 roundtrip YAML (smoke test)
         run: node tests/generate-roundtrip-protocol.js --outdir /tmp/roundtrip-output
 
-      - name: Verify generated files exist
+      - name: Verify generated v2 files exist
         run: |
           echo "Checking generated files..."
           ls -la /tmp/roundtrip-output/
@@ -53,7 +70,7 @@ jobs:
         run: |
           echo "## Protocol YAML Roundtrip Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Test Suites (130 checks):" >> $GITHUB_STEP_SUMMARY
+          echo "### v2 Test Suites (130 checks):" >> $GITHUB_STEP_SUMMARY
           echo "- Suite 1: V1 Generate → Parse Roundtrip" >> $GITHUB_STEP_SUMMARY
           echo "- Suite 2: Comment-Handling Regression" >> $GITHUB_STEP_SUMMARY
           echo "- Suite 3: Excluded Phases" >> $GITHUB_STEP_SUMMARY
@@ -64,9 +81,15 @@ jobs:
           echo "- Suite 8: V2 All Possible Plugins (serial, class, script)" >> $GITHUB_STEP_SUMMARY
           echo "- Suite 9: V2 Generate → Parse Roundtrip (plugins+params)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### v3 Test Suite:" >> $GITHUB_STEP_SUMMARY
+          echo "- Canonical round-trip (Phase 1): anchors + comments preserved" >> $GITHUB_STEP_SUMMARY
+          echo "- Coverage-gap fixtures (Phase 7): multi-block, randomize=false, no-vars, no-ITI, refs-only, future-keys, plugin-config, G6" >> $GITHUB_STEP_SUMMARY
+          echo "- _Note: Phase 0 ships a stub; Phase 1 populates the real suite._" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Generated Files:" >> $GITHUB_STEP_SUMMARY
           echo "- test_protocol_v1.yaml + manifest (legacy)" >> $GITHUB_STEP_SUMMARY
           echo "- test_protocol_v2.yaml + manifest (plugins, multi-command conditions)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "> **MATLAB validation (35 checks)**: Run locally with" >> $GITHUB_STEP_SUMMARY
+          echo "> **MATLAB validation (v2)**: Run locally with" >> $GITHUB_STEP_SUMMARY
           echo "> \`validate_web_protocol_roundtrip('v2')\` in maDisplayTools." >> $GITHUB_STEP_SUMMARY
+          echo "> **MATLAB validation (v3)**: Manual flow via the matlab MCP server (see \`docs/development/v3-matlab-validation.md\`, added in PR2)." >> $GITHUB_STEP_SUMMARY

--- a/docs/development/ROADMAP.md
+++ b/docs/development/ROADMAP.md
@@ -1,5 +1,37 @@
 # webDisplayTools Roadmap
 
+## v3 Experiment Designer (beta)
+
+A new designer for the **Protocol v3** YAML format introduced in maDisplayTools
+on `origin/version3` (pinned SHA `00c8f95`). Lives alongside the existing v2
+Experiment Designer; the v2 designer stays untouched while v3 iterates. After
+the v3 editor (PR2) lands and the lab confirms v3 production use, a follow-up
+effort retires v2.
+
+### PR1 — v0.1 Viewer / Importer (in progress)
+Read-only 3-zone view of imported v3 YAMLs.
+- **Phase 0** (in progress): canonical fixtures, coverage-gap fixtures (MATLAB-validated),
+  js-yaml spike (PASSED — 100% anchor/alias/comment preservation on canonical files),
+  spec doc, CI wiring, stub page.
+- **Phase 1**: js-yaml-based parser/generator with anchor + comment round-trip;
+  unknown-keys passthrough at every nesting level.
+- **Phase 2**: read-only viewer (Library / Sequence / Inspector + bottom timeline preview).
+
+### PR2 — v0.2 Editor (planned)
+- Inline editing, drag/drop, Variables UX, atomic import + validation, rename cascade.
+- Quickstart page (`experiment_designer_v3_quickstart.html`).
+- Manual MATLAB validation flow documented (no GitHub-Actions MATLAB CI).
+
+### Retirement of v2 Experiment Designer (post-PR2)
+Separate follow-up effort. Triggered by lab confirming v3 production use over
+~2–4 weeks.
+
+### Reference
+- Spec doc: [`docs/development/v3-spec.md`](v3-spec.md)
+- Planning notes / Codex review artifacts: archived in `.codex-review/` (gitignored)
+
+---
+
 ## Pattern Editor
 
 ### v1.0 Milestone (Pending Hardware Validation)

--- a/docs/development/v3-spec.md
+++ b/docs/development/v3-spec.md
@@ -25,6 +25,27 @@ designer exists to view and edit data they could represent. Run
 `tests/refresh-v3-canonical.sh` to re-fetch them at a newer SHA; any `git diff`
 output is a signal the spec drifted upstream.
 
+### MATLAB-side validation (manual flow)
+
+The maDisplayTools v3 `ProtocolParser.m` calls `yaml.loadFile`, which lives in
+the third-party [MartinKoch123/yaml](https://github.com/MartinKoch123/yaml)
+library (NOT MATLAB base; NOT Text Analytics Toolbox). To validate a v3 YAML
+against the upstream parser locally:
+
+```matlab
+% One-time setup (clone the YAML library and add it to the path):
+%   git clone https://github.com/MartinKoch123/yaml.git /tmp/matlab-yaml-namespaced
+addpath('/tmp/matlab-yaml-namespaced');
+addpath(genpath('/path/to/maDisplayTools'));  % must be on origin/version3
+parser = ProtocolParser();
+result = parser.parse('tests/fixtures/v3_canonical_a.yaml');
+```
+
+The canonical fixtures use absolute paths pinned to a single developer's
+machine. For portable MATLAB validation, use the rig-path-normalized copies in
+`tests/fixtures/matlab_normalized/` (rewritten to the user's local
+`maDisplayTools` checkout location).
+
 ---
 
 ## Top-level structure

--- a/docs/development/v3-spec.md
+++ b/docs/development/v3-spec.md
@@ -46,6 +46,26 @@ machine. For portable MATLAB validation, use the rig-path-normalized copies in
 `tests/fixtures/matlab_normalized/` (rewritten to the user's local
 `maDisplayTools` checkout location).
 
+### Cross-check (designer round-trip vs. MATLAB flattened step sequence)
+
+For a regenerated YAML to be considered round-trip-equivalent to its original,
+the MATLAB ProtocolParser must produce the same flattened `commandSequence`
+when fed either version. Randomized blocks reorder per parse via `randperm`,
+so the comparison is only meaningful with the RNG seeded:
+
+```matlab
+rng(42);
+ro = ProtocolParser().parse('original.yaml');
+rng(42);
+rr = ProtocolParser().parse('regenerated.yaml');
+% Compare step ids cell-array element-by-element (must be byte-identical).
+```
+
+When the RNG is seeded identically, randomized blocks produce identical
+orderings. When unseeded, only the *multiset* of step ids per block is
+guaranteed equal (and even that depends on whether MATLAB's `randperm` is
+sampling with or without replacement — verify per block type before asserting).
+
 ---
 
 ## Top-level structure

--- a/docs/development/v3-spec.md
+++ b/docs/development/v3-spec.md
@@ -1,0 +1,166 @@
+# Protocol v3 YAML — Spec by Example
+
+This document describes the **Protocol v3** YAML format as implemented in
+maDisplayTools at the pinned commit below. It is the JS-side reference for
+the v3 Experiment Designer (`experiment_designer_v3.html`). It defers to the
+MATLAB `ProtocolParser.m` as the ultimate authority — if this doc disagrees
+with the canonical example files or the MATLAB parser, the latter wins.
+
+---
+
+## Pinned upstream version
+
+- Repo: `reiserlab/maDisplayTools`
+- Branch: `origin/version3`
+- Commit SHA: **`00c8f9561bb1915a36d54054aeadf89778888ba2`** (`00c8f95`, captured 2026-05-23)
+
+The two canonical example YAMLs from this commit are committed verbatim in
+this repo as:
+
+- `tests/fixtures/v3_canonical_a.yaml` ← `examples/yamls/experimentExampleVersion3.yaml`
+- `tests/fixtures/v3_canonical_b.yaml` ← `examples/yamls/version3Attempt.yaml`
+
+**These files are the spec.** The v3 parser exists to round-trip them; the
+designer exists to view and edit data they could represent. Run
+`tests/refresh-v3-canonical.sh` to re-fetch them at a newer SHA; any `git diff`
+output is a signal the spec drifted upstream.
+
+---
+
+## Top-level structure
+
+Canonical field order, as emitted by the canonical examples:
+
+```yaml
+version: 3
+experiment_info: {...}    # required
+rig: '<path>'             # required — path to a rig YAML on disk
+variables: {...}          # optional — YAML anchor definitions
+plugins: [...]            # optional — class/script/serial plugin definitions
+experiment: [...]         # required — ordered heterogeneous sequence
+conditions: [...]         # required — flat library of named command sequences
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `version` | int | yes | Must equal `3` for the v3 designer; the parser rejects `1` and `2`. |
+| `experiment_info` | map | yes | `name`, `date_created`, `author`, `pattern_library` |
+| `rig` | string (path) | yes | Replaces v2's inline `arena_info`. The MATLAB parser loads this file. |
+| `variables` | map | no | Map of name → value, declared with `&anchor`. Used via `*alias` anywhere in the file. |
+| `plugins` | list | no | Each entry: `name`, `type` (`class`/`script`/`serial`), and a type-specific config block (`matlab: {class}` for class plugins). |
+| `experiment` | list | yes | The ordered sequence — heterogeneous (see below). |
+| `conditions` | list | yes | Flat library of `{name, commands}` objects. At least one required. |
+
+---
+
+## The `experiment:` sequence
+
+The `experiment:` list is **heterogeneous**: each entry is either
+
+- a **bare string** — a reference to a named condition in the library, or
+- a **block object** — a map with the keys below.
+
+```yaml
+experiment:
+  - "arena_check"               # bare reference — runs the named condition once
+  - name: "main block"          # block object
+    trials: ["cond_a", "cond_b", "cond_c"]
+    repetitions: 3              # optional, default 1
+    randomize: true             # optional, default false
+    intertrial: "intertrial_c"  # optional — REFERENCE to a condition, not inline
+  - "posttrial"
+```
+
+| Block key | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | no | Human-readable label. Defaults to an auto-generated `block_N` if omitted. |
+| `trials` | list of condition names | yes | Each name must exist in `conditions`. Non-empty. |
+| `repetitions` | int | no, default 1 | Number of times the `trials` list runs. |
+| `randomize` | bool | no, default false | If true, each repetition shuffles `trials` independently (MATLAB uses `randperm`). |
+| `intertrial` | condition name | no | Condition inserted between consecutive trials in this block (not after the final trial of the final rep). |
+
+**Reserved future-compat keys** (not yet implemented in the MATLAB parser but
+to be passed through by the designer): `retry_on_fail`, `abort_if`,
+`repeat_until`, `branch_to`, `branch`, `adaptive`.
+
+---
+
+## The `conditions:` library
+
+```yaml
+conditions:
+  - name: "arena_check"
+    commands:
+      - {type: "controller", command_name: "allOn"}
+      - {type: "wait", duration: *dur_long}
+      - {type: "controller", command_name: "allOff"}
+```
+
+Each condition is `{name: <string>, commands: <list>}`. Commands have a
+`type` field (`controller`, `wait`, or `plugin`) plus type-specific fields,
+exactly as v2 used. Notable v3 additions:
+
+- `trialParams` commands carry a `pattern_ID: <int>` field (added during SD-card prep).
+- Plugin commands include a `params: {...}` map.
+
+---
+
+## Variables / anchors / comments
+
+Users hand-author v3 YAMLs and **rely on anchors and comments** to keep
+protocols maintainable. The designer therefore must round-trip both.
+
+**Anchors.** Defined in the optional `variables:` block (or anywhere in
+the file). The designer uses `js-yaml` Document mode
+(`yaml.parseDocument({keepSourceTokens: true})`) which preserves anchor names
+and alias references at their source positions. A scalar that was written as
+`*dur_long` round-trips as `*dur_long`, not as the literal value `10`.
+
+**Comments.** Whole-line `# ...` comments and trailing `value  # ...` comments
+are preserved by Document mode.
+
+**Designer scope.** The editor UI supports binding/unbinding scalar anchors
+(numbers, strings, booleans). Complex anchors that bind whole maps or lists
+(or that use YAML merge keys `<<: *anchor`) round-trip transparently but
+appear in the editor as read-only "advanced anchor" badges — the user must
+hand-edit them in YAML.
+
+---
+
+## Designer constraints (known)
+
+The designer is **not** the authoritative parser. If MATLAB accepts a file
+the designer rejects, the designer is wrong. Known constraints:
+
+- Complex anchors (map/list/merge) are read-only in the editor (see above).
+- Randomized blocks: the timeline preview shows a *sample* order and labels
+  the block "randomized". Runtime order in MATLAB will differ per repetition.
+- Plugin types beyond `class` are accepted on import (passed through) but the
+  Settings UI in v0.2 will not provide first-class affordances for them; users
+  hand-edit those plugin entries in the Variables drawer.
+- Unknown keys at any level (top-level, plugin, condition, command, params)
+  are preserved via `_unknownKeys` slots in the data model.
+
+---
+
+## Reference: features exercised by the canonical examples
+
+- 1 block object with `trials`, `repetitions: 3`, `randomize: true`, `intertrial: "intertrial"`
+- 2 bare refs before the block (`"arena check"`, `"start light and camera"`); 1 bare ref after (`"posttrial"`)
+- 4 scalar anchors in `variables:` (`dur_long`, `dur_short`, `color_command`, `color_power`)
+  - Strings AND numbers, used in `duration:`, `command_name:`, and inside `params:` maps
+- 2 plugins, both `type: "class"` (`BiasPlugin`, `LEDControllerPlugin`), no inline `config:`
+- 11 conditions in the library
+- ~18 comment lines
+
+**Coverage gaps the canonical examples don't exercise** (the designer test
+suite synthesizes these — see `tests/fixtures/v3_*.yaml`):
+
+- Multiple blocks at different repetition counts
+- `randomize: false`
+- No `variables:` section
+- No `intertrial:`
+- Consecutive bare refs (no block at all)
+- Forward-compat keys (`retry_on_fail`, `abort_if`)
+- Plugins with inline `config:` overrides
+- Non-G4 arena generations

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -3,119 +3,1117 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>v3 Experiment Designer (under construction)</title>
+    <title>v3 Experiment Designer (Viewer)</title>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
+
+    <!-- Import map: lets js/protocol-yaml-v3.js's `import YAML from 'yaml'`
+         resolve to the CDN-hosted browser build. Same module is consumable
+         in Node (via node_modules/yaml) and browser (via this import map). -->
+    <script type="importmap">
+    {
+        "imports": {
+            "yaml": "https://cdn.jsdelivr.net/npm/yaml@2.9.0/browser/dist/index.js"
+        }
+    }
+    </script>
+
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         :root {
             --bg: #0f1419;
             --surface: #1a1f26;
+            --surface-2: #232a33;
             --border: #2d3640;
             --text: #e6edf3;
             --text-dim: #8b949e;
             --accent: #00e676;
             --hover: #00c853;
             --beta: #29b6f6;
+            --warn: #ff9800;
+            --error: #f44336;
+            --ref-bg: rgba(0, 230, 118, 0.08);
+            --block-bg: rgba(41, 182, 246, 0.08);
+            --selected: rgba(0, 230, 118, 0.18);
         }
 
+        html, body { height: 100%; }
         body {
             font-family: 'IBM Plex Mono', monospace;
             background: var(--bg);
             color: var(--text);
-            min-height: 100vh;
+            font-size: 13px;
+            line-height: 1.4;
             display: flex;
             flex-direction: column;
+            overflow: hidden;
+        }
+
+        /* ── Header ─────────────────────────────────────────────────── */
+        .app-header {
+            display: flex;
             align-items: center;
-            justify-content: center;
-            padding: 2rem;
-        }
-
-        .card {
+            gap: 0.75rem;
+            padding: 0.5rem 1rem;
             background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            padding: 2.5rem;
-            max-width: 640px;
-            text-align: center;
+            border-bottom: 1px solid var(--border);
+            flex-shrink: 0;
         }
-
-        h1 {
+        .app-header h1 {
             font-family: 'JetBrains Mono', monospace;
-            font-size: 1.8rem;
+            font-size: 1.1rem;
             color: var(--accent);
-            margin-bottom: 0.5rem;
+            font-weight: 700;
         }
-
         .beta-badge {
             display: inline-block;
-            padding: 0.25rem 0.6rem;
-            border-radius: 4px;
-            font-size: 0.7rem;
+            padding: 0.1rem 0.5rem;
+            font-size: 0.65rem;
             font-weight: 600;
             text-transform: uppercase;
             letter-spacing: 0.5px;
             background: rgba(41, 182, 246, 0.15);
             color: var(--beta);
             border: 1px solid var(--beta);
-            margin-left: 0.5rem;
-            vertical-align: middle;
+            border-radius: 3px;
         }
+        .header-spacer { flex: 1; }
+        .header-btn {
+            background: var(--surface-2);
+            color: var(--text);
+            border: 1px solid var(--border);
+            padding: 0.35rem 0.75rem;
+            font-family: inherit;
+            font-size: 0.8rem;
+            cursor: pointer;
+            border-radius: 3px;
+        }
+        .header-btn:hover { background: var(--border); border-color: var(--accent); color: var(--accent); }
+        .header-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .header-btn.primary { background: rgba(0, 230, 118, 0.1); border-color: var(--accent); color: var(--accent); }
+        .header-btn.primary:hover { background: rgba(0, 230, 118, 0.2); }
 
-        p {
+        /* ── View-only banner ────────────────────────────────────────── */
+        .view-only-banner {
+            padding: 0.4rem 1rem;
+            background: rgba(41, 182, 246, 0.08);
+            border-bottom: 1px solid var(--border);
+            color: var(--beta);
+            font-size: 0.75rem;
+            flex-shrink: 0;
+        }
+        .view-only-banner a { color: var(--accent); text-decoration: none; }
+        .view-only-banner a:hover { color: var(--hover); text-decoration: underline; }
+
+        /* ── Settings drawer ─────────────────────────────────────────── */
+        .settings-drawer {
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+            padding: 0;
+            overflow: hidden;
+            max-height: 0;
+            transition: max-height 0.2s ease-out;
+            flex-shrink: 0;
+        }
+        .settings-drawer.open { max-height: 360px; overflow-y: auto; }
+        .settings-drawer-inner {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 1rem;
+            padding: 1rem;
+        }
+        .settings-section h3 {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
             color: var(--text-dim);
+            margin-bottom: 0.5rem;
+        }
+        .settings-section .kv {
+            font-size: 0.8rem;
             line-height: 1.6;
-            margin-top: 1rem;
         }
-
-        a {
-            color: var(--accent);
-            text-decoration: none;
+        .settings-section .kv .k { color: var(--text-dim); }
+        .settings-section .kv .v { color: var(--text); word-break: break-all; }
+        .vars-table {
+            width: 100%;
+            font-size: 0.75rem;
+            border-collapse: collapse;
         }
-
-        a:hover {
-            color: var(--hover);
+        .vars-table th, .vars-table td {
+            padding: 0.2rem 0.4rem;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
         }
+        .vars-table th { color: var(--text-dim); font-weight: 400; }
+        .vars-table .num { text-align: right; font-family: 'JetBrains Mono', monospace; color: var(--accent); }
+        .vars-table .str { color: var(--accent); }
 
-        .links {
-            margin-top: 1.5rem;
+        /* ── 3-zone main area ────────────────────────────────────────── */
+        .three-zone {
+            display: grid;
+            grid-template-columns: 280px 1fr 360px;
+            flex: 1;
+            min-height: 0;
+            border-bottom: 1px solid var(--border);
+        }
+        .zone {
+            border-right: 1px solid var(--border);
             display: flex;
-            justify-content: center;
-            gap: 1.5rem;
-            font-size: 0.9rem;
+            flex-direction: column;
+            min-height: 0;
         }
-
-        footer {
-            margin-top: 2rem;
+        .zone:last-child { border-right: none; }
+        .zone-header {
+            padding: 0.5rem 0.75rem;
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
             color: var(--text-dim);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            flex-shrink: 0;
+        }
+        .zone-header .count {
+            background: var(--surface-2);
+            padding: 0.05rem 0.4rem;
+            border-radius: 8px;
+            color: var(--accent);
+            font-size: 0.65rem;
+        }
+        .zone-body {
+            flex: 1;
+            overflow-y: auto;
+            padding: 0.5rem;
+        }
+        .empty-state {
+            color: var(--text-dim);
+            font-style: italic;
+            padding: 1rem 0.5rem;
             font-size: 0.8rem;
         }
+
+        /* ── Library ─────────────────────────────────────────────────── */
+        .library-search {
+            margin: 0 0 0.5rem 0;
+            padding: 0.35rem 0.5rem;
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            color: var(--text);
+            font-family: inherit;
+            font-size: 0.8rem;
+            border-radius: 3px;
+            width: 100%;
+        }
+        .library-search:focus { outline: none; border-color: var(--accent); }
+        .lib-row {
+            padding: 0.4rem 0.5rem;
+            border: 1px solid transparent;
+            border-radius: 3px;
+            cursor: pointer;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 0.4rem;
+            margin-bottom: 1px;
+        }
+        .lib-row:hover { background: var(--surface-2); border-color: var(--border); }
+        .lib-row.selected { background: var(--selected); border-color: var(--accent); }
+        .lib-row .name { font-size: 0.8rem; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .lib-row .usage {
+            font-size: 0.65rem;
+            color: var(--text-dim);
+            background: var(--surface-2);
+            padding: 0.05rem 0.4rem;
+            border-radius: 8px;
+            flex-shrink: 0;
+        }
+        .lib-row.unused .name { color: var(--text-dim); }
+        .lib-row.unused .usage { color: var(--warn); }
+
+        /* ── Sequence ────────────────────────────────────────────────── */
+        .seq-entry {
+            margin-bottom: 0.5rem;
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            background: var(--surface);
+            cursor: pointer;
+            transition: border-color 0.1s, background 0.1s;
+        }
+        .seq-entry:hover { border-color: var(--accent); }
+        .seq-entry.selected { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(0, 230, 118, 0.15); }
+        .seq-entry.ref {
+            background: var(--ref-bg);
+            padding: 0.5rem 0.75rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .seq-entry.ref .marker { color: var(--accent); font-weight: 700; }
+        .seq-entry.ref .name { font-family: 'JetBrains Mono', monospace; }
+        .seq-entry.block { background: var(--block-bg); padding: 0.6rem 0.75rem; }
+        .seq-entry.block .block-name {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            color: var(--beta);
+            font-size: 0.85rem;
+            margin-bottom: 0.3rem;
+        }
+        .seq-entry.block .block-meta {
+            font-size: 0.7rem;
+            color: var(--text-dim);
+            margin-bottom: 0.4rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+        }
+        .seq-entry.block .block-meta .randomize-badge {
+            color: var(--warn);
+            font-weight: 600;
+        }
+        .seq-entry.block .trials-row { display: flex; flex-wrap: wrap; gap: 0.25rem; }
+        .trial-chip {
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            padding: 0.15rem 0.4rem;
+            border-radius: 10px;
+            font-size: 0.7rem;
+            font-family: 'JetBrains Mono', monospace;
+        }
+        .trial-chip.missing { color: var(--error); border-color: var(--error); }
+        .iti-row {
+            margin-top: 0.4rem;
+            font-size: 0.7rem;
+            color: var(--text-dim);
+        }
+        .iti-row .iti-ref { color: var(--accent); }
+        .unknown-keys-pill {
+            margin-top: 0.4rem;
+            display: inline-block;
+            background: rgba(255, 152, 0, 0.1);
+            border: 1px solid var(--warn);
+            color: var(--warn);
+            padding: 0.1rem 0.4rem;
+            border-radius: 8px;
+            font-size: 0.65rem;
+        }
+
+        /* ── Inspector ───────────────────────────────────────────────── */
+        .inspector-title {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.95rem;
+            font-weight: 700;
+            color: var(--accent);
+            margin-bottom: 0.5rem;
+            word-break: break-all;
+        }
+        .inspector-title .kind { font-size: 0.7rem; color: var(--text-dim); text-transform: uppercase; margin-right: 0.4rem; }
+        .insp-section { margin-bottom: 0.75rem; }
+        .insp-section h4 {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-dim);
+            margin-bottom: 0.3rem;
+        }
+        .cmd-card {
+            border: 1px solid var(--border);
+            border-radius: 3px;
+            padding: 0.4rem 0.5rem;
+            margin-bottom: 0.3rem;
+            background: var(--surface);
+            font-size: 0.75rem;
+        }
+        .cmd-card.controller { border-left: 3px solid var(--accent); }
+        .cmd-card.wait { border-left: 3px solid var(--text-dim); }
+        .cmd-card.plugin { border-left: 3px solid var(--beta); }
+        .cmd-card .cmd-head { font-weight: 600; margin-bottom: 0.2rem; }
+        .cmd-card .cmd-head .ctype { color: var(--text-dim); font-weight: 400; font-size: 0.65rem; text-transform: uppercase; margin-right: 0.3rem; }
+        .cmd-card .kv-line { font-size: 0.7rem; color: var(--text-dim); }
+        .cmd-card .kv-line .k { display: inline-block; min-width: 80px; }
+        .cmd-card .kv-line .v { color: var(--text); }
+        .jump-btn {
+            background: rgba(0, 230, 118, 0.1);
+            border: 1px solid var(--accent);
+            color: var(--accent);
+            padding: 0.25rem 0.6rem;
+            font-family: inherit;
+            font-size: 0.75rem;
+            border-radius: 3px;
+            cursor: pointer;
+        }
+        .jump-btn:hover { background: rgba(0, 230, 118, 0.25); }
+
+        /* ── Bottom timeline ─────────────────────────────────────────── */
+        .timeline-container {
+            flex-shrink: 0;
+            background: var(--surface);
+            border-top: 1px solid var(--border);
+            max-height: 180px;
+            display: flex;
+            flex-direction: column;
+        }
+        .timeline-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0.4rem 0.75rem;
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-dim);
+            flex-shrink: 0;
+        }
+        .timeline-track {
+            display: flex;
+            gap: 2px;
+            padding: 0.5rem 0.75rem;
+            overflow-x: auto;
+            overflow-y: hidden;
+            flex: 1;
+        }
+        .step {
+            flex-shrink: 0;
+            min-width: 60px;
+            border-radius: 3px;
+            padding: 0.3rem 0.4rem;
+            font-size: 0.65rem;
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            overflow: hidden;
+        }
+        .step.ref { background: var(--ref-bg); border-color: var(--accent); }
+        .step.block-trial { background: var(--block-bg); border-color: var(--beta); }
+        .step.iti { background: rgba(139, 148, 158, 0.05); border-color: var(--border); color: var(--text-dim); min-width: 40px; }
+        .step .step-label { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .step .step-dur { color: var(--text-dim); margin-top: 0.1rem; }
+        .randomize-note {
+            font-size: 0.7rem;
+            color: var(--warn);
+            margin: 0.25rem 0.75rem;
+            font-style: italic;
+        }
+
+        /* ── App footer ──────────────────────────────────────────────── */
+        .app-footer {
+            padding: 0.4rem 1rem;
+            background: var(--surface);
+            border-top: 1px solid var(--border);
+            color: var(--text-dim);
+            font-size: 0.7rem;
+            flex-shrink: 0;
+        }
+        .app-footer a { color: var(--accent); text-decoration: none; }
+        .app-footer a:hover { color: var(--hover); }
+
+        /* ── Modal ───────────────────────────────────────────────────── */
+        .modal-backdrop {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.6);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 100;
+        }
+        .modal-backdrop.open { display: flex; }
+        .modal {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 1.25rem;
+            max-width: 600px;
+            max-height: 80vh;
+            overflow-y: auto;
+        }
+        .modal h2 { font-family: 'JetBrains Mono', monospace; color: var(--error); margin-bottom: 0.5rem; }
+        .modal pre { background: var(--bg); padding: 0.75rem; border-radius: 3px; font-size: 0.75rem; white-space: pre-wrap; word-break: break-word; }
+        .modal-actions { margin-top: 1rem; text-align: right; }
     </style>
 </head>
 <body>
-    <div class="card">
-        <h1>v3 Experiment Designer<span class="beta-badge">Beta / Viewer</span></h1>
-        <p>
-            This page will host a new designer for the <strong>Protocol v3</strong> YAML format
-            introduced in maDisplayTools (<code>origin/version3</code>).
-        </p>
-        <p>
-            <strong>PR1 (v0.1)</strong> ships a read-only viewer/importer that round-trips
-            v3 YAMLs with anchors and comments preserved.
-            <strong>PR2 (v0.2)</strong> adds inline editing, drag/drop, the Variables UX, and validation.
-        </p>
-        <p>
-            Until v0.1 lands, please use the existing
-            <a href="experiment_designer.html">Experiment Designer</a>
-            (v2 YAML format only).
-        </p>
-        <div class="links">
-            <a href="index.html">← All tools</a>
-            <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">GitHub</a>
+    <!-- Header -->
+    <div class="app-header">
+        <h1>v3 Experiment Designer</h1>
+        <span class="beta-badge">Beta / Viewer</span>
+        <div class="header-spacer"></div>
+        <button id="settingsToggle" class="header-btn" title="Show/hide experiment metadata, rig, plugins, variables">Settings ▾</button>
+        <input type="file" id="fileInput" accept=".yaml,.yml" style="display: none;">
+        <button id="importBtn" class="header-btn primary" title="Load a v3 protocol YAML file">Import YAML</button>
+        <button id="exportBtn" class="header-btn" disabled title="Re-export the loaded YAML (round-trip)">Export YAML</button>
+        <a href="index.html" class="header-btn" style="text-decoration: none; display: inline-flex; align-items: center;">← All tools</a>
+    </div>
+
+    <!-- View-only banner -->
+    <div class="view-only-banner">
+        <strong>View only.</strong> v0.1 viewer round-trips v3 YAML preserving anchors and comments — editing arrives in v0.2.
+        Open in the <a href="experiment_designer.html">v2 Experiment Designer</a> to edit a v2 protocol.
+    </div>
+
+    <!-- Settings drawer -->
+    <div id="settingsDrawer" class="settings-drawer">
+        <div class="settings-drawer-inner" id="settingsContent">
+            <!-- populated by JS -->
         </div>
     </div>
-    <footer>
-        <p>v3 Experiment Designer (stub) | scaffolded 2026-05-24 ET</p>
-    </footer>
+
+    <!-- 3-zone main -->
+    <div class="three-zone">
+        <!-- LIBRARY -->
+        <div class="zone" id="libraryZone">
+            <div class="zone-header">
+                <span>Library</span>
+                <span class="count" id="libCount">0</span>
+            </div>
+            <div class="zone-body">
+                <input type="text" class="library-search" id="librarySearch" placeholder="Search conditions..." disabled>
+                <div id="libraryList">
+                    <div class="empty-state">Import a v3 YAML to populate the conditions library.</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- SEQUENCE -->
+        <div class="zone" id="sequenceZone">
+            <div class="zone-header">
+                <span>Experiment Sequence</span>
+                <span class="count" id="seqCount">0</span>
+            </div>
+            <div class="zone-body">
+                <div id="sequenceList">
+                    <div class="empty-state">Import a v3 YAML to view the experiment sequence.</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- INSPECTOR -->
+        <div class="zone" id="inspectorZone">
+            <div class="zone-header">
+                <span>Inspector</span>
+            </div>
+            <div class="zone-body" id="inspectorBody">
+                <div class="empty-state">Select a condition in the Library or an entry in the Sequence to view details.</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bottom timeline -->
+    <div class="timeline-container">
+        <div class="timeline-header">
+            <span>Flattened Timeline Preview</span>
+            <span id="timelineNote" style="font-size: 0.65rem; color: var(--text-dim); text-transform: none;"></span>
+        </div>
+        <div class="timeline-track" id="timelineTrack">
+            <div class="empty-state">No timeline to preview yet.</div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="app-footer">
+        <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
+        v3 Experiment Designer v0.1 | <span id="footerTimestamp">2026-05-24 ET</span>
+    </div>
+
+    <!-- Error modal -->
+    <div class="modal-backdrop" id="errorModal">
+        <div class="modal">
+            <h2 id="modalTitle">Import error</h2>
+            <pre id="modalBody"></pre>
+            <div class="modal-actions">
+                <button class="header-btn" id="modalClose">Close</button>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import { parseV3Protocol, generateV3Protocol, validateReferences, V3ParseError }
+            from './js/protocol-yaml-v3.js';
+
+        // ═══════════════════════════════════════════════════════════════
+        // State
+        // ═══════════════════════════════════════════════════════════════
+
+        let experiment = null;        // current parsed v3 protocol
+        let lastFilename = null;       // for export naming
+        let selection = null;          // { kind: 'condition', name } | { kind: 'block', index } | { kind: 'ref', index }
+        let librarySearchText = '';
+
+        // ═══════════════════════════════════════════════════════════════
+        // DOM helpers
+        // ═══════════════════════════════════════════════════════════════
+
+        const $ = (id) => document.getElementById(id);
+        const el = (tag, props = {}, ...children) => {
+            const e = document.createElement(tag);
+            for (const [k, v] of Object.entries(props)) {
+                if (k === 'class') e.className = v;
+                else if (k === 'onClick') e.addEventListener('click', v);
+                else if (k === 'dataset') for (const [dk, dv] of Object.entries(v)) e.dataset[dk] = dv;
+                else if (k.startsWith('on')) e.addEventListener(k.slice(2).toLowerCase(), v);
+                else if (k in e) e[k] = v;
+                else e.setAttribute(k, v);
+            }
+            for (const c of children.flat()) {
+                if (c == null || c === false) continue;
+                if (typeof c === 'string') e.appendChild(document.createTextNode(c));
+                else e.appendChild(c);
+            }
+            return e;
+        };
+        const escapeHtml = (s) => String(s ?? '').replace(/[&<>"']/g, ch =>
+            ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+
+        // ═══════════════════════════════════════════════════════════════
+        // Import / Export
+        // ═══════════════════════════════════════════════════════════════
+
+        $('importBtn').addEventListener('click', () => $('fileInput').click());
+
+        $('fileInput').addEventListener('change', async (e) => {
+            const file = e.target.files[0];
+            if (!file) return;
+            const text = await file.text();
+            try {
+                const parsed = parseV3Protocol(text);
+                // Atomic validation: collect all reference errors before committing
+                const refs = validateReferences(parsed);
+                if (!refs.ok) {
+                    showError(
+                        'Reference validation failed for ' + file.name,
+                        refs.errors.join('\n')
+                    );
+                    return;
+                }
+                experiment = parsed;
+                lastFilename = file.name;
+                selection = null;
+                renderAll();
+                $('exportBtn').disabled = false;
+            } catch (err) {
+                showError('Import error: ' + (err.name || 'Error'), err.message + (err.code ? '\n\n[' + err.code + ']' : ''));
+            }
+            $('fileInput').value = '';  // allow re-importing the same file
+        });
+
+        $('exportBtn').addEventListener('click', () => {
+            if (!experiment) return;
+            try {
+                const yaml = generateV3Protocol(experiment);
+                const blob = new Blob([yaml], { type: 'application/x-yaml' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = (lastFilename || 'experiment.yaml').replace(/\.ya?ml$/i, '') + '_roundtrip.yaml';
+                a.click();
+                URL.revokeObjectURL(url);
+            } catch (err) {
+                showError('Export error', err.message);
+            }
+        });
+
+        // ═══════════════════════════════════════════════════════════════
+        // Modal
+        // ═══════════════════════════════════════════════════════════════
+
+        function showError(title, body) {
+            $('modalTitle').textContent = title;
+            $('modalBody').textContent = body;
+            $('errorModal').classList.add('open');
+        }
+        $('modalClose').addEventListener('click', () => $('errorModal').classList.remove('open'));
+        $('errorModal').addEventListener('click', (e) => {
+            if (e.target.id === 'errorModal') $('errorModal').classList.remove('open');
+        });
+
+        // ═══════════════════════════════════════════════════════════════
+        // Settings drawer
+        // ═══════════════════════════════════════════════════════════════
+
+        $('settingsToggle').addEventListener('click', () => {
+            $('settingsDrawer').classList.toggle('open');
+        });
+
+        function renderSettings() {
+            const root = $('settingsContent');
+            root.innerHTML = '';
+            if (!experiment) {
+                root.appendChild(el('div', { class: 'empty-state' }, 'No experiment loaded.'));
+                return;
+            }
+
+            // Experiment info
+            const info = experiment.experiment_info;
+            const infoBox = el('div', { class: 'settings-section' });
+            infoBox.appendChild(el('h3', {}, 'Experiment Info'));
+            for (const k of ['name', 'date_created', 'author', 'pattern_library']) {
+                const v = info[k];
+                if (v != null && v !== '') {
+                    infoBox.appendChild(el('div', { class: 'kv' },
+                        el('span', { class: 'k' }, k + ': '),
+                        el('span', { class: 'v' }, String(v))
+                    ));
+                }
+            }
+            root.appendChild(infoBox);
+
+            // Rig
+            const rigBox = el('div', { class: 'settings-section' });
+            rigBox.appendChild(el('h3', {}, 'Rig'));
+            rigBox.appendChild(el('div', { class: 'kv' },
+                el('span', { class: 'k' }, 'path: '),
+                el('span', { class: 'v' }, experiment.rig_path)
+            ));
+            root.appendChild(rigBox);
+
+            // Plugins
+            if (experiment.plugins.length > 0) {
+                const pluginBox = el('div', { class: 'settings-section' });
+                pluginBox.appendChild(el('h3', {}, 'Plugins (' + experiment.plugins.length + ')'));
+                for (const p of experiment.plugins) {
+                    const pluginCard = el('div', { class: 'kv', style: 'margin-bottom: 0.5rem;' });
+                    pluginCard.appendChild(el('div', {},
+                        el('span', { class: 'k' }, p.name + ': '),
+                        el('span', { class: 'v' }, p.type + (p.matlab ? ' / ' + p.matlab.class : ''))
+                    ));
+                    if (p.config) {
+                        for (const [ck, cv] of Object.entries(p.config)) {
+                            pluginCard.appendChild(el('div', { style: 'padding-left: 1rem;' },
+                                el('span', { class: 'k' }, ck + ': '),
+                                el('span', { class: 'v' }, JSON.stringify(cv))
+                            ));
+                        }
+                    }
+                    pluginBox.appendChild(pluginCard);
+                }
+                root.appendChild(pluginBox);
+            }
+
+            // Variables
+            if (experiment.variables.length > 0) {
+                const varBox = el('div', { class: 'settings-section' });
+                varBox.appendChild(el('h3', {}, 'Variables (' + experiment.variables.length + ')'));
+                const table = el('table', { class: 'vars-table' });
+                const thead = el('thead', {}, el('tr', {},
+                    el('th', {}, 'Anchor'), el('th', {}, 'Value')
+                ));
+                table.appendChild(thead);
+                const tbody = el('tbody');
+                for (const v of experiment.variables) {
+                    const valClass = typeof v.value === 'number' ? 'num' : (typeof v.value === 'string' ? 'str' : '');
+                    tbody.appendChild(el('tr', {},
+                        el('td', {}, '&' + v.name),
+                        el('td', { class: valClass }, typeof v.value === 'string' ? JSON.stringify(v.value) : String(v.value))
+                    ));
+                }
+                table.appendChild(tbody);
+                varBox.appendChild(table);
+                root.appendChild(varBox);
+            }
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // Library
+        // ═══════════════════════════════════════════════════════════════
+
+        $('librarySearch').addEventListener('input', (e) => {
+            librarySearchText = e.target.value.toLowerCase();
+            renderLibrary();
+        });
+
+        function computeUsage() {
+            const usage = new Map();
+            if (!experiment) return usage;
+            for (const c of experiment.conditions) usage.set(c.name, 0);
+            for (const entry of experiment.sequence) {
+                if (entry.kind === 'ref') {
+                    usage.set(entry.condition_name, (usage.get(entry.condition_name) || 0) + 1);
+                } else if (entry.kind === 'block') {
+                    for (const t of entry.trials) usage.set(t, (usage.get(t) || 0) + 1);
+                    if (entry.intertrial) usage.set(entry.intertrial, (usage.get(entry.intertrial) || 0) + 1);
+                }
+            }
+            return usage;
+        }
+
+        function renderLibrary() {
+            const list = $('libraryList');
+            list.innerHTML = '';
+            $('librarySearch').disabled = !experiment;
+            $('libCount').textContent = experiment ? experiment.conditions.length : 0;
+
+            if (!experiment) {
+                list.appendChild(el('div', { class: 'empty-state' },
+                    'Import a v3 YAML to populate the conditions library.'));
+                return;
+            }
+
+            const usage = computeUsage();
+            const filter = librarySearchText.trim();
+            let shown = 0;
+            for (const cond of experiment.conditions) {
+                if (filter && !cond.name.toLowerCase().includes(filter)) continue;
+                const useCount = usage.get(cond.name) || 0;
+                const row = el('div', {
+                    class: 'lib-row' + (useCount === 0 ? ' unused' : '') +
+                           (selection && selection.kind === 'condition' && selection.name === cond.name ? ' selected' : ''),
+                    title: useCount === 0 ? 'Unreferenced in sequence' : (useCount + ' reference' + (useCount === 1 ? '' : 's')),
+                    onClick: () => { selection = { kind: 'condition', name: cond.name }; renderLibrary(); renderInspector(); renderSequence(); }
+                },
+                    el('span', { class: 'name' }, cond.name),
+                    el('span', { class: 'usage' }, useCount + '×')
+                );
+                list.appendChild(row);
+                shown++;
+            }
+            if (shown === 0) {
+                list.appendChild(el('div', { class: 'empty-state' }, 'No matches.'));
+            }
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // Sequence
+        // ═══════════════════════════════════════════════════════════════
+
+        function renderSequence() {
+            const list = $('sequenceList');
+            list.innerHTML = '';
+            $('seqCount').textContent = experiment ? experiment.sequence.length : 0;
+
+            if (!experiment) {
+                list.appendChild(el('div', { class: 'empty-state' },
+                    'Import a v3 YAML to view the experiment sequence.'));
+                return;
+            }
+
+            const knownConds = new Set(experiment.conditions.map(c => c.name));
+
+            experiment.sequence.forEach((entry, idx) => {
+                const isSelected = selection && (
+                    (selection.kind === 'ref' && selection.index === idx) ||
+                    (selection.kind === 'block' && selection.index === idx)
+                );
+
+                if (entry.kind === 'ref') {
+                    const card = el('div', {
+                        class: 'seq-entry ref' + (isSelected ? ' selected' : ''),
+                        onClick: () => { selection = { kind: 'ref', index: idx }; renderSequence(); renderInspector(); renderLibrary(); }
+                    },
+                        el('span', { class: 'marker' }, '▸'),
+                        el('span', { class: 'name' }, entry.condition_name),
+                        !knownConds.has(entry.condition_name) ? el('span', { class: 'trial-chip missing', style: 'margin-left: auto;' }, 'missing') : null
+                    );
+                    list.appendChild(card);
+                } else if (entry.kind === 'block') {
+                    const meta = el('div', { class: 'block-meta' });
+                    meta.appendChild(el('span', {}, 'trials: ' + entry.trials.length));
+                    meta.appendChild(el('span', {}, 'reps: ' + entry.repetitions));
+                    if (entry.randomize) meta.appendChild(el('span', { class: 'randomize-badge' }, '⚄ randomize'));
+
+                    const trialsRow = el('div', { class: 'trials-row' });
+                    for (const t of entry.trials) {
+                        const chip = el('span', {
+                            class: 'trial-chip' + (!knownConds.has(t) ? ' missing' : ''),
+                            title: !knownConds.has(t) ? 'Condition "' + t + '" not in library' : 'Click to view ' + t,
+                            onClick: (e) => {
+                                e.stopPropagation();
+                                if (knownConds.has(t)) {
+                                    selection = { kind: 'condition', name: t };
+                                    renderLibrary(); renderInspector(); renderSequence();
+                                }
+                            }
+                        }, t);
+                        trialsRow.appendChild(chip);
+                    }
+
+                    const itiRow = entry.intertrial
+                        ? el('div', { class: 'iti-row' },
+                            'intertrial: ',
+                            el('span', { class: 'iti-ref' + (!knownConds.has(entry.intertrial) ? ' missing' : '') }, entry.intertrial))
+                        : null;
+
+                    const unknownPill = entry._unknownKeys && Object.keys(entry._unknownKeys).length > 0
+                        ? el('div', { class: 'unknown-keys-pill', title: Object.keys(entry._unknownKeys).join(', ') },
+                            '⚠ ' + Object.keys(entry._unknownKeys).length + ' future-compat key' + (Object.keys(entry._unknownKeys).length === 1 ? '' : 's'))
+                        : null;
+
+                    const card = el('div', {
+                        class: 'seq-entry block' + (isSelected ? ' selected' : ''),
+                        onClick: () => { selection = { kind: 'block', index: idx }; renderSequence(); renderInspector(); renderLibrary(); }
+                    },
+                        el('div', { class: 'block-name' }, '▾ ' + (entry.name || 'block_' + (idx + 1))),
+                        meta,
+                        trialsRow,
+                        itiRow,
+                        unknownPill
+                    );
+                    list.appendChild(card);
+                }
+            });
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // Inspector
+        // ═══════════════════════════════════════════════════════════════
+
+        function renderInspector() {
+            const body = $('inspectorBody');
+            body.innerHTML = '';
+
+            if (!experiment) {
+                body.appendChild(el('div', { class: 'empty-state' },
+                    'Select a condition in the Library or an entry in the Sequence to view details.'));
+                return;
+            }
+            if (!selection) {
+                body.appendChild(el('div', { class: 'empty-state' },
+                    'Click a condition (Library) or a sequence entry to inspect.'));
+                return;
+            }
+
+            if (selection.kind === 'condition') {
+                const cond = experiment.conditions.find(c => c.name === selection.name);
+                if (!cond) {
+                    body.appendChild(el('div', { class: 'empty-state' }, 'Condition not found.'));
+                    return;
+                }
+                body.appendChild(el('div', { class: 'inspector-title' },
+                    el('span', { class: 'kind' }, 'Condition'),
+                    cond.name
+                ));
+                const section = el('div', { class: 'insp-section' });
+                section.appendChild(el('h4', {}, 'Commands (' + cond.commands.length + ')'));
+                for (const cmd of cond.commands) {
+                    section.appendChild(renderCommandCard(cmd));
+                }
+                body.appendChild(section);
+                return;
+            }
+
+            if (selection.kind === 'block') {
+                const entry = experiment.sequence[selection.index];
+                if (!entry || entry.kind !== 'block') return;
+                body.appendChild(el('div', { class: 'inspector-title' },
+                    el('span', { class: 'kind' }, 'Block'),
+                    entry.name || 'block_' + (selection.index + 1)
+                ));
+                const props = el('div', { class: 'insp-section' });
+                props.appendChild(el('h4', {}, 'Properties'));
+                props.appendChild(el('div', { class: 'kv' },
+                    el('span', { class: 'k' }, 'repetitions: '),
+                    el('span', { class: 'v' }, String(entry.repetitions))));
+                props.appendChild(el('div', { class: 'kv' },
+                    el('span', { class: 'k' }, 'randomize: '),
+                    el('span', { class: 'v' }, entry.randomize ? 'true' : 'false')));
+                if (entry.intertrial) {
+                    props.appendChild(el('div', { class: 'kv' },
+                        el('span', { class: 'k' }, 'intertrial: '),
+                        el('button', { class: 'jump-btn', onClick: () => {
+                            selection = { kind: 'condition', name: entry.intertrial };
+                            renderLibrary(); renderInspector(); renderSequence();
+                        }}, '→ ' + entry.intertrial)));
+                }
+                body.appendChild(props);
+
+                const trials = el('div', { class: 'insp-section' });
+                trials.appendChild(el('h4', {}, 'Trials (' + entry.trials.length + ')'));
+                const trialList = el('div', { style: 'display: flex; flex-direction: column; gap: 0.25rem;' });
+                for (const t of entry.trials) {
+                    trialList.appendChild(el('button', { class: 'jump-btn', style: 'text-align: left;', onClick: () => {
+                        selection = { kind: 'condition', name: t };
+                        renderLibrary(); renderInspector(); renderSequence();
+                    }}, '→ ' + t));
+                }
+                trials.appendChild(trialList);
+                body.appendChild(trials);
+
+                if (entry._unknownKeys && Object.keys(entry._unknownKeys).length > 0) {
+                    const unk = el('div', { class: 'insp-section' });
+                    unk.appendChild(el('h4', {}, 'Forward-compat keys (not edited in v0.1)'));
+                    const pre = el('pre', { style: 'background: var(--bg); padding: 0.5rem; border-radius: 3px; font-size: 0.7rem; white-space: pre-wrap;' },
+                        JSON.stringify(entry._unknownKeys, null, 2));
+                    unk.appendChild(pre);
+                    body.appendChild(unk);
+                }
+                return;
+            }
+
+            if (selection.kind === 'ref') {
+                const entry = experiment.sequence[selection.index];
+                if (!entry || entry.kind !== 'ref') return;
+                body.appendChild(el('div', { class: 'inspector-title' },
+                    el('span', { class: 'kind' }, 'Reference'),
+                    entry.condition_name
+                ));
+                body.appendChild(el('div', { class: 'insp-section' },
+                    el('div', { style: 'color: var(--text-dim); font-size: 0.8rem; margin-bottom: 0.5rem;' },
+                        'This entry in the sequence runs the condition "' + entry.condition_name + '" once.'),
+                    el('button', { class: 'jump-btn', onClick: () => {
+                        selection = { kind: 'condition', name: entry.condition_name };
+                        renderLibrary(); renderInspector(); renderSequence();
+                    }}, '→ View condition details')
+                ));
+                return;
+            }
+        }
+
+        function renderCommandCard(cmd) {
+            const card = el('div', { class: 'cmd-card ' + cmd.type });
+            const head = el('div', { class: 'cmd-head' },
+                el('span', { class: 'ctype' }, cmd.type),
+                cmd.type === 'plugin' ? (cmd.plugin_name + '.' + cmd.command_name) :
+                cmd.type === 'wait' ? 'wait' :
+                cmd.command_name || ''
+            );
+            card.appendChild(head);
+            const detailKeys = {
+                controller: ['pattern', 'pattern_ID', 'duration', 'mode', 'frame_index', 'frame_rate', 'gain'],
+                wait: ['duration'],
+                plugin: []
+            }[cmd.type] || [];
+            for (const k of detailKeys) {
+                if (cmd[k] !== undefined) {
+                    card.appendChild(el('div', { class: 'kv-line' },
+                        el('span', { class: 'k' }, k + ':'),
+                        el('span', { class: 'v' }, ' ' + (typeof cmd[k] === 'string' ? cmd[k] : String(cmd[k])))));
+                }
+            }
+            if (cmd.type === 'plugin' && cmd.params && Object.keys(cmd.params).length > 0) {
+                card.appendChild(el('div', { class: 'kv-line' }, el('span', { class: 'k' }, 'params:')));
+                for (const [pk, pv] of Object.entries(cmd.params)) {
+                    card.appendChild(el('div', { class: 'kv-line', style: 'padding-left: 1rem;' },
+                        el('span', { class: 'k' }, pk + ':'),
+                        el('span', { class: 'v' }, ' ' + (typeof pv === 'string' ? JSON.stringify(pv) : String(pv)))));
+                }
+            }
+            if (cmd._unknownKeys && Object.keys(cmd._unknownKeys).length > 0) {
+                card.appendChild(el('div', { class: 'kv-line', style: 'color: var(--warn); margin-top: 0.2rem;' },
+                    '⚠ unknown keys: ' + Object.keys(cmd._unknownKeys).join(', ')));
+            }
+            return card;
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // Timeline preview (flattened)
+        // ═══════════════════════════════════════════════════════════════
+
+        function condDuration(cond) {
+            if (!cond) return 0;
+            let tp = 0, wait = 0;
+            for (const c of cond.commands) {
+                if (c.type === 'controller' && c.command_name === 'trialParams') tp = Math.max(tp, c.duration || 0);
+                if (c.type === 'wait') wait += (c.duration || 0);
+            }
+            return Math.max(tp, wait);
+        }
+
+        function flattenSequence() {
+            if (!experiment) return { steps: [], hasRandom: false };
+            const byName = new Map(experiment.conditions.map(c => [c.name, c]));
+            const steps = [];
+            let hasRandom = false;
+            for (const entry of experiment.sequence) {
+                if (entry.kind === 'ref') {
+                    steps.push({
+                        kind: 'ref',
+                        label: entry.condition_name,
+                        dur: condDuration(byName.get(entry.condition_name))
+                    });
+                } else if (entry.kind === 'block') {
+                    if (entry.randomize) hasRandom = true;
+                    const iti = entry.intertrial ? byName.get(entry.intertrial) : null;
+                    for (let r = 0; r < entry.repetitions; r++) {
+                        for (let t = 0; t < entry.trials.length; t++) {
+                            const condName = entry.trials[t];
+                            steps.push({
+                                kind: 'block-trial',
+                                label: condName,
+                                blockName: entry.name,
+                                dur: condDuration(byName.get(condName)),
+                                rep: r,
+                                randomize: entry.randomize
+                            });
+                            // Intertrial between consecutive trials within a rep (not after last)
+                            const isLastTrialOfFinalRep = (r === entry.repetitions - 1) && (t === entry.trials.length - 1);
+                            if (entry.intertrial && !isLastTrialOfFinalRep) {
+                                steps.push({
+                                    kind: 'iti',
+                                    label: 'iti: ' + entry.intertrial,
+                                    dur: condDuration(iti)
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            return { steps, hasRandom };
+        }
+
+        function renderTimeline() {
+            const track = $('timelineTrack');
+            track.innerHTML = '';
+            const note = $('timelineNote');
+            if (!experiment) {
+                track.appendChild(el('div', { class: 'empty-state' }, 'No timeline to preview yet.'));
+                note.textContent = '';
+                return;
+            }
+            const { steps, hasRandom } = flattenSequence();
+            note.textContent = steps.length + ' step' + (steps.length === 1 ? '' : 's') +
+                (hasRandom ? ' • randomized blocks shown in nominal order; runtime order will differ' : '');
+
+            // Build pixel-proportional widths (min 60px). Cap total to viewport width × 4.
+            const maxTotalPx = 4000;
+            const maxDur = steps.reduce((m, s) => Math.max(m, s.dur || 0), 0) || 1;
+            const pxPerSec = Math.max(8, Math.min(40, maxTotalPx / Math.max(1, steps.reduce((s, x) => s + (x.dur || 1), 0))));
+
+            for (const step of steps) {
+                const widthPx = Math.max(60, (step.dur || 1) * pxPerSec);
+                const cell = el('div', {
+                    class: 'step ' + step.kind,
+                    style: 'width: ' + widthPx + 'px;'
+                },
+                    el('div', { class: 'step-label', title: step.label }, step.label),
+                    el('div', { class: 'step-dur' }, (step.dur || 0).toFixed(1) + 's')
+                );
+                track.appendChild(cell);
+            }
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // Render orchestrator
+        // ═══════════════════════════════════════════════════════════════
+
+        function renderAll() {
+            renderSettings();
+            renderLibrary();
+            renderSequence();
+            renderInspector();
+            renderTimeline();
+        }
+
+        // Set the ET timestamp in the footer
+        function setFooterTimestamp() {
+            const now = new Date();
+            // Format as YYYY-MM-DD HH:MM ET
+            const fmt = (d) => {
+                const opts = { timeZone: 'America/New_York', year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false };
+                return d.toLocaleString('en-CA', opts).replace(',', '');
+            };
+            $('footerTimestamp').textContent = fmt(now) + ' ET';
+        }
+        setFooterTimestamp();
+
+        // Initial empty render
+        renderAll();
+    </script>
 </body>
 </html>

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>v3 Experiment Designer (under construction)</title>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #0f1419;
+            --surface: #1a1f26;
+            --border: #2d3640;
+            --text: #e6edf3;
+            --text-dim: #8b949e;
+            --accent: #00e676;
+            --hover: #00c853;
+            --beta: #29b6f6;
+        }
+
+        body {
+            font-family: 'IBM Plex Mono', monospace;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem;
+        }
+
+        .card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 2.5rem;
+            max-width: 640px;
+            text-align: center;
+        }
+
+        h1 {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.8rem;
+            color: var(--accent);
+            margin-bottom: 0.5rem;
+        }
+
+        .beta-badge {
+            display: inline-block;
+            padding: 0.25rem 0.6rem;
+            border-radius: 4px;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            background: rgba(41, 182, 246, 0.15);
+            color: var(--beta);
+            border: 1px solid var(--beta);
+            margin-left: 0.5rem;
+            vertical-align: middle;
+        }
+
+        p {
+            color: var(--text-dim);
+            line-height: 1.6;
+            margin-top: 1rem;
+        }
+
+        a {
+            color: var(--accent);
+            text-decoration: none;
+        }
+
+        a:hover {
+            color: var(--hover);
+        }
+
+        .links {
+            margin-top: 1.5rem;
+            display: flex;
+            justify-content: center;
+            gap: 1.5rem;
+            font-size: 0.9rem;
+        }
+
+        footer {
+            margin-top: 2rem;
+            color: var(--text-dim);
+            font-size: 0.8rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>v3 Experiment Designer<span class="beta-badge">Beta / Viewer</span></h1>
+        <p>
+            This page will host a new designer for the <strong>Protocol v3</strong> YAML format
+            introduced in maDisplayTools (<code>origin/version3</code>).
+        </p>
+        <p>
+            <strong>PR1 (v0.1)</strong> ships a read-only viewer/importer that round-trips
+            v3 YAMLs with anchors and comments preserved.
+            <strong>PR2 (v0.2)</strong> adds inline editing, drag/drop, the Variables UX, and validation.
+        </p>
+        <p>
+            Until v0.1 lands, please use the existing
+            <a href="experiment_designer.html">Experiment Designer</a>
+            (v2 YAML format only).
+        </p>
+        <div class="links">
+            <a href="index.html">← All tools</a>
+            <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">GitHub</a>
+        </div>
+    </div>
+    <footer>
+        <p>v3 Experiment Designer (stub) | scaffolded 2026-05-24 ET</p>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -142,6 +142,12 @@
             border: 1px solid #ff9800;
         }
 
+        .status.beta {
+            background: rgba(41, 182, 246, 0.15);
+            color: #29b6f6;
+            border: 1px solid #29b6f6;
+        }
+
         .tool-card.disabled {
             opacity: 0.6;
             cursor: not-allowed;
@@ -240,6 +246,12 @@
                 <h2>Experiment Designer</h2>
                 <p>Design experiment protocols with stimulus sequences and trial parameters. YAML export for MATLAB execution.</p>
                 <span class="status in-dev">In Development</span>
+            </a>
+
+            <a href="experiment_designer_v3.html" class="tool-card">
+                <h2>v3 Experiment Designer</h2>
+                <p>New designer for Protocol v3 YAML (library of conditions + ordered sequence of blocks). Read-only viewer in v0.1; editor follows in v0.2.</p>
+                <span class="status beta">Beta / Viewer</span>
             </a>
         </div>
 

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -1,0 +1,448 @@
+/**
+ * protocol-yaml-v3.js — Parser/generator for Protocol v3 YAML files.
+ *
+ * Provides:
+ *   - parseV3Protocol(yamlText) — parse a v3 YAML into the in-memory data model.
+ *   - generateV3Protocol(experiment) — emit a v3 YAML from the data model.
+ *   - V3ParseError — typed error thrown for schema / version mismatches.
+ *
+ * Design notes:
+ *   - Backed by the `yaml` npm package (a.k.a. js-yaml v2.x) in Document mode,
+ *     which preserves anchors, alias references, and comments through round-trip.
+ *     This is the foundation for the "users hand-author YAML with anchors and
+ *     comments — designer must not destroy them" requirement.
+ *   - For v0.1 (viewer), `parseV3Protocol` extracts a JS data model AND
+ *     preserves the original `YAML.Document` as `_doc`. `generateV3Protocol`
+ *     just re-serializes `_doc` — round-trip is a no-op at the document level.
+ *   - For v0.2 (editor), edits to the data model will be threaded back into
+ *     `_doc` via setIn/delete calls, then serialized. v0.2 will also add a
+ *     constructive emit path (`constructFreshDocument`) for new-from-scratch
+ *     experiments.
+ *
+ * Dual-export pattern (same as js/protocol-yaml.js):
+ *   - Browser <script type="module">: import YAML from CDN before this module,
+ *     or load this module with yaml bundled. v0.1 viewer page (Phase 2) wires
+ *     this up.
+ *   - Node test runner: `require('./js/protocol-yaml-v3.js')` works because the
+ *     `export` syntax is interop-handled.
+ */
+
+'use strict';
+
+import YAML from 'yaml';
+
+// ════════════════════════════════════════════════════
+// Constants — known schema keys per level
+// ════════════════════════════════════════════════════
+
+const KNOWN_TOP_LEVEL_KEYS = [
+    'version',
+    'experiment_info',
+    'rig',
+    'variables',
+    'plugins',
+    'experiment',
+    'conditions'
+];
+
+const KNOWN_EXPERIMENT_INFO_KEYS = ['name', 'date_created', 'author', 'pattern_library'];
+
+const KNOWN_BLOCK_KEYS = ['name', 'trials', 'repetitions', 'randomize', 'intertrial'];
+
+const KNOWN_CONDITION_KEYS = ['name', 'commands'];
+
+const KNOWN_COMMAND_KEYS_BY_TYPE = {
+    controller: [
+        'type',
+        'command_name',
+        'pattern',
+        'pattern_ID',
+        'duration',
+        'mode',
+        'frame_index',
+        'frame_rate',
+        'gain'
+    ],
+    wait: ['type', 'duration'],
+    plugin: ['type', 'plugin_name', 'command_name', 'params']
+};
+
+const KNOWN_PLUGIN_KEYS = [
+    'name',
+    'type',
+    'matlab',
+    'python',
+    'config',
+    'port',
+    'baudrate',
+    'script_path'
+];
+
+// ════════════════════════════════════════════════════
+// Errors
+// ════════════════════════════════════════════════════
+
+class V3ParseError extends Error {
+    constructor(message, code) {
+        super(message);
+        this.name = 'V3ParseError';
+        this.code = code || 'PARSE_ERROR';
+    }
+}
+
+// ════════════════════════════════════════════════════
+// Helpers — unknown-key extraction
+// ════════════════════════════════════════════════════
+
+/**
+ * Pull every key from `obj` that isn't in `knownKeys` into a flat map.
+ * Used to preserve forward-compat fields (retry_on_fail, abort_if, etc.)
+ * at every nesting level.
+ */
+function extractUnknownKeys(obj, knownKeys) {
+    const out = {};
+    if (!obj || typeof obj !== 'object') return out;
+    for (const k of Object.keys(obj)) {
+        if (!knownKeys.includes(k)) out[k] = obj[k];
+    }
+    return out;
+}
+
+// ════════════════════════════════════════════════════
+// Parser
+// ════════════════════════════════════════════════════
+
+/**
+ * Parse a v3 protocol YAML string into the in-memory data model.
+ *
+ * @param {string} yamlText - raw YAML content
+ * @returns {object} experiment data model (see top-of-file docs)
+ * @throws V3ParseError
+ */
+function parseV3Protocol(yamlText) {
+    if (typeof yamlText !== 'string') {
+        throw new V3ParseError('Expected YAML text, got ' + typeof yamlText, 'INVALID_INPUT');
+    }
+
+    const doc = YAML.parseDocument(yamlText, { keepSourceTokens: true });
+
+    if (doc.errors && doc.errors.length > 0) {
+        throw new V3ParseError('YAML parse error: ' + doc.errors[0].message, 'YAML_ERROR');
+    }
+
+    const data = doc.toJS();
+
+    if (!data || typeof data !== 'object') {
+        throw new V3ParseError('YAML root must be a mapping', 'INVALID_SCHEMA');
+    }
+
+    // Version check — must come before anything else
+    if (data.version === 1 || data.version === 2) {
+        throw new V3ParseError(
+            'This is a v' +
+                data.version +
+                ' protocol. The v3 designer reads v3 only — please open this file in the v2 Experiment Designer page.',
+            'WRONG_VERSION'
+        );
+    }
+    if (data.version !== 3) {
+        throw new V3ParseError(
+            'Expected `version: 3`, got `version: ' + JSON.stringify(data.version) + '`',
+            'WRONG_VERSION'
+        );
+    }
+
+    // Required top-level fields
+    if (!data.experiment_info || typeof data.experiment_info !== 'object') {
+        throw new V3ParseError(
+            'Missing or invalid required field: experiment_info',
+            'INVALID_SCHEMA'
+        );
+    }
+    if (typeof data.rig !== 'string' || !data.rig.trim()) {
+        throw new V3ParseError('Missing or invalid required field: rig', 'INVALID_SCHEMA');
+    }
+    if (!Array.isArray(data.experiment) || data.experiment.length === 0) {
+        throw new V3ParseError(
+            'Missing or empty required field: experiment (must be a non-empty list)',
+            'INVALID_SCHEMA'
+        );
+    }
+    if (!Array.isArray(data.conditions) || data.conditions.length === 0) {
+        throw new V3ParseError(
+            'Missing or empty required field: conditions (must be a non-empty list)',
+            'INVALID_SCHEMA'
+        );
+    }
+
+    // Build the in-memory model
+    const experiment = {
+        version: 3,
+        experiment_info: extractExperimentInfo(data.experiment_info),
+        rig_path: String(data.rig),
+        variables: extractVariables(doc),
+        plugins: Array.isArray(data.plugins) ? data.plugins.map(extractPlugin) : [],
+        conditions: data.conditions.map(extractCondition),
+        sequence: data.experiment.map(extractSequenceEntry),
+        _unknownTopLevel: extractUnknownKeys(data, KNOWN_TOP_LEVEL_KEYS),
+        _doc: doc
+    };
+
+    return experiment;
+}
+
+function extractExperimentInfo(info) {
+    const out = {};
+    for (const k of KNOWN_EXPERIMENT_INFO_KEYS) {
+        out[k] = info[k] !== undefined ? info[k] : null;
+    }
+    out._unknownKeys = extractUnknownKeys(info, KNOWN_EXPERIMENT_INFO_KEYS);
+    return out;
+}
+
+/**
+ * Extract the optional `variables:` section as an ordered list. Preserves
+ * insertion order (matters for stable round-trip).
+ */
+function extractVariables(doc) {
+    const out = [];
+    const varsNode = doc.get('variables', true);
+    if (!varsNode || !varsNode.items) return out;
+    for (const pair of varsNode.items) {
+        const name = pair.key && pair.key.value !== undefined ? pair.key.value : String(pair.key);
+        let value;
+        if (pair.value && pair.value.value !== undefined) {
+            value = pair.value.value;
+        } else if (pair.value && typeof pair.value.toJSON === 'function') {
+            value = pair.value.toJSON();
+        } else {
+            value = pair.value;
+        }
+        out.push({ name: String(name), value: value });
+    }
+    return out;
+}
+
+function extractPlugin(plugin) {
+    if (!plugin || typeof plugin !== 'object') {
+        throw new V3ParseError('Plugin entry must be a mapping', 'INVALID_SCHEMA');
+    }
+    const out = {
+        name: plugin.name,
+        type: plugin.type
+    };
+    if (plugin.matlab) out.matlab = plugin.matlab;
+    if (plugin.python) out.python = plugin.python;
+    if (plugin.config && typeof plugin.config === 'object') {
+        // Plugin config is freeform — no fixed schema, but stash any known shape
+        // we want to preserve unchanged. For v0.1, just copy the whole object.
+        out.config = JSON.parse(JSON.stringify(plugin.config));
+    }
+    if (plugin.port !== undefined) out.port = plugin.port;
+    if (plugin.baudrate !== undefined) out.baudrate = plugin.baudrate;
+    if (plugin.script_path !== undefined) out.script_path = plugin.script_path;
+    out._unknownKeys = extractUnknownKeys(plugin, KNOWN_PLUGIN_KEYS);
+    return out;
+}
+
+function extractCondition(cond) {
+    if (!cond || typeof cond !== 'object') {
+        throw new V3ParseError('Condition entry must be a mapping', 'INVALID_SCHEMA');
+    }
+    if (typeof cond.name !== 'string' || !cond.name.trim()) {
+        throw new V3ParseError('Condition is missing a required string `name`', 'INVALID_SCHEMA');
+    }
+    if (!Array.isArray(cond.commands)) {
+        throw new V3ParseError(
+            'Condition "' + cond.name + '" is missing a required `commands` list',
+            'INVALID_SCHEMA'
+        );
+    }
+    return {
+        name: cond.name,
+        commands: cond.commands.map(extractCommand),
+        _unknownKeys: extractUnknownKeys(cond, KNOWN_CONDITION_KEYS)
+    };
+}
+
+function extractCommand(cmd) {
+    if (!cmd || typeof cmd !== 'object') {
+        throw new V3ParseError('Command entry must be a mapping', 'INVALID_SCHEMA');
+    }
+    const t = cmd.type;
+    const known = KNOWN_COMMAND_KEYS_BY_TYPE[t];
+    if (!known) {
+        throw new V3ParseError(
+            'Unknown command type: ' +
+                JSON.stringify(t) +
+                ' (expected one of: ' +
+                Object.keys(KNOWN_COMMAND_KEYS_BY_TYPE).join(', ') +
+                ')',
+            'INVALID_SCHEMA'
+        );
+    }
+    const out = {};
+    for (const k of known) {
+        if (cmd[k] !== undefined) {
+            out[k] =
+                t === 'plugin' && k === 'params' && cmd[k] && typeof cmd[k] === 'object'
+                    ? JSON.parse(JSON.stringify(cmd[k]))
+                    : cmd[k];
+        }
+    }
+    // Params get their own unknown-keys map (forward-compat for new params)
+    if (t === 'plugin' && cmd.params && typeof cmd.params === 'object') {
+        out.params = out.params || {};
+        // Params are freeform — every key is "known" in the sense that we
+        // preserve them all. No _unknownKeys map at the param level for v0.1
+        // (revisit in v0.2 if we want per-param schema validation).
+    }
+    out._unknownKeys = extractUnknownKeys(cmd, known);
+    return out;
+}
+
+function extractSequenceEntry(entry) {
+    if (typeof entry === 'string') {
+        return { kind: 'ref', condition_name: entry };
+    }
+    if (entry && typeof entry === 'object') {
+        // Block object
+        if (!Array.isArray(entry.trials) || entry.trials.length === 0) {
+            throw new V3ParseError(
+                'Block entry "' + (entry.name || '?') + '" is missing a non-empty `trials` list',
+                'INVALID_SCHEMA'
+            );
+        }
+        return {
+            kind: 'block',
+            name: typeof entry.name === 'string' ? entry.name : null,
+            trials: entry.trials.map(String),
+            repetitions: typeof entry.repetitions === 'number' ? entry.repetitions : 1,
+            randomize: entry.randomize === true,
+            intertrial: typeof entry.intertrial === 'string' ? entry.intertrial : null,
+            _unknownKeys: extractUnknownKeys(entry, KNOWN_BLOCK_KEYS)
+        };
+    }
+    throw new V3ParseError(
+        'Experiment sequence entry must be a string or mapping; got ' + typeof entry,
+        'INVALID_SCHEMA'
+    );
+}
+
+// ════════════════════════════════════════════════════
+// Reference validation (cross-cuts the data model)
+// ════════════════════════════════════════════════════
+
+/**
+ * Walk the parsed experiment and collect every reference error
+ * (bare refs, block trial lists, block intertrials) into one report.
+ * Used by the import-time atomic-validation step in PR2.
+ *
+ * Returns { ok: boolean, errors: string[] } — never throws.
+ */
+function validateReferences(experiment) {
+    const errors = [];
+    if (!experiment || !Array.isArray(experiment.conditions)) {
+        return { ok: false, errors: ['experiment.conditions missing or not an array'] };
+    }
+    const condNames = new Set(experiment.conditions.map((c) => c.name));
+    const seen = new Set();
+    for (const c of experiment.conditions) {
+        if (seen.has(c.name)) {
+            errors.push('Duplicate condition name: "' + c.name + '"');
+        }
+        seen.add(c.name);
+    }
+    for (let i = 0; i < experiment.sequence.length; i++) {
+        const entry = experiment.sequence[i];
+        if (entry.kind === 'ref') {
+            if (!condNames.has(entry.condition_name)) {
+                errors.push(
+                    'sequence[' +
+                        i +
+                        ']: bare reference "' +
+                        entry.condition_name +
+                        '" not in conditions library'
+                );
+            }
+        } else if (entry.kind === 'block') {
+            for (let j = 0; j < entry.trials.length; j++) {
+                if (!condNames.has(entry.trials[j])) {
+                    errors.push(
+                        'sequence[' +
+                            i +
+                            '].trials[' +
+                            j +
+                            ']: "' +
+                            entry.trials[j] +
+                            '" not in conditions library'
+                    );
+                }
+            }
+            if (entry.intertrial && !condNames.has(entry.intertrial)) {
+                errors.push(
+                    'sequence[' +
+                        i +
+                        '].intertrial: "' +
+                        entry.intertrial +
+                        '" not in conditions library'
+                );
+            }
+        }
+    }
+    return { ok: errors.length === 0, errors };
+}
+
+// ════════════════════════════════════════════════════
+// Generator
+// ════════════════════════════════════════════════════
+
+/**
+ * Emit a v3 YAML string from the data model.
+ *
+ * v0.1 strategy: if the experiment came from `parseV3Protocol`, it has a
+ * `_doc` handle on the original YAML.Document. We just re-serialize that
+ * document, which preserves anchors, comments, formatting, and field order
+ * exactly as imported. (Edits in v0.2 will mutate `_doc` in place before
+ * this serialization happens.)
+ *
+ * If `_doc` is absent (e.g., a fresh experiment built programmatically),
+ * we throw — constructive emit is a v0.2 feature.
+ */
+function generateV3Protocol(experiment) {
+    if (!experiment || typeof experiment !== 'object') {
+        throw new V3ParseError('generateV3Protocol: experiment must be an object', 'INVALID_INPUT');
+    }
+    if (experiment._doc) {
+        return experiment._doc.toString();
+    }
+    throw new V3ParseError(
+        'generateV3Protocol: experiment has no `_doc` handle. Constructive emit (building YAML from a data model with no source document) is a v0.2 feature; v0.1 only supports round-tripping imported documents.',
+        'NOT_IMPLEMENTED'
+    );
+}
+
+// ════════════════════════════════════════════════════
+// Exports
+// ════════════════════════════════════════════════════
+
+const ProtocolV3 = {
+    parseV3Protocol,
+    generateV3Protocol,
+    validateReferences,
+    V3ParseError
+};
+
+// Browser global
+if (typeof window !== 'undefined') {
+    window.ProtocolV3 = ProtocolV3;
+}
+
+// Node.js / CommonJS
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = ProtocolV3;
+}
+
+// ES module export
+export { parseV3Protocol, generateV3Protocol, validateReferences, V3ParseError };
+export default ProtocolV3;

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -29,7 +29,10 @@
 
 'use strict';
 
-import YAML from 'yaml';
+// Import as namespace so both Node (yaml@2 npm package with a default export)
+// and browser (yaml@2/browser CDN build with named exports only) resolve.
+// All uses below go through `YAML.<fn>`.
+import * as YAML from 'yaml';
 
 // ════════════════════════════════════════════════════
 // Constants — known schema keys per level

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
     "name": "web-display-tools",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "web-display-tools",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "devDependencies": {
-                "prettier": "^3.8.1"
+                "prettier": "^3.8.1",
+                "yaml": "^2.9.0"
             }
         },
         "node_modules/prettier": {
@@ -26,6 +27,22 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
     "version": "1.0.1",
     "description": "Web-based tools for configuring and editing display patterns for modular arena systems",
     "scripts": {
-        "test": "node tests/validate-arena-calculations.js",
+        "test": "node tests/validate-arena-calculations.js && node tests/test-protocol-roundtrip.js && node tests/test-protocol-roundtrip-v3.js",
+        "test:arena": "node tests/validate-arena-calculations.js",
+        "test:protocol-v2": "node tests/test-protocol-roundtrip.js",
+        "test:protocol-v3": "node tests/test-protocol-roundtrip-v3.js",
         "validate": "node tests/validate-arena-calculations.js",
         "format": "prettier --write \"**/*.js\"",
         "format:check": "prettier --check \"**/*.js\""
@@ -15,6 +18,7 @@
     "author": "Reiser Lab",
     "license": "MIT",
     "devDependencies": {
-        "prettier": "^3.8.1"
+        "prettier": "^3.8.1",
+        "yaml": "^2.9.0"
     }
 }

--- a/tests/fixtures/matlab_normalized/v3_canonical_a.yaml
+++ b/tests/fixtures/matlab_normalized/v3_canonical_a.yaml
@@ -1,0 +1,378 @@
+version: 3
+
+# ============================================================================
+# EXPERIMENT METADATA
+# ============================================================================
+experiment_info:
+  name: "G4.1 Test Experiment using Bias and backlight"
+  date_created: "2026-03-23"
+  author: "Reiser Lab"
+  pattern_library: '/Users/reiserm/Documents/GitHub/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+# ============================================================================
+# ARENA CONFIGURATION
+# ============================================================================
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+# ============================================================================
+# VARIABLES
+# ============================================================================
+variables:
+  dur_long: &dur_long 10
+  dur_short: &dur_short 3
+  color_command: &color_command "setRedLEDPower"
+  color_power: &color_power 5
+
+# ============================================================================
+# PLUGIN DEFINITIONS
+# ============================================================================
+plugins:
+  - name: "camera"
+    type: "class"
+    matlab:
+      class: "BiasPlugin"
+
+  - name: "backlight"
+    type: "class"
+    matlab:
+      class: "LEDControllerPlugin"
+
+
+# ============================================================================
+# EXPERIMENT SEQUENCE
+# ============================================================================
+experiment:
+  - "arena check"
+  - "start light and camera"
+  - name: "main block"
+    trials:
+      - "sine_grating_60deg_fine_gs16"
+      - "counter_0000_1000_gs2"
+      - "top_on_gs2_G4"
+      - "sq_grating_60deg_gs16"
+      - "sine_grating_30deg_gs16"
+      - "sine_grating_60deg_gs16"
+      - "sine_grating_30deg_fine_gs16"
+    repetitions: 3
+    randomize: true
+    intertrial: "intertrial"
+  - "posttrial"
+
+
+# ============================================================================
+# CONDITIONS LIBRARY
+# ============================================================================
+conditions:
+  - name: "arena check"
+    commands:
+      - type: "controller"
+        command_name: "allOn"
+      - type: "wait"
+        duration: *dur_short
+      - type: "controller"
+        command_name: "allOff"
+
+  - name: "start light and camera"
+    commands:
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setIRLEDPower"
+        params:
+          power: 50
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOnLED"
+
+      - type: "wait"
+        duration: 0.5
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "startRecording"
+        params:
+          filename: 'testExperiment'
+
+  - name: "sine_grating_60deg_fine_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat08_sine_grating_60deg_fine_gs16_G4.pat"
+        pattern_ID: 1
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 3
+
+  - name: "counter_0000_1000_gs2"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat09_counter_0000_1000_gs2_G4.pat"
+        pattern_ID: 2
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "top_on_gs2_G4"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat13_top_on_gs2_G4.pat"
+        pattern_ID: 3
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 5
+
+  - name: "sq_grating_60deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 4
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: *dur_long
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "sine_grating_30deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat05_sine_grating_30deg_gs16_G4.pat"
+        pattern_ID: 5
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: *dur_long
+
+  - name: "sine_grating_60deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat06_sine_grating_60deg_gs16_G4.pat"
+        pattern_ID: 6
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "sine_grating_30deg_fine_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat07_sine_grating_30deg_fine_gs16_G4.pat"
+        pattern_ID: 7
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "intertrial"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "posttrial"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOffLED"
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopRecording"
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopCapture"
+
+      - type: "wait"
+        duration: 1

--- a/tests/fixtures/matlab_normalized/v3_canonical_b.yaml
+++ b/tests/fixtures/matlab_normalized/v3_canonical_b.yaml
@@ -1,0 +1,378 @@
+version: 3
+
+# ============================================================================
+# EXPERIMENT METADATA
+# ============================================================================
+experiment_info:
+  name: "G4.1 Test Experiment using Bias and backlight"
+  date_created: "2026-03-23"
+  author: "Reiser Lab"
+  pattern_library: '/Users/reiserm/Documents/GitHub/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+# ============================================================================
+# ARENA CONFIGURATION
+# ============================================================================
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+# ============================================================================
+# VARIABLES
+# ============================================================================
+variables:
+  dur_long: &dur_long 10
+  dur_short: &dur_short 3
+  color_command: &color_command "setRedLEDPower"
+  color_power: &color_power 5
+
+# ============================================================================
+# PLUGIN DEFINITIONS
+# ============================================================================
+plugins:
+  - name: "camera"
+    type: "class"
+    matlab:
+      class: "BiasPlugin"
+
+  - name: "backlight"
+    type: "class"
+    matlab:
+      class: "LEDControllerPlugin"
+
+
+# ============================================================================
+# EXPERIMENT SEQUENCE
+# ============================================================================
+experiment:
+  - "arena check"
+  - "start light and camera"
+  - name: "main block"
+    trials:
+      - "sq_grating_30deg_gs2"
+      - "sq_grating_30deg_gs16"
+      - "sq_grating_60deg_gs2"
+      - "sq_grating_60deg_gs16"
+      - "sine_grating_30deg_gs16"
+      - "sine_grating_60deg_gs16"
+      - "sine_grating_30deg_fine_gs16"
+    repetitions: 3
+    randomize: true
+    intertrial: "intertrial"
+  - "posttrial"
+
+
+# ============================================================================
+# CONDITIONS LIBRARY
+# ============================================================================
+conditions:
+  - name: "arena check"
+    commands:
+      - type: "controller"
+        command_name: "allOn"
+      - type: "wait"
+        duration: *dur_short
+      - type: "controller"
+        command_name: "allOff"
+
+  - name: "start light and camera"
+    commands:
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setIRLEDPower"
+        params:
+          power: 50
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOnLED"
+
+      - type: "wait"
+        duration: 0.5
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "startRecording"
+        params:
+          filename: 'testExperiment'
+
+  - name: "sq_grating_30deg_gs2"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"
+        pattern_ID: 1
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 3
+
+  - name: "sq_grating_30deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat02_sq_grating_30deg_gs16_G4.pat"
+        pattern_ID: 2
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "sq_grating_60deg_gs2"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat03_sq_grating_60deg_gs2_G4.pat"
+        pattern_ID: 3
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 5
+
+  - name: "sq_grating_60deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 4
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: *dur_long
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "sine_grating_30deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat05_sine_grating_30deg_gs16_G4.pat"
+        pattern_ID: 5
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: *dur_long
+
+  - name: "sine_grating_60deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat06_sine_grating_60deg_gs16_G4.pat"
+        pattern_ID: 6
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "sine_grating_30deg_fine_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat07_sine_grating_30deg_fine_gs16_G4.pat"
+        pattern_ID: 7
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "intertrial"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "posttrial"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOffLED"
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopRecording"
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopCapture"
+
+      - type: "wait"
+        duration: 1

--- a/tests/fixtures/v3_canonical_a.yaml
+++ b/tests/fixtures/v3_canonical_a.yaml
@@ -1,0 +1,378 @@
+version: 3
+
+# ============================================================================
+# EXPERIMENT METADATA
+# ============================================================================
+experiment_info:
+  name: "G4.1 Test Experiment using Bias and backlight"
+  date_created: "2026-03-23"
+  author: "Reiser Lab"
+  pattern_library: '/Users/lisaferguson/Documents/PC/Programming/Reiser/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+# ============================================================================
+# ARENA CONFIGURATION
+# ============================================================================
+rig: '/Users/lisaferguson/Documents/PC/Programming/Reiser/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+# ============================================================================
+# VARIABLES
+# ============================================================================
+variables:
+  dur_long: &dur_long 10
+  dur_short: &dur_short 3
+  color_command: &color_command "setRedLEDPower"
+  color_power: &color_power 5
+
+# ============================================================================
+# PLUGIN DEFINITIONS
+# ============================================================================
+plugins:
+  - name: "camera"
+    type: "class"
+    matlab:
+      class: "BiasPlugin"
+
+  - name: "backlight"
+    type: "class"
+    matlab:
+      class: "LEDControllerPlugin"
+
+
+# ============================================================================
+# EXPERIMENT SEQUENCE
+# ============================================================================
+experiment:
+  - "arena check"
+  - "start light and camera"
+  - name: "main block"
+    trials:
+      - "sine_grating_60deg_fine_gs16"
+      - "counter_0000_1000_gs2"
+      - "top_on_gs2_G4"
+      - "sq_grating_60deg_gs16"
+      - "sine_grating_30deg_gs16"
+      - "sine_grating_60deg_gs16"
+      - "sine_grating_30deg_fine_gs16"
+    repetitions: 3
+    randomize: true
+    intertrial: "intertrial"
+  - "posttrial"
+
+
+# ============================================================================
+# CONDITIONS LIBRARY
+# ============================================================================
+conditions:
+  - name: "arena check"
+    commands:
+      - type: "controller"
+        command_name: "allOn"
+      - type: "wait"
+        duration: *dur_short
+      - type: "controller"
+        command_name: "allOff"
+
+  - name: "start light and camera"
+    commands:
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setIRLEDPower"
+        params:
+          power: 50
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOnLED"
+
+      - type: "wait"
+        duration: 0.5
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "startRecording"
+        params:
+          filename: 'testExperiment'
+
+  - name: "sine_grating_60deg_fine_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat08_sine_grating_60deg_fine_gs16_G4.pat"
+        pattern_ID: 1
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 3
+
+  - name: "counter_0000_1000_gs2"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat09_counter_0000_1000_gs2_G4.pat"
+        pattern_ID: 2
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "top_on_gs2_G4"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat13_top_on_gs2_G4.pat"
+        pattern_ID: 3
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 5
+
+  - name: "sq_grating_60deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 4
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: *dur_long
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "sine_grating_30deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat05_sine_grating_30deg_gs16_G4.pat"
+        pattern_ID: 5
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: *dur_long
+
+  - name: "sine_grating_60deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat06_sine_grating_60deg_gs16_G4.pat"
+        pattern_ID: 6
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "sine_grating_30deg_fine_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat07_sine_grating_30deg_fine_gs16_G4.pat"
+        pattern_ID: 7
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "intertrial"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "posttrial"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOffLED"
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopRecording"
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopCapture"
+
+      - type: "wait"
+        duration: 1

--- a/tests/fixtures/v3_canonical_b.yaml
+++ b/tests/fixtures/v3_canonical_b.yaml
@@ -1,0 +1,378 @@
+version: 3
+
+# ============================================================================
+# EXPERIMENT METADATA
+# ============================================================================
+experiment_info:
+  name: "G4.1 Test Experiment using Bias and backlight"
+  date_created: "2026-03-23"
+  author: "Reiser Lab"
+  pattern_library: '/Users/lisaferguson/Documents/PC/Programming/Reiser/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+# ============================================================================
+# ARENA CONFIGURATION
+# ============================================================================
+rig: '/Users/lisaferguson/Documents/PC/Programming/Reiser/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+# ============================================================================
+# VARIABLES
+# ============================================================================
+variables:
+  dur_long: &dur_long 10
+  dur_short: &dur_short 3
+  color_command: &color_command "setRedLEDPower"
+  color_power: &color_power 5
+
+# ============================================================================
+# PLUGIN DEFINITIONS
+# ============================================================================
+plugins:
+  - name: "camera"
+    type: "class"
+    matlab:
+      class: "BiasPlugin"
+
+  - name: "backlight"
+    type: "class"
+    matlab:
+      class: "LEDControllerPlugin"
+
+
+# ============================================================================
+# EXPERIMENT SEQUENCE
+# ============================================================================
+experiment:
+  - "arena check"
+  - "start light and camera"
+  - name: "main block"
+    trials:
+      - "sq_grating_30deg_gs2"
+      - "sq_grating_30deg_gs16"
+      - "sq_grating_60deg_gs2"
+      - "sq_grating_60deg_gs16"
+      - "sine_grating_30deg_gs16"
+      - "sine_grating_60deg_gs16"
+      - "sine_grating_30deg_fine_gs16"
+    repetitions: 3
+    randomize: true
+    intertrial: "intertrial"
+  - "posttrial"
+
+
+# ============================================================================
+# CONDITIONS LIBRARY
+# ============================================================================
+conditions:
+  - name: "arena check"
+    commands:
+      - type: "controller"
+        command_name: "allOn"
+      - type: "wait"
+        duration: *dur_short
+      - type: "controller"
+        command_name: "allOff"
+
+  - name: "start light and camera"
+    commands:
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setIRLEDPower"
+        params:
+          power: 50
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOnLED"
+
+      - type: "wait"
+        duration: 0.5
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "startRecording"
+        params:
+          filename: 'testExperiment'
+
+  - name: "sq_grating_30deg_gs2"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"
+        pattern_ID: 1
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 3
+
+  - name: "sq_grating_30deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat02_sq_grating_30deg_gs16_G4.pat"
+        pattern_ID: 2
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "sq_grating_60deg_gs2"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat03_sq_grating_60deg_gs2_G4.pat"
+        pattern_ID: 3
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 5
+
+  - name: "sq_grating_60deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 4
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: *dur_long
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "sine_grating_30deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat05_sine_grating_30deg_gs16_G4.pat"
+        pattern_ID: 5
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: *dur_long
+
+  - name: "sine_grating_60deg_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat06_sine_grating_60deg_gs16_G4.pat"
+        pattern_ID: 6
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "sine_grating_30deg_fine_gs16"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: *color_command
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat07_sine_grating_30deg_fine_gs16_G4.pat"
+        pattern_ID: 7
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *color_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "intertrial"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "posttrial"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOffLED"
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopRecording"
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopCapture"
+
+      - type: "wait"
+        duration: 1

--- a/tests/fixtures/v3_consecutive_refs.yaml
+++ b/tests/fixtures/v3_consecutive_refs.yaml
@@ -1,0 +1,57 @@
+version: 3
+
+# ============================================================================
+# Consecutive-refs fixture — `experiment:` contains only bare condition
+# references, no block objects. Exercises the heterogeneous-list parser path
+# when only one branch (bare-string) is taken.
+# ============================================================================
+
+experiment_info:
+  name: "v3 fixture — sequence of bare references, no blocks"
+  date_created: "2026-05-24"
+  author: "webDisplayTools test fixture"
+  pattern_library: '/Users/reiserm/Documents/GitHub/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+experiment:
+  - "step_1"
+  - "step_2"
+  - "step_3"
+  - "step_4"
+
+conditions:
+  - name: "step_1"
+    commands:
+      - type: "controller"
+        command_name: "allOn"
+      - type: "wait"
+        duration: 1
+      - type: "controller"
+        command_name: "allOff"
+
+  - name: "step_2"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"
+        pattern_ID: 1
+        duration: 5
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 5
+
+  - name: "step_3"
+    commands:
+      - type: "wait"
+        duration: 2
+
+  - name: "step_4"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+      - type: "wait"
+        duration: 1

--- a/tests/fixtures/v3_future_keys.yaml
+++ b/tests/fixtures/v3_future_keys.yaml
@@ -1,0 +1,68 @@
+version: 3
+
+# ============================================================================
+# Future-keys fixture — includes reserved v3.x keys that the current MATLAB
+# parser doesn't implement (`retry_on_fail`, `abort_if`). Exercises the
+# unknown-keys passthrough at the block level.
+#
+# The MATLAB parser at the pinned SHA (00c8f95) silently ignores unknown
+# block keys, so this fixture parses cleanly. The designer must preserve
+# these keys through a parse → generate → parse round-trip.
+# ============================================================================
+
+experiment_info:
+  name: "v3 fixture — block with reserved future-compat keys"
+  date_created: "2026-05-24"
+  author: "webDisplayTools test fixture"
+  pattern_library: '/Users/reiserm/Documents/GitHub/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+experiment:
+  - name: "main_block_with_future_keys"
+    trials: ["trial_a", "trial_b"]
+    repetitions: 5
+    randomize: true
+    intertrial: "rest"
+    # Reserved v3.x flow-control keys (proposal-only, MATLAB ignores for now)
+    retry_on_fail:
+      condition: "tracker.fly_visible == false"
+      max_retries_per_trial: 3
+      placement: "end_of_block"
+    abort_if: "tracker.idle_seconds > 60"
+
+conditions:
+  - name: "trial_a"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"
+        pattern_ID: 1
+        duration: 5
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 5
+
+  - name: "trial_b"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 2
+        duration: 5
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 5
+
+  - name: "rest"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+      - type: "wait"
+        duration: 2

--- a/tests/fixtures/v3_multi_block.yaml
+++ b/tests/fixtures/v3_multi_block.yaml
@@ -1,0 +1,82 @@
+version: 3
+
+# ============================================================================
+# Multi-block fixture — the Shubham-P008-style structure that motivated v3.
+# Three blocks at independent repetition counts: pre-test (1 rep, no random),
+# training (4 reps, randomized), post-test (1 rep, no random).
+# ============================================================================
+
+experiment_info:
+  name: "v3 fixture — multi-block at different repetition counts"
+  date_created: "2026-05-24"
+  author: "webDisplayTools test fixture"
+  pattern_library: '/Users/reiserm/Documents/GitHub/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+experiment:
+  - "arena_check"
+  - name: "pretest"
+    trials: ["probe"]
+    repetitions: 1
+  - name: "training"
+    trials: ["training_trial", "probe"]
+    repetitions: 4
+    randomize: true
+    intertrial: "baseline"
+  - name: "posttest"
+    trials: ["probe"]
+    repetitions: 1
+  - "shutdown"
+
+conditions:
+  - name: "arena_check"
+    commands:
+      - type: "controller"
+        command_name: "allOn"
+      - type: "wait"
+        duration: 1
+      - type: "controller"
+        command_name: "allOff"
+
+  - name: "training_trial"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"
+        pattern_ID: 1
+        duration: 10
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 10
+
+  - name: "probe"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 2
+        duration: 5
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 5
+
+  - name: "baseline"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+      - type: "wait"
+        duration: 2
+
+  - name: "shutdown"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+      - type: "wait"
+        duration: 1

--- a/tests/fixtures/v3_no_intertrial.yaml
+++ b/tests/fixtures/v3_no_intertrial.yaml
@@ -1,0 +1,52 @@
+version: 3
+
+# ============================================================================
+# No-intertrial fixture — block omits the optional `intertrial:` field.
+# Trials run back-to-back with no inserted between-trial commands.
+# ============================================================================
+
+experiment_info:
+  name: "v3 fixture — block without intertrial"
+  date_created: "2026-05-24"
+  author: "webDisplayTools test fixture"
+  pattern_library: '/Users/reiserm/Documents/GitHub/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+variables:
+  trial_dur: &trial_dur 4
+
+experiment:
+  - name: "no_iti_block"
+    trials: ["fast_A", "fast_B"]
+    repetitions: 3
+    randomize: true
+
+conditions:
+  - name: "fast_A"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"
+        pattern_ID: 1
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: *trial_dur
+
+  - name: "fast_B"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 2
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: *trial_dur

--- a/tests/fixtures/v3_no_randomize.yaml
+++ b/tests/fixtures/v3_no_randomize.yaml
@@ -1,0 +1,72 @@
+version: 3
+
+# ============================================================================
+# randomize: false fixture — block runs trials in the order listed for every
+# repetition. Exercises the explicit randomize=false case (default-omitted
+# behavior is covered by other fixtures).
+# ============================================================================
+
+experiment_info:
+  name: "v3 fixture — randomize=false block"
+  date_created: "2026-05-24"
+  author: "webDisplayTools test fixture"
+  pattern_library: '/Users/reiserm/Documents/GitHub/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+experiment:
+  - name: "deterministic order"
+    trials: ["A", "B", "C"]
+    repetitions: 2
+    randomize: false
+    intertrial: "pause"
+
+conditions:
+  - name: "A"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"
+        pattern_ID: 1
+        duration: 3
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 3
+
+  - name: "B"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 2
+        duration: 3
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 3
+
+  - name: "C"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat05_sine_grating_30deg_gs16_G4.pat"
+        pattern_ID: 3
+        duration: 3
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 3
+
+  - name: "pause"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+      - type: "wait"
+        duration: 1

--- a/tests/fixtures/v3_no_variables.yaml
+++ b/tests/fixtures/v3_no_variables.yaml
@@ -1,0 +1,34 @@
+version: 3
+
+# ============================================================================
+# No-variables fixture — minimal experiment with no `variables:` section.
+# Exercises the optional-anchor-block path in the parser/generator.
+# ============================================================================
+
+experiment_info:
+  name: "v3 fixture — no variables section"
+  date_created: "2026-05-24"
+  author: "webDisplayTools test fixture"
+  pattern_library: '/Users/reiserm/Documents/GitHub/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+experiment:
+  - name: "single block"
+    trials: ["stimulus"]
+    repetitions: 1
+
+conditions:
+  - name: "stimulus"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"
+        pattern_ID: 1
+        duration: 5
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 5

--- a/tests/fixtures/v3_plugin_config.yaml
+++ b/tests/fixtures/v3_plugin_config.yaml
@@ -1,0 +1,94 @@
+version: 3
+
+# ============================================================================
+# Plugin-config fixture — plugins carry inline `config:` blocks that override
+# defaults from the rig YAML. Exercises the plugin config nesting and the
+# `_unknownKeys`-at-plugin-config level for forward compatibility.
+# ============================================================================
+
+experiment_info:
+  name: "v3 fixture — plugins with inline config overrides"
+  date_created: "2026-05-24"
+  author: "webDisplayTools test fixture"
+  pattern_library: '/Users/reiserm/Documents/GitHub/maDisplayTools/patterns/reference/G41_2x12_cw'
+
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'
+
+plugins:
+  - name: "camera"
+    type: "class"
+    matlab:
+      class: "BiasPlugin"
+    config:
+      frame_rate: 150
+      video_format: "avi"
+
+  - name: "backlight"
+    type: "class"
+    matlab:
+      class: "LEDControllerPlugin"
+    config:
+      port: "COM5"
+
+experiment:
+  - "setup"
+  - name: "main"
+    trials: ["stim"]
+    repetitions: 2
+    intertrial: "rest"
+  - "shutdown"
+
+conditions:
+  - name: "setup"
+    commands:
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setIRLEDPower"
+        params:
+          power: 50
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOnLED"
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "startRecording"
+        params:
+          filename: 'fixture_test'
+
+  - name: "stim"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"
+        pattern_ID: 1
+        duration: 5
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "wait"
+        duration: 5
+
+  - name: "rest"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+      - type: "wait"
+        duration: 1
+
+  - name: "shutdown"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOffLED"
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopRecording"
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopCapture"

--- a/tests/refresh-v3-canonical.sh
+++ b/tests/refresh-v3-canonical.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# refresh-v3-canonical.sh
+#
+# Pull the latest v3 canonical YAMLs from maDisplayTools' origin/version3
+# branch into tests/fixtures/. Surfaces any upstream drift via `git diff`.
+#
+# Why this exists:
+#   The two canonical v3 YAMLs in maDisplayTools ARE the spec for the v3
+#   Experiment Designer. The designer must round-trip them. If upstream
+#   changes them (e.g., after hardware validation), we want to know so we
+#   can update the parser, data model, and tests to match.
+#
+# Usage:
+#   tests/refresh-v3-canonical.sh                # default repo location
+#   MAREPO=/path/to/maDisplayTools tests/refresh-v3-canonical.sh
+#
+# Workflow:
+#   1. Run this script.
+#   2. `git diff tests/fixtures/v3_canonical_*.yaml` — if non-empty, upstream changed.
+#   3. Inspect the diff. Update docs/development/v3-spec.md's pinned SHA.
+#   4. Re-run `npm test` to confirm the parser still round-trips them.
+#   5. If parser tests break, the spec drifted in a way the parser doesn't
+#      handle — fix it before committing the updated fixtures.
+
+set -euo pipefail
+
+# Default to a sibling-directory checkout; override with MAREPO=...
+MAREPO="${MAREPO:-/Users/reiserm/Documents/GitHub/maDisplayTools}"
+
+if [ ! -d "$MAREPO/.git" ]; then
+    echo "Error: maDisplayTools repo not found at $MAREPO" >&2
+    echo "Set MAREPO=/path/to/maDisplayTools or clone it there." >&2
+    exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "Fetching latest from maDisplayTools origin..."
+git -C "$MAREPO" fetch origin --quiet
+
+UPSTREAM_SHA="$(git -C "$MAREPO" rev-parse origin/version3)"
+echo "  origin/version3 currently at: $UPSTREAM_SHA"
+
+PINNED_SHA="$(grep -oE '00c8f9[0-9a-f]*|`[0-9a-f]{7,40}`' docs/development/v3-spec.md | head -1 | tr -d '`' || true)"
+echo "  Pinned in v3-spec.md:         $PINNED_SHA"
+
+echo ""
+echo "Refreshing canonical fixtures..."
+git -C "$MAREPO" show origin/version3:examples/yamls/experimentExampleVersion3.yaml > tests/fixtures/v3_canonical_a.yaml
+git -C "$MAREPO" show origin/version3:examples/yamls/version3Attempt.yaml         > tests/fixtures/v3_canonical_b.yaml
+
+echo ""
+echo "Diff vs committed fixtures:"
+if git diff --quiet tests/fixtures/v3_canonical_a.yaml tests/fixtures/v3_canonical_b.yaml; then
+    echo "  No changes. Upstream is in sync with the committed fixtures."
+else
+    git --no-pager diff --stat tests/fixtures/v3_canonical_a.yaml tests/fixtures/v3_canonical_b.yaml
+    echo ""
+    echo "Upstream changed. Next steps:"
+    echo "  1. Inspect: git diff tests/fixtures/v3_canonical_*.yaml"
+    echo "  2. Update pinned SHA in docs/development/v3-spec.md to: $UPSTREAM_SHA"
+    echo "  3. Run: npm test  (verify parser still round-trips)"
+    echo "  4. If parser tests fail, fix js/protocol-yaml-v3.js before committing."
+fi

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -1,0 +1,20 @@
+/**
+ * Protocol v3 Roundtrip Tests
+ *
+ * Scaffolded in Phase 0 — populated in Phase 1 (parser/generator) and
+ * expanded in Phase 7 (full coverage). See `docs/development/v3-spec.md`
+ * and the canonical fixtures at `tests/fixtures/v3_canonical_*.yaml`.
+ *
+ * Run via:
+ *   node tests/test-protocol-roundtrip-v3.js
+ *   npm run test:protocol-v3
+ */
+
+'use strict';
+
+// Phase 0 stub: emit a status line and exit cleanly so `npm test` doesn't
+// fail on a branch where the v3 parser hasn't been written yet. Phase 1
+// replaces this entire file with the real canonical round-trip suite.
+console.log('Protocol v3 roundtrip suite — Phase 0 stub (no tests yet).');
+console.log('Next: Phase 1 implements js/protocol-yaml-v3.js and the canonical round-trip gate.');
+process.exit(0);

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -1,20 +1,359 @@
+#!/usr/bin/env node
 /**
  * Protocol v3 Roundtrip Tests
  *
- * Scaffolded in Phase 0 — populated in Phase 1 (parser/generator) and
- * expanded in Phase 7 (full coverage). See `docs/development/v3-spec.md`
- * and the canonical fixtures at `tests/fixtures/v3_canonical_*.yaml`.
+ * Phase 1 gate: round-trip the two canonical v3 YAMLs from origin/version3
+ * @ 00c8f95, plus all 7 coverage-gap fixtures, preserving anchors and comments.
+ *
+ * MATLAB-side cross-check (Phase 1 gate item 4) lives in a separate manual
+ * script (docs/development/v3-matlab-validation.md and Phase 8 work);
+ * see README at top of that doc.
  *
  * Run via:
  *   node tests/test-protocol-roundtrip-v3.js
  *   npm run test:protocol-v3
+ *
+ * Exit code 0 = all passed, 1 = failures.
  */
 
 'use strict';
 
-// Phase 0 stub: emit a status line and exit cleanly so `npm test` doesn't
-// fail on a branch where the v3 parser hasn't been written yet. Phase 1
-// replaces this entire file with the real canonical round-trip suite.
-console.log('Protocol v3 roundtrip suite — Phase 0 stub (no tests yet).');
-console.log('Next: Phase 1 implements js/protocol-yaml-v3.js and the canonical round-trip gate.');
+const fs = require('fs');
+const path = require('path');
+
+const {
+    parseV3Protocol,
+    generateV3Protocol,
+    validateReferences,
+    V3ParseError
+} = require('../js/protocol-yaml-v3.js');
+
+// ─── Counters & helpers ─────────────────────────────────────────────────────
+
+let totalTests = 0;
+let passedTests = 0;
+let failedTests = [];
+
+function pass(label, detail) {
+    totalTests++;
+    passedTests++;
+    console.log('  \x1b[32m✓\x1b[0m ' + label + (detail ? ' — ' + detail : ''));
+}
+
+function fail(label, detail) {
+    totalTests++;
+    failedTests.push(label);
+    console.log('  \x1b[31m✗\x1b[0m ' + label + (detail ? ' — ' + detail : ''));
+}
+
+function check(label, actual, expected) {
+    if (actual === expected) {
+        pass(label, JSON.stringify(actual));
+    } else {
+        fail(label, 'got ' + JSON.stringify(actual) + ', expected ' + JSON.stringify(expected));
+    }
+}
+
+function checkTrue(label, condition, detail) {
+    if (condition) pass(label, detail);
+    else fail(label, detail || 'expected truthy');
+}
+
+function checkThrows(label, fn, expectedCode) {
+    try {
+        fn();
+        fail(label, 'expected throw with code ' + expectedCode + ', but did not throw');
+    } catch (e) {
+        if (expectedCode && e.code !== expectedCode) {
+            fail(label, 'threw with code ' + e.code + ', expected ' + expectedCode);
+        } else {
+            pass(label, e.code + ': ' + e.message.slice(0, 80));
+        }
+    }
+}
+
+function dropDoc(experiment) {
+    // For deep-equal comparisons: strip the YAML.Document handle (which holds
+    // CST nodes that aren't JSON-serializable in a stable way).
+    const { _doc, ...rest } = experiment;
+    return rest;
+}
+
+function readFixture(name) {
+    return fs.readFileSync(path.join(__dirname, 'fixtures', name), 'utf8');
+}
+
+// ─── Test Suite 1: Canonical round-trip (Phase 1 gate, priority 1) ──────────
+console.log('\n--- Suite 1: Canonical round-trip ---');
+
+for (const fname of ['v3_canonical_a.yaml', 'v3_canonical_b.yaml']) {
+    const text = readFixture(fname);
+    const exp1 = parseV3Protocol(text);
+    const regen = generateV3Protocol(exp1);
+    const exp2 = parseV3Protocol(regen);
+
+    check(fname + ': version', exp1.version, 3);
+    check(fname + ': conditions count', exp1.conditions.length, 11);
+    check(fname + ': sequence length', exp1.sequence.length, 4);
+    check(fname + ': sequence[0].kind', exp1.sequence[0].kind, 'ref');
+    check(fname + ': sequence[2].kind', exp1.sequence[2].kind, 'block');
+    check(fname + ': variables count', exp1.variables.length, 4);
+
+    const refs = validateReferences(exp1);
+    checkTrue(
+        fname + ': all references resolve',
+        refs.ok,
+        refs.ok ? 'all bare refs + trials + intertrials resolve' : refs.errors.join('; ')
+    );
+
+    // Data-model deep equality (modulo _doc)
+    checkTrue(
+        fname + ': parse → generate → parse data model stable',
+        JSON.stringify(dropDoc(exp1)) === JSON.stringify(dropDoc(exp2))
+    );
+
+    // Anchor & alias survival in regenerated YAML text
+    for (const anchorName of ['dur_long', 'dur_short', 'color_command', 'color_power']) {
+        checkTrue(
+            fname + ': anchor "' + anchorName + '" defined in regen',
+            regen.includes('&' + anchorName)
+        );
+        checkTrue(
+            fname + ': anchor "' + anchorName + '" referenced as alias in regen',
+            regen.includes('*' + anchorName)
+        );
+    }
+
+    // Comment survival
+    const origComments = text.split('\n').filter((l) => l.trimStart().startsWith('#')).length;
+    const regenComments = regen.split('\n').filter((l) => l.trimStart().startsWith('#')).length;
+    checkTrue(
+        fname + ': comment lines preserved',
+        regenComments === origComments,
+        'orig=' + origComments + ', regen=' + regenComments
+    );
+}
+
+// ─── Test Suite 2: Coverage-gap fixtures ────────────────────────────────────
+console.log('\n--- Suite 2: Coverage-gap fixtures ---');
+
+const coverageFixtures = [
+    'v3_multi_block.yaml',
+    'v3_no_randomize.yaml',
+    'v3_no_variables.yaml',
+    'v3_no_intertrial.yaml',
+    'v3_consecutive_refs.yaml',
+    'v3_future_keys.yaml',
+    'v3_plugin_config.yaml'
+];
+
+for (const fname of coverageFixtures) {
+    const text = readFixture(fname);
+    let exp1;
+    try {
+        exp1 = parseV3Protocol(text);
+        pass(fname + ': parses cleanly');
+    } catch (e) {
+        fail(fname + ': parse failed', e.message);
+        continue;
+    }
+    const regen = generateV3Protocol(exp1);
+    const exp2 = parseV3Protocol(regen);
+    checkTrue(
+        fname + ': round-trip data model stable',
+        JSON.stringify(dropDoc(exp1)) === JSON.stringify(dropDoc(exp2))
+    );
+    const refs = validateReferences(exp1);
+    checkTrue(fname + ': references resolve', refs.ok, refs.ok ? '' : refs.errors.join('; '));
+}
+
+// ─── Test Suite 3: Multi-block fixture — structural details ─────────────────
+console.log('\n--- Suite 3: Multi-block structural checks ---');
+
+{
+    const exp = parseV3Protocol(readFixture('v3_multi_block.yaml'));
+    check('multi_block: sequence length', exp.sequence.length, 5);
+    check('multi_block: seq[0] is bare ref', exp.sequence[0].kind, 'ref');
+    check('multi_block: seq[1] is block', exp.sequence[1].kind, 'block');
+    check('multi_block: block "pretest" reps', exp.sequence[1].repetitions, 1);
+    check('multi_block: block "training" reps', exp.sequence[2].repetitions, 4);
+    check('multi_block: block "training" randomize', exp.sequence[2].randomize, true);
+    check('multi_block: block "training" intertrial', exp.sequence[2].intertrial, 'baseline');
+    check(
+        'multi_block: block "posttest" randomize defaults false',
+        exp.sequence[3].randomize,
+        false
+    );
+}
+
+// ─── Test Suite 4: Future-keys passthrough ──────────────────────────────────
+console.log('\n--- Suite 4: Forward-compat unknown-keys passthrough ---');
+
+{
+    const exp = parseV3Protocol(readFixture('v3_future_keys.yaml'));
+    const block = exp.sequence[0];
+    check('future_keys: block has known keys', block.kind, 'block');
+    checkTrue(
+        'future_keys: retry_on_fail preserved in _unknownKeys',
+        block._unknownKeys && typeof block._unknownKeys.retry_on_fail === 'object'
+    );
+    checkTrue(
+        'future_keys: abort_if preserved in _unknownKeys',
+        block._unknownKeys && typeof block._unknownKeys.abort_if === 'string'
+    );
+
+    const regen = generateV3Protocol(exp);
+    checkTrue('future_keys: retry_on_fail survives in regen YAML', regen.includes('retry_on_fail'));
+    checkTrue('future_keys: abort_if survives in regen YAML', regen.includes('abort_if'));
+    checkTrue(
+        'future_keys: max_retries_per_trial nested value survives',
+        regen.includes('max_retries_per_trial')
+    );
+}
+
+// ─── Test Suite 5: Plugin config & params ──────────────────────────────────
+console.log('\n--- Suite 5: Plugin config and command params ---');
+
+{
+    const exp = parseV3Protocol(readFixture('v3_plugin_config.yaml'));
+    check('plugin_config: plugin count', exp.plugins.length, 2);
+    check('plugin_config: camera plugin name', exp.plugins[0].name, 'camera');
+    check('plugin_config: camera config.frame_rate', exp.plugins[0].config.frame_rate, 150);
+    check('plugin_config: camera config.video_format', exp.plugins[0].config.video_format, 'avi');
+    check('plugin_config: backlight config.port', exp.plugins[1].config.port, 'COM5');
+
+    // Plugin command with params
+    const setupCond = exp.conditions.find((c) => c.name === 'setup');
+    checkTrue('plugin_config: setup condition found', !!setupCond);
+    const irPower = setupCond.commands.find((c) => c.command_name === 'setIRLEDPower');
+    checkTrue('plugin_config: setIRLEDPower command found', !!irPower);
+    check('plugin_config: setIRLEDPower power param', irPower.params.power, 50);
+}
+
+// ─── Test Suite 6: Variables — types & order ────────────────────────────────
+console.log('\n--- Suite 6: Variables (anchors) types and order ---');
+
+{
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    check('variables: count', exp.variables.length, 4);
+    check('variables: order[0].name', exp.variables[0].name, 'dur_long');
+    check('variables: order[0].value (number)', exp.variables[0].value, 10);
+    check('variables: order[2].name', exp.variables[2].name, 'color_command');
+    check('variables: order[2].value (string)', exp.variables[2].value, 'setRedLEDPower');
+}
+
+// ─── Test Suite 7: Validation error cases ───────────────────────────────────
+console.log('\n--- Suite 7: Validation error cases ---');
+
+checkThrows('rejects version: 1', () => parseV3Protocol('version: 1\nfoo: bar\n'), 'WRONG_VERSION');
+
+checkThrows('rejects version: 2', () => parseV3Protocol('version: 2\nfoo: bar\n'), 'WRONG_VERSION');
+
+checkThrows(
+    'rejects missing rig',
+    () =>
+        parseV3Protocol(
+            'version: 3\nexperiment_info: {name: x}\nexperiment: [foo]\nconditions: [{name: foo, commands: []}]\n'
+        ),
+    'INVALID_SCHEMA'
+);
+
+checkThrows(
+    'rejects empty experiment',
+    () =>
+        parseV3Protocol(
+            'version: 3\nexperiment_info: {name: x}\nrig: "/tmp/r.yaml"\nexperiment: []\nconditions: [{name: foo, commands: []}]\n'
+        ),
+    'INVALID_SCHEMA'
+);
+
+checkThrows(
+    'rejects unknown command type',
+    () =>
+        parseV3Protocol(
+            [
+                'version: 3',
+                'experiment_info: {name: x}',
+                'rig: "/tmp/r.yaml"',
+                'experiment: [foo]',
+                'conditions:',
+                '  - name: foo',
+                '    commands:',
+                '      - {type: "bogus", duration: 1}'
+            ].join('\n') + '\n'
+        ),
+    'INVALID_SCHEMA'
+);
+
+// Reference validation catches dangling refs (returns errors, doesn't throw)
+{
+    const exp = parseV3Protocol(
+        [
+            'version: 3',
+            'experiment_info: {name: x}',
+            'rig: "/tmp/r.yaml"',
+            'experiment: ["nonexistent"]',
+            'conditions:',
+            '  - name: foo',
+            '    commands:',
+            '      - {type: "wait", duration: 1}'
+        ].join('\n') + '\n'
+    );
+    const refs = validateReferences(exp);
+    check('validateReferences: dangling ref detected (ok=false)', refs.ok, false);
+    checkTrue(
+        'validateReferences: error message mentions "nonexistent"',
+        refs.errors.some((e) => e.includes('nonexistent'))
+    );
+}
+
+// Duplicate condition names
+{
+    const exp = parseV3Protocol(
+        [
+            'version: 3',
+            'experiment_info: {name: x}',
+            'rig: "/tmp/r.yaml"',
+            'experiment: ["foo"]',
+            'conditions:',
+            '  - name: foo',
+            '    commands: [{type: "wait", duration: 1}]',
+            '  - name: foo',
+            '    commands: [{type: "wait", duration: 2}]'
+        ].join('\n') + '\n'
+    );
+    const refs = validateReferences(exp);
+    check('validateReferences: duplicate condition name detected', refs.ok, false);
+    checkTrue(
+        'validateReferences: error message mentions "Duplicate"',
+        refs.errors.some((e) => e.includes('Duplicate'))
+    );
+}
+
+// ─── Test Suite 8: Numeric type preservation ────────────────────────────────
+console.log('\n--- Suite 8: Numeric type preservation ---');
+
+{
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const block = exp.sequence[2];
+    check('numeric: block.repetitions is number', typeof block.repetitions, 'number');
+    check('numeric: block.repetitions value', block.repetitions, 3);
+
+    const arenaCheck = exp.conditions.find((c) => c.name === 'arena check');
+    const waitCmd = arenaCheck.commands.find((c) => c.type === 'wait');
+    check('numeric: wait.duration is number', typeof waitCmd.duration, 'number');
+    check('numeric: wait.duration value', waitCmd.duration, 3);
+
+    // Variable value (number)
+    check('numeric: variable dur_long is number', typeof exp.variables[0].value, 'number');
+    check('numeric: variable color_power value', exp.variables[3].value, 5);
+}
+
+// ─── Results ────────────────────────────────────────────────────────────────
+console.log('\n=== Results: ' + passedTests + '/' + totalTests + ' passed ===');
+if (failedTests.length > 0) {
+    console.log('\nFailed tests:');
+    for (const t of failedTests) console.log('  - ' + t);
+    process.exit(1);
+}
 process.exit(0);


### PR DESCRIPTION
## Summary

Lands the **v3 Experiment Designer (Viewer)** as a new page alongside the existing v2 designer. Users can import v3 protocol YAML files, inspect them in a read-only 3-zone UI (Library / Sequence / Inspector + flattened timeline), and round-trip export with all anchors and comments preserved. v2 designer is **untouched**.

This is **PR1 of 2** for the v3 designer effort. PR2 will add inline editing, drag/drop, the Variables UX, validation cascade, and the v3 quickstart.

Plan: `/Users/reiserm/.claude/plans/let-s-check-if-matlabtools-enumerated-acorn.md`
Spec: [`docs/development/v3-spec.md`](docs/development/v3-spec.md) — pinned to maDisplayTools `origin/version3` @ `00c8f95`

## What ships in PR1

**New files:**
- `experiment_designer_v3.html` — 3-zone read-only viewer + bottom timeline + collapsible Settings drawer + modal error report. Browser loads `yaml@2` via CDN with an import map.
- `js/protocol-yaml-v3.js` — parser/generator built on `yaml@2` Document mode. Preserves anchors + comments + forward-compat unknown keys at every nesting level. Rejects v1/v2 inputs with a pointer to the v2 designer page.
- 9 v3 fixtures in `tests/fixtures/`:
  - `v3_canonical_a.yaml`, `v3_canonical_b.yaml` — verbatim from upstream (the canonical "spec by example")
  - `matlab_normalized/v3_canonical_*.yaml` — rig-path-rewritten copies for portable MATLAB validation
  - 7 coverage-gap fixtures: multi_block (Shubham-P008 shape), no_randomize, no_variables, no_intertrial, consecutive_refs, future_keys (retry_on_fail + abort_if), plugin_config
- `tests/test-protocol-roundtrip-v3.js` — 97 checks across 8 suites
- `tests/refresh-v3-canonical.sh` — re-pull canonical YAMLs from upstream and surface drift
- `docs/development/v3-spec.md` — spec-by-example doc with pinned SHA, designer constraints, and the manual MATLAB cross-check recipe

**Modified (small, additive):**
- `index.html` — new card linking to v3 viewer with a "Beta / Viewer" badge
- `package.json` — `npm test` now runs all three suites (v2, v3, arena calcs); `yaml@^2.9.0` as dev dep
- `.github/workflows/validate-protocol-roundtrip.yml` — add v3 path filters + v3 test step
- `docs/development/ROADMAP.md` — v3 designer section (PR1 + PR2 plan, v2 retirement note)

**Untouched (zero risk):** `experiment_designer.html`, `experiment_designer_quickstart.html`, `js/protocol-yaml.js`, `tests/test-protocol-roundtrip.js`, `tests/fixtures/v2_*.yaml`, `js/plugin-registry.js`, `js/arena-configs.js`.

## Why a parallel page (not in-place)

Reviewed via the `codex-plan-review` skill (Codex GPT-5.5 standard + adversarial, plus independent Claude analysis). The biggest input from that review: hand-rolling an anchor-aware YAML parser was wrong; use `yaml@2` (PR uses `yaml` in Document mode for browser + Node).

The parallel-page approach keeps v2 live as a UI reference + fallback while v3 iterates and the hardware-validation work continues upstream. The coexistence window is short (v2 YAML is already obsolete on the MATLAB side per Lab discussion).

## Validation

**JS-side automated** (CI: `.github/workflows/validate-protocol-roundtrip.yml`):
- `npm test`: arena calcs + 137/137 v2 + 97/97 v3 — all green

**MATLAB-side manual** (instructions in [docs/development/v3-spec.md](docs/development/v3-spec.md#matlab-side-validation-manual-flow)):
- Worktree of maDisplayTools at the pinned SHA + the [MartinKoch123/yaml](https://github.com/MartinKoch123/yaml) library on the MATLAB path
- All 9 v3 fixtures parse cleanly through the upstream `ProtocolParser.m`
- With `rng(42)` seeded before each parse, the regenerated YAML produces a **byte-identical `commandSequence`** in MATLAB for all 9 fixture pairs

**Browser smoke** (driven via Claude in Chrome MCP):
- Page loads cleanly with no console errors
- `v3_canonical_a.yaml`: Library shows 11 conditions, Sequence shows 4 entries (2 refs + 1 block + 1 ref), Variables drawer lists 4 anchors, Timeline shows 44 flattened steps
- `v3_future_keys.yaml`: "⚠ 2 future-compat keys" pill correctly appears on the block carrying `retry_on_fail` + `abort_if`
- Export round-trip in browser: 4/4 anchors + 18/18 comments preserved, data model deep-equal
- v2 YAML import: rejected with modal saying "This is a v2 protocol. Please open this file in the v2 Experiment Designer page." [WRONG_VERSION]
- v2 designer page (`experiment_designer.html`) still loads with no errors

## Test plan

- [ ] Pull the branch, run `npm install && npm test` — expect all suites green
- [ ] `python -m http.server 8080` and open `http://localhost:8080/experiment_designer.html` — confirm v2 sanity, import a v2 fixture, edit, export
- [ ] Open `http://localhost:8080/experiment_designer_v3.html`
- [ ] Click **Import YAML**, select `tests/fixtures/v3_canonical_a.yaml`:
  - [ ] Library shows 11 conditions with usage badges
  - [ ] Sequence shows 4 entries (2 green ref cards, 1 blue block card with 7 trial chips and randomize badge, 1 green ref)
  - [ ] Settings drawer (toggle button) shows experiment info, rig path, 2 plugins, 4 variables anchors with proper types
- [ ] Click each sequence entry and verify Inspector shows the right details + jump buttons work
- [ ] Click **Export YAML** → diff the downloaded file against the input — expect only whitespace differences (collapsed blank lines); anchors + comments preserved
- [ ] Import `tests/fixtures/v3_future_keys.yaml` — verify the "⚠ 2 future-compat keys" pill renders on the block
- [ ] Import any `tests/fixtures/v2_*.yaml` — expect a clean error modal pointing to the v2 designer

## What's NOT in PR1 (lands in PR2)

- Inline editing of conditions, blocks, and variables
- Drag/drop in the sequence pane and within block trial strips
- Variables UX (rename cascade, AliasOr-aware inputs)
- Undo/redo
- v3 quickstart page
- `docs/development/v3-matlab-validation.md` formalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)