### PR TITLE
v3 Experiment Designer — v0.2 Editor (inspector edits, command CRUD, undo)

### DIFF
--- a/docs/development/ROADMAP.md
+++ b/docs/development/ROADMAP.md
@@ -3,7 +3,7 @@
 ## v3 Experiment Designer (beta)
 
 A new designer for the **Protocol v3** YAML format introduced in maDisplayTools
-on `origin/version3` (pinned SHA `00c8f95`). Lives alongside the existing v2
+on `origin/version3` (pinned SHA `649d7ef`). Lives alongside the existing v2
 Experiment Designer; the v2 designer stays untouched while v3 iterates. After
 the v3 editor (PR2) lands and the lab confirms v3 production use, a follow-up
 effort retires v2.

--- a/docs/development/v3-spec.md
+++ b/docs/development/v3-spec.md
@@ -12,18 +12,57 @@ with the canonical example files or the MATLAB parser, the latter wins.
 
 - Repo: `reiserlab/maDisplayTools`
 - Branch: `origin/version3`
-- Commit SHA: **`00c8f9561bb1915a36d54054aeadf89778888ba2`** (`00c8f95`, captured 2026-05-23)
+- Commit SHA: **`649d7efd…`** (`649d7ef`, captured 2026-05-27)
+- Previous pin: `00c8f95` (2026-05-23) — bumped after Lisa added docs +
+  full-experiment example on 2026-05-26.
 
-The two canonical example YAMLs from this commit are committed verbatim in
-this repo as:
+The reference YAMLs from this commit are committed verbatim in this repo as:
 
 - `tests/fixtures/v3_canonical_a.yaml` ← `examples/yamls/experimentExampleVersion3.yaml`
 - `tests/fixtures/v3_canonical_b.yaml` ← `examples/yamls/version3Attempt.yaml`
+- `tests/fixtures/v3_full_experiment.yaml` ← `examples/yamls/full_experiment_test_v3.yaml`
+  (Lisa's port of the v2 test experiment to v3; **three syntactic typos in the
+  upstream file were fixed locally** — missing `commands:` key on the
+  `start recording` condition, indent slip on a `wait`, missing close-quote on a
+  `type: "controller` — pending a fix push upstream)
 
-**These files are the spec.** The v3 parser exists to round-trip them; the
-designer exists to view and edit data they could represent. Run
-`tests/refresh-v3-canonical.sh` to re-fetch them at a newer SHA; any `git diff`
-output is a signal the spec drifted upstream.
+**These files plus Lisa's documentation are the spec.** The v3 parser exists
+to round-trip them; the designer exists to view and edit data they could
+represent. Run `tests/refresh-v3-canonical.sh` to re-fetch them at a newer SHA;
+any `git diff` output is a signal the spec drifted upstream.
+
+### Authoritative spec docs (upstream)
+
+- **`docs/development/yaml_protocol_documentation_v3.md`** on `origin/version3`
+  (added by Lisa in `3e1eb63`, 2026-05-26). This is the human-readable spec for
+  the v3 YAML format — three-tier config (arena/rig/experiment), all command
+  types, plugin catalog, validation checklist. **Defer to this doc, not this
+  file, when in doubt about format details.** This file documents
+  designer-specific concerns (round-trip strategy, designer constraints) and
+  the JS-side parser contract.
+
+### Spec details added by Lisa's documentation (2026-05-26)
+
+These are documented upstream but were not surfaced in the original `00c8f95`
+canonical examples; the designer should expect them eventually:
+
+- **`DAQThermometerPlugin`** — third built-in class plugin alongside
+  `BiasPlugin` and `LEDControllerPlugin`. Commands: `startContinuousLogging`,
+  `stopContinuousLogging` (added in `dfbfd0b`), `get_temperature`,
+  `log_temperature`. Config fields: `device_id`, `channels`,
+  `thermocouple_type`, `sample_rate`, `sample_duration`, `generate_plots`.
+- **Built-in `log` plugin** — `plugin_name: "log"`, `command_name: "log"`,
+  params `{message, level}` where `level ∈ {DEBUG, INFO, WARNING, ERROR}`. Not
+  declared in `plugins:`; treated as always-available.
+- **Anchor as `command_name`** — a plugin command's `command_name:` field may
+  be set via `*alias` (e.g. variables `&led_command "setRedLEDPower"` →
+  `command_name: *led_command`). The editor's anchor-binding UI must support
+  enum-style command-name fields, not just numeric/string scalars.
+- **Negative `frame_rate`** — explicit: a negative value on `trialParams`
+  plays the pattern in reverse.
+- **`pattern_ID` auto-update at SD-card prep** — `pattern_ID` is rewritten
+  during deployment to match SD slot, so its value in source YAML is
+  informational. Author hint: use a `*var` so the value is in one place.
 
 ### MATLAB-side validation (manual flow)
 

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -722,6 +722,14 @@
             $('dirtyIndicator').style.display = dirty ? 'inline-block' : 'none';
         }
 
+        // Warn before close/reload if there are unsaved edits.
+        window.addEventListener('beforeunload', (e) => {
+            if (dirty) {
+                e.preventDefault();
+                e.returnValue = '';
+            }
+        });
+
         function updateUndoUI() {
             document.getElementById('undoBtn').disabled = undoStack.length === 0;
             document.getElementById('redoBtn').disabled = redoStack.length === 0;
@@ -835,6 +843,10 @@
         $('fileInput').addEventListener('change', async (e) => {
             const file = e.target.files[0];
             if (!file) return;
+            if (dirty && !confirm('Discard unsaved edits and import "' + file.name + '"?')) {
+                $('fileInput').value = '';
+                return;
+            }
             const text = await file.text();
             try {
                 const parsed = parseV3Protocol(text);
@@ -1271,6 +1283,12 @@
                 let raw = input.value;
                 let coerced = raw;
                 if (typeHint === 'number') {
+                    // Number("") === 0 — reject empty so clearing a field doesn't
+                    // silently commit zero. User must explicitly type a value.
+                    if (raw.trim() === '') {
+                        input.value = String(value);
+                        return;
+                    }
                     const n = Number(raw);
                     if (!Number.isFinite(n)) {
                         input.value = String(value);
@@ -1304,6 +1322,8 @@
             renderInspector();
             renderSequence();
             renderTimeline();
+            // Re-render library: block intertrial changes shift usage counts.
+            renderLibrary();
         }
 
         function renderBlockNameRow(blockIdx, entry) {

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -379,6 +379,40 @@
             border-radius: 8px;
             margin-left: 0.4rem;
         }
+
+        /* Block-property editor controls */
+        .block-prop-row {
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            margin-bottom: 0.3rem;
+            font-size: 0.75rem;
+        }
+        .block-prop-row .k { color: var(--text-dim); min-width: 90px; flex-shrink: 0; }
+        .block-prop-row input.field-edit,
+        .block-prop-row select.field-edit {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            color: var(--text);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.75rem;
+            padding: 0.15rem 0.4rem;
+            border-radius: 2px;
+        }
+        .block-prop-row input.field-edit:focus,
+        .block-prop-row select.field-edit:focus {
+            outline: none; border-color: var(--accent);
+        }
+        .block-prop-row input.field-edit.num { width: 70px; text-align: right; color: var(--accent); }
+        .block-prop-row input.field-edit.str { min-width: 180px; color: var(--accent); }
+        .block-prop-row select.field-edit { min-width: 180px; color: var(--accent); }
+        .block-prop-row input[type="checkbox"] {
+            width: 16px;
+            height: 16px;
+            accent-color: var(--accent);
+            cursor: pointer;
+        }
+        .block-prop-row .jump-btn { padding: 0.1rem 0.4rem; font-size: 0.7rem; }
         .jump-btn {
             background: rgba(0, 230, 118, 0.1);
             border: 1px solid var(--accent);
@@ -585,6 +619,7 @@
             validateReferences,
             V3ParseError,
             docSet,
+            docDelete,
             nodeIsAliasAt,
             aliasNameAt
         } from './js/protocol-yaml-v3.js';
@@ -958,28 +993,19 @@
             }
 
             if (selection.kind === 'block') {
-                const entry = experiment.sequence[selection.index];
+                const blockIdx = selection.index;
+                const entry = experiment.sequence[blockIdx];
                 if (!entry || entry.kind !== 'block') return;
                 body.appendChild(el('div', { class: 'inspector-title' },
                     el('span', { class: 'kind' }, 'Block'),
-                    entry.name || 'block_' + (selection.index + 1)
+                    entry.name || 'block_' + (blockIdx + 1)
                 ));
                 const props = el('div', { class: 'insp-section' });
                 props.appendChild(el('h4', {}, 'Properties'));
-                props.appendChild(el('div', { class: 'kv' },
-                    el('span', { class: 'k' }, 'repetitions: '),
-                    el('span', { class: 'v' }, String(entry.repetitions))));
-                props.appendChild(el('div', { class: 'kv' },
-                    el('span', { class: 'k' }, 'randomize: '),
-                    el('span', { class: 'v' }, entry.randomize ? 'true' : 'false')));
-                if (entry.intertrial) {
-                    props.appendChild(el('div', { class: 'kv' },
-                        el('span', { class: 'k' }, 'intertrial: '),
-                        el('button', { class: 'jump-btn', onClick: () => {
-                            selection = { kind: 'condition', name: entry.intertrial };
-                            renderLibrary(); renderInspector(); renderSequence();
-                        }}, '→ ' + entry.intertrial)));
-                }
+                props.appendChild(renderBlockNameRow(blockIdx, entry));
+                props.appendChild(renderBlockRepsRow(blockIdx, entry));
+                props.appendChild(renderBlockRandomizeRow(blockIdx, entry));
+                props.appendChild(renderBlockIntertrialRow(blockIdx, entry));
                 body.appendChild(props);
 
                 const trials = el('div', { class: 'insp-section' });
@@ -1095,6 +1121,167 @@
             });
             wrapper.appendChild(input);
             return wrapper;
+        }
+
+        // ── Block property row renderers ─────────────────────────────────
+        // After every commit, re-render sequence (block cards reflect new
+        // reps / randomize badge / iti label) and timeline (step count and
+        // step widths depend on reps + iti).
+
+        function commitBlockEdit() {
+            setDirty(true);
+            renderInspector();
+            renderSequence();
+            renderTimeline();
+        }
+
+        function renderBlockNameRow(blockIdx, entry) {
+            const row = el('div', { class: 'block-prop-row' },
+                el('span', { class: 'k' }, 'name:')
+            );
+            const input = el('input', {
+                type: 'text',
+                class: 'field-edit str',
+                value: entry.name || '',
+                placeholder: '(optional, auto-numbered)',
+                title: 'Block label shown in logs. Leave empty for auto-numbered fallback.'
+            });
+            input.addEventListener('change', () => {
+                const v = input.value.trim();
+                try {
+                    if (v === '') {
+                        if (entry.name) docDelete(experiment, ['experiment', blockIdx, 'name']);
+                    } else if (v !== entry.name) {
+                        docSet(experiment, ['experiment', blockIdx, 'name'], v);
+                    } else {
+                        return;
+                    }
+                    commitBlockEdit();
+                } catch (err) {
+                    showError('Edit failed', err.message);
+                    input.value = entry.name || '';
+                }
+            });
+            row.appendChild(input);
+            return row;
+        }
+
+        function renderBlockRepsRow(blockIdx, entry) {
+            const row = el('div', { class: 'block-prop-row' },
+                el('span', { class: 'k' }, 'repetitions:')
+            );
+            const aliasName = aliasNameAt(experiment, ['experiment', blockIdx, 'repetitions']);
+            if (aliasName) {
+                row.appendChild(el('span', {
+                    class: 'alias-chip',
+                    title: 'Bound to anchor &' + aliasName + '. Edit via Variables when the variables editor lands.'
+                },
+                    '→ &' + aliasName,
+                    el('span', { class: 'resolved-val' }, '= ' + entry.repetitions)
+                ));
+                return row;
+            }
+            const input = el('input', {
+                type: 'number',
+                class: 'field-edit num',
+                value: String(entry.repetitions),
+                min: '1',
+                step: '1',
+                title: 'Number of times the trials list runs (positive integer).'
+            });
+            input.addEventListener('change', () => {
+                const n = parseInt(input.value, 10);
+                if (!Number.isFinite(n) || n < 1) {
+                    input.value = String(entry.repetitions);
+                    return;
+                }
+                if (n === entry.repetitions) return;
+                try {
+                    docSet(experiment, ['experiment', blockIdx, 'repetitions'], n);
+                    commitBlockEdit();
+                } catch (err) {
+                    showError('Edit failed', err.message);
+                    input.value = String(entry.repetitions);
+                }
+            });
+            row.appendChild(input);
+            return row;
+        }
+
+        function renderBlockRandomizeRow(blockIdx, entry) {
+            const row = el('div', { class: 'block-prop-row' },
+                el('span', { class: 'k' }, 'randomize:')
+            );
+            const aliasName = aliasNameAt(experiment, ['experiment', blockIdx, 'randomize']);
+            if (aliasName) {
+                row.appendChild(el('span', { class: 'alias-chip' },
+                    '→ &' + aliasName,
+                    el('span', { class: 'resolved-val' }, '= ' + (entry.randomize ? 'true' : 'false'))
+                ));
+                return row;
+            }
+            const input = el('input', {
+                type: 'checkbox',
+                checked: entry.randomize,
+                title: 'When checked, trial order is shuffled per repetition (MATLAB randperm).'
+            });
+            input.addEventListener('change', () => {
+                try {
+                    docSet(experiment, ['experiment', blockIdx, 'randomize'], input.checked);
+                    commitBlockEdit();
+                } catch (err) {
+                    showError('Edit failed', err.message);
+                    input.checked = entry.randomize;
+                }
+            });
+            row.appendChild(input);
+            row.appendChild(el('span', { style: 'color: var(--text-dim); font-size: 0.7rem;' },
+                input.checked ? 'shuffled per repetition' : 'fixed order'));
+            return row;
+        }
+
+        function renderBlockIntertrialRow(blockIdx, entry) {
+            const row = el('div', { class: 'block-prop-row' },
+                el('span', { class: 'k' }, 'intertrial:')
+            );
+            const select = el('select', {
+                class: 'field-edit',
+                title: 'Condition inserted between consecutive trials in this block.'
+            });
+            select.appendChild(el('option', { value: '' }, '(none)'));
+            for (const c of experiment.conditions) {
+                const opt = el('option', { value: c.name }, c.name);
+                if (c.name === entry.intertrial) opt.selected = true;
+                select.appendChild(opt);
+            }
+            select.addEventListener('change', () => {
+                const v = select.value;
+                try {
+                    if (v === '') {
+                        if (entry.intertrial) docDelete(experiment, ['experiment', blockIdx, 'intertrial']);
+                    } else if (v !== entry.intertrial) {
+                        docSet(experiment, ['experiment', blockIdx, 'intertrial'], v);
+                    } else {
+                        return;
+                    }
+                    commitBlockEdit();
+                } catch (err) {
+                    showError('Edit failed', err.message);
+                    select.value = entry.intertrial || '';
+                }
+            });
+            row.appendChild(select);
+            if (entry.intertrial) {
+                row.appendChild(el('button', {
+                    class: 'jump-btn',
+                    title: 'Jump to "' + entry.intertrial + '" in the library',
+                    onClick: () => {
+                        selection = { kind: 'condition', name: entry.intertrial };
+                        renderLibrary(); renderInspector(); renderSequence();
+                    }
+                }, '→'));
+            }
+            return row;
         }
 
         function renderCommandCard(cmd, cmdPath) {

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -380,6 +380,70 @@
             margin-left: 0.4rem;
         }
 
+        /* Command-card action buttons (↑ ↓ ✕) */
+        .cmd-card { position: relative; }
+        .cmd-card .cmd-actions {
+            position: absolute;
+            top: 0.25rem;
+            right: 0.25rem;
+            display: flex;
+            gap: 2px;
+        }
+        .cmd-card .cmd-act-btn {
+            background: transparent;
+            border: 1px solid transparent;
+            color: var(--text-dim);
+            font-family: inherit;
+            font-size: 0.7rem;
+            width: 22px;
+            height: 22px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            border-radius: 3px;
+            padding: 0;
+        }
+        .cmd-card .cmd-act-btn:hover {
+            background: var(--surface-2);
+            color: var(--accent);
+            border-color: var(--border);
+        }
+        .cmd-card .cmd-act-btn:disabled {
+            color: var(--border);
+            cursor: not-allowed;
+            background: transparent;
+            border-color: transparent;
+        }
+        .cmd-card .cmd-act-btn.danger:hover {
+            background: rgba(244, 67, 54, 0.12);
+            color: var(--error);
+            border-color: var(--error);
+        }
+        .cmd-card .cmd-head { padding-right: 80px; }
+
+        /* + Add command picker */
+        .add-cmd-row {
+            margin-top: 0.5rem;
+            display: flex;
+            gap: 0.4rem;
+            align-items: center;
+            font-size: 0.75rem;
+        }
+        .add-cmd-row .k { color: var(--text-dim); }
+        .add-cmd-row select.field-edit {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            color: var(--text);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.75rem;
+            padding: 0.15rem 0.4rem;
+            border-radius: 2px;
+            flex: 1;
+            max-width: 280px;
+        }
+        .add-cmd-row select.field-edit:focus { outline: none; border-color: var(--accent); }
+
         /* Block-property editor controls */
         .block-prop-row {
             display: flex;
@@ -620,9 +684,18 @@
             V3ParseError,
             docSet,
             docDelete,
+            docInsertCommand,
+            docMoveCommand,
             nodeIsAliasAt,
             aliasNameAt
         } from './js/protocol-yaml-v3.js';
+
+        import {
+            CONTROLLER_COMMANDS,
+            getV3PluginCommands,
+            listV3PluginNames,
+            getV3CommandParams
+        } from './js/plugin-registry.js';
 
         // ═══════════════════════════════════════════════════════════════
         // State
@@ -985,9 +1058,15 @@
                 ));
                 const section = el('div', { class: 'insp-section' });
                 section.appendChild(el('h4', {}, 'Commands (' + cond.commands.length + ')'));
+                const total = cond.commands.length;
                 cond.commands.forEach((cmd, cmdIdx) => {
-                    section.appendChild(renderCommandCard(cmd, ['conditions', condIdx, 'commands', cmdIdx]));
+                    section.appendChild(renderCommandCard(
+                        cmd,
+                        ['conditions', condIdx, 'commands', cmdIdx],
+                        { condIdx, cmdIdx, total }
+                    ));
                 });
+                section.appendChild(renderAddCommandPicker(condIdx));
                 body.appendChild(section);
                 return;
             }
@@ -1284,7 +1363,150 @@
             return row;
         }
 
-        function renderCommandCard(cmd, cmdPath) {
+        // ── Command template factory + add/move/delete handlers ──────────
+        // Build a default command object for a newly-inserted card. Uses the
+        // plugin-registry to populate sensible defaults so the user starts
+        // from a working command rather than blank text inputs.
+
+        function buildCommandTemplate(kind, pluginName, commandName) {
+            if (kind === 'wait') {
+                return { type: 'wait', duration: 1 };
+            }
+            // Default value when a required param has no `default:` in the
+            // schema. Lets the new card render with an editable field instead
+            // of dropping the param entirely.
+            const fallbackForType = (t) => (t === 'number' ? 0 : t === 'boolean' ? false : '');
+            const valueFor = (schema) =>
+                schema.default !== undefined && schema.default !== ''
+                    ? schema.default
+                    : fallbackForType(schema.type);
+
+            if (kind === 'controller') {
+                const def = CONTROLLER_COMMANDS[commandName];
+                const cmd = { type: 'controller', command_name: commandName };
+                if (def && def.params) {
+                    for (const [k, schema] of Object.entries(def.params)) {
+                        if (schema.required || (schema.default !== undefined && schema.default !== '')) {
+                            cmd[k] = valueFor(schema);
+                        }
+                    }
+                }
+                return cmd;
+            }
+            if (kind === 'plugin') {
+                const cmd = {
+                    type: 'plugin',
+                    plugin_name: pluginName,
+                    command_name: commandName
+                };
+                const paramsSchema = getV3CommandParams(experiment, 'plugin', pluginName, commandName);
+                if (paramsSchema) {
+                    const params = {};
+                    let hasAny = false;
+                    for (const [k, schema] of Object.entries(paramsSchema)) {
+                        if (schema.required || (schema.default !== undefined && schema.default !== '')) {
+                            params[k] = valueFor(schema);
+                            hasAny = true;
+                        }
+                    }
+                    if (hasAny) cmd.params = params;
+                }
+                return cmd;
+            }
+            throw new Error('Unknown command kind: ' + kind);
+        }
+
+        function commitInspectorEdit() {
+            setDirty(true);
+            renderInspector();
+            renderTimeline();
+        }
+
+        function onMoveCommand(condIdx, fromIdx, toIdx) {
+            try {
+                docMoveCommand(experiment, condIdx, fromIdx, toIdx);
+                commitInspectorEdit();
+            } catch (err) {
+                showError('Move failed', err.message);
+            }
+        }
+
+        function onDeleteCommand(condIdx, atIdx) {
+            try {
+                docDelete(experiment, ['conditions', condIdx, 'commands', atIdx]);
+                commitInspectorEdit();
+            } catch (err) {
+                showError('Delete failed', err.message);
+            }
+        }
+
+        function onAddCommand(condIdx, addSelectValue) {
+            // addSelectValue encoding: "wait" | "controller:<name>" | "plugin:<plugin>:<command>"
+            try {
+                let cmd;
+                if (addSelectValue === 'wait') {
+                    cmd = buildCommandTemplate('wait');
+                } else if (addSelectValue.startsWith('controller:')) {
+                    cmd = buildCommandTemplate('controller', null, addSelectValue.slice('controller:'.length));
+                } else if (addSelectValue.startsWith('plugin:')) {
+                    const parts = addSelectValue.split(':');
+                    cmd = buildCommandTemplate('plugin', parts[1], parts[2]);
+                } else {
+                    return;
+                }
+                const cond = experiment.conditions[condIdx];
+                docInsertCommand(experiment, condIdx, cond.commands.length, cmd);
+                commitInspectorEdit();
+            } catch (err) {
+                showError('Add failed', err.message);
+            }
+        }
+
+        function renderAddCommandPicker(condIdx) {
+            const row = el('div', { class: 'add-cmd-row' },
+                el('span', { class: 'k' }, '+ add:')
+            );
+            const select = el('select', {
+                class: 'field-edit',
+                title: 'Append a new command to this condition'
+            });
+            select.appendChild(el('option', { value: '' }, 'choose…'));
+
+            // Wait
+            const waitGroup = el('optgroup', { label: 'Timing' });
+            waitGroup.appendChild(el('option', { value: 'wait' }, 'wait'));
+            select.appendChild(waitGroup);
+
+            // Controller commands
+            const ctrlGroup = el('optgroup', { label: 'Controller' });
+            for (const [name, def] of Object.entries(CONTROLLER_COMMANDS)) {
+                ctrlGroup.appendChild(el('option', { value: 'controller:' + name }, name));
+            }
+            select.appendChild(ctrlGroup);
+
+            // Plugin commands — group per declared plugin + log
+            for (const pluginName of listV3PluginNames(experiment)) {
+                const cmds = getV3PluginCommands(experiment, pluginName);
+                const keys = Object.keys(cmds);
+                if (keys.length === 0) continue;
+                const grp = el('optgroup', { label: 'Plugin: ' + pluginName });
+                for (const cName of keys) {
+                    grp.appendChild(el('option', { value: 'plugin:' + pluginName + ':' + cName }, cName));
+                }
+                select.appendChild(grp);
+            }
+
+            select.addEventListener('change', () => {
+                const v = select.value;
+                if (!v) return;
+                onAddCommand(condIdx, v);
+            });
+            row.appendChild(select);
+            return row;
+        }
+
+        function renderCommandCard(cmd, cmdPath, cardMeta) {
+            // cardMeta: { condIdx, cmdIdx, total } — required for action buttons
             const card = el('div', { class: 'cmd-card ' + cmd.type });
             const head = el('div', { class: 'cmd-head' },
                 el('span', { class: 'ctype' }, cmd.type),
@@ -1293,6 +1515,35 @@
                 cmd.command_name || ''
             );
             card.appendChild(head);
+
+            // Per-card action buttons (↑ ↓ ✕)
+            const actions = el('div', { class: 'cmd-actions' });
+            const upBtn = el('button', {
+                class: 'cmd-act-btn',
+                title: 'Move command up',
+                disabled: cardMeta.cmdIdx === 0,
+                onClick: (e) => { e.stopPropagation(); onMoveCommand(cardMeta.condIdx, cardMeta.cmdIdx, cardMeta.cmdIdx - 1); }
+            }, '↑');
+            const downBtn = el('button', {
+                class: 'cmd-act-btn',
+                title: 'Move command down',
+                disabled: cardMeta.cmdIdx === cardMeta.total - 1,
+                onClick: (e) => { e.stopPropagation(); onMoveCommand(cardMeta.condIdx, cardMeta.cmdIdx, cardMeta.cmdIdx + 1); }
+            }, '↓');
+            const delBtn = el('button', {
+                class: 'cmd-act-btn danger',
+                title: 'Delete command',
+                onClick: (e) => {
+                    e.stopPropagation();
+                    if (confirm('Delete this ' + cmd.type + ' command? (Undo not yet available.)')) {
+                        onDeleteCommand(cardMeta.condIdx, cardMeta.cmdIdx);
+                    }
+                }
+            }, '✕');
+            actions.appendChild(upBtn);
+            actions.appendChild(downBtn);
+            actions.appendChild(delBtn);
+            card.appendChild(actions);
 
             const detailKeys = {
                 controller: ['command_name', 'pattern', 'pattern_ID', 'duration', 'mode', 'frame_index', 'frame_rate', 'gain'],

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>v3 Experiment Designer (Viewer)</title>
+    <title>v3 Experiment Designer</title>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
 
     <!-- Import map: lets js/protocol-yaml-v3.js's `import YAML from 'yaml'`
@@ -335,9 +335,50 @@
         .cmd-card.plugin { border-left: 3px solid var(--beta); }
         .cmd-card .cmd-head { font-weight: 600; margin-bottom: 0.2rem; }
         .cmd-card .cmd-head .ctype { color: var(--text-dim); font-weight: 400; font-size: 0.65rem; text-transform: uppercase; margin-right: 0.3rem; }
-        .cmd-card .kv-line { font-size: 0.7rem; color: var(--text-dim); }
-        .cmd-card .kv-line .k { display: inline-block; min-width: 80px; }
+        .cmd-card .kv-line { font-size: 0.7rem; color: var(--text-dim); display: flex; align-items: center; gap: 0.3rem; }
+        .cmd-card .kv-line .k { display: inline-block; min-width: 80px; flex-shrink: 0; }
         .cmd-card .kv-line .v { color: var(--text); }
+        .cmd-card .kv-line input.field-edit {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            color: var(--text);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.7rem;
+            padding: 0.1rem 0.35rem;
+            border-radius: 2px;
+            min-width: 60px;
+            max-width: 220px;
+        }
+        .cmd-card .kv-line input.field-edit:focus { outline: none; border-color: var(--accent); }
+        .cmd-card .kv-line input.field-edit.num { width: 70px; text-align: right; color: var(--accent); }
+        .cmd-card .kv-line input.field-edit.str { color: var(--accent); }
+        .cmd-card .kv-line .alias-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.2rem;
+            padding: 0.05rem 0.4rem;
+            background: rgba(41, 182, 246, 0.12);
+            border: 1px solid var(--beta);
+            color: var(--beta);
+            border-radius: 8px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.65rem;
+            cursor: help;
+        }
+        .cmd-card .kv-line .alias-chip .resolved-val {
+            color: var(--text-dim);
+            font-size: 0.6rem;
+        }
+        .dirty-badge {
+            display: inline-block;
+            background: rgba(255, 152, 0, 0.15);
+            color: var(--warn);
+            border: 1px solid var(--warn);
+            padding: 0.05rem 0.4rem;
+            font-size: 0.65rem;
+            border-radius: 8px;
+            margin-left: 0.4rem;
+        }
         .jump-btn {
             background: rgba(0, 230, 118, 0.1);
             border: 1px solid var(--accent);
@@ -444,19 +485,22 @@
     <!-- Header -->
     <div class="app-header">
         <h1>v3 Experiment Designer</h1>
-        <span class="beta-badge">Beta / Viewer</span>
+        <span class="beta-badge">Beta / Editor</span>
         <div class="header-spacer"></div>
+        <span id="dirtyIndicator" class="dirty-badge" style="display: none;" title="Unsaved edits — Export to save">● edited</span>
         <button id="settingsToggle" class="header-btn" title="Show/hide experiment metadata, rig, plugins, variables">Settings ▾</button>
         <input type="file" id="fileInput" accept=".yaml,.yml" style="display: none;">
         <button id="importBtn" class="header-btn primary" title="Load a v3 protocol YAML file">Import YAML</button>
-        <button id="exportBtn" class="header-btn" disabled title="Re-export the loaded YAML (round-trip)">Export YAML</button>
+        <button id="exportBtn" class="header-btn" disabled title="Export the (possibly edited) YAML">Export YAML</button>
         <a href="index.html" class="header-btn" style="text-decoration: none; display: inline-flex; align-items: center;">← All tools</a>
     </div>
 
-    <!-- View-only banner -->
+    <!-- Editing banner -->
     <div class="view-only-banner">
-        <strong>View only.</strong> v0.1 viewer round-trips v3 YAML preserving anchors and comments — editing arrives in v0.2.
-        Open in the <a href="experiment_designer.html">v2 Experiment Designer</a> to edit a v2 protocol.
+        <strong>Editing (early).</strong> Scalar fields in command cards are editable; anchor-bound fields (
+        <span style="color: var(--beta);">→ &amp;name</span>) are read-only until the Variables editor lands.
+        Drag/drop, undo, and sequence editing arrive in later updates.
+        Need v2? <a href="experiment_designer.html">Open the v2 Experiment Designer</a>.
     </div>
 
     <!-- Settings drawer -->
@@ -520,7 +564,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.1 | <span id="footerTimestamp">2026-05-24 ET</span>
+        v3 Experiment Designer v0.2 | <span id="footerTimestamp">2026-05-27 08:56 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -535,8 +579,15 @@
     </div>
 
     <script type="module">
-        import { parseV3Protocol, generateV3Protocol, validateReferences, V3ParseError }
-            from './js/protocol-yaml-v3.js';
+        import {
+            parseV3Protocol,
+            generateV3Protocol,
+            validateReferences,
+            V3ParseError,
+            docSet,
+            nodeIsAliasAt,
+            aliasNameAt
+        } from './js/protocol-yaml-v3.js';
 
         // ═══════════════════════════════════════════════════════════════
         // State
@@ -546,6 +597,12 @@
         let lastFilename = null;       // for export naming
         let selection = null;          // { kind: 'condition', name } | { kind: 'block', index } | { kind: 'ref', index }
         let librarySearchText = '';
+        let dirty = false;             // true once the user has edited anything
+
+        function setDirty(val) {
+            dirty = !!val;
+            $('dirtyIndicator').style.display = dirty ? 'inline-block' : 'none';
+        }
 
         // ═══════════════════════════════════════════════════════════════
         // DOM helpers
@@ -596,6 +653,7 @@
                 experiment = parsed;
                 lastFilename = file.name;
                 selection = null;
+                setDirty(false);
                 renderAll();
                 $('exportBtn').disabled = false;
             } catch (err) {
@@ -880,20 +938,21 @@
             }
 
             if (selection.kind === 'condition') {
-                const cond = experiment.conditions.find(c => c.name === selection.name);
-                if (!cond) {
+                const condIdx = experiment.conditions.findIndex(c => c.name === selection.name);
+                if (condIdx < 0) {
                     body.appendChild(el('div', { class: 'empty-state' }, 'Condition not found.'));
                     return;
                 }
+                const cond = experiment.conditions[condIdx];
                 body.appendChild(el('div', { class: 'inspector-title' },
                     el('span', { class: 'kind' }, 'Condition'),
                     cond.name
                 ));
                 const section = el('div', { class: 'insp-section' });
                 section.appendChild(el('h4', {}, 'Commands (' + cond.commands.length + ')'));
-                for (const cmd of cond.commands) {
-                    section.appendChild(renderCommandCard(cmd));
-                }
+                cond.commands.forEach((cmd, cmdIdx) => {
+                    section.appendChild(renderCommandCard(cmd, ['conditions', condIdx, 'commands', cmdIdx]));
+                });
                 body.appendChild(section);
                 return;
             }
@@ -965,7 +1024,80 @@
             }
         }
 
-        function renderCommandCard(cmd) {
+        // Field type hints — drive input coercion (number vs string).
+        // Plugin params are freeform — type is inferred from the live value.
+        const FIELD_TYPES = {
+            // controller fields
+            'pattern': 'string',
+            'pattern_ID': 'number',
+            'duration': 'number',
+            'mode': 'number',
+            'frame_index': 'number',
+            'frame_rate': 'number',
+            'gain': 'number',
+            'command_name': 'string',
+            'plugin_name': 'string'
+        };
+
+        // Render a single editable scalar field. If the underlying YAML node is
+        // an Alias, show a read-only badge instead of an input. Otherwise, an
+        // input that calls docSet() on commit.
+        function renderEditableField(label, path, value, typeHint, opts) {
+            opts = opts || {};
+            const wrapper = el('div', { class: 'kv-line', style: opts.indent ? 'padding-left: 1rem;' : '' });
+            wrapper.appendChild(el('span', { class: 'k' }, label + ':'));
+
+            const aliasName = aliasNameAt(experiment, path);
+            if (aliasName) {
+                const chip = el('span', {
+                    class: 'alias-chip',
+                    title: 'Bound to anchor &' + aliasName + ' (resolved: ' + JSON.stringify(value) + '). Anchor binding editor arrives in a later update.'
+                },
+                    '→ &' + aliasName,
+                    el('span', { class: 'resolved-val' }, '= ' + (typeof value === 'string' ? JSON.stringify(value) : String(value)))
+                );
+                wrapper.appendChild(chip);
+                return wrapper;
+            }
+
+            const inputType = typeHint === 'number' ? 'number' : 'text';
+            const input = el('input', {
+                type: inputType,
+                class: 'field-edit ' + (typeHint === 'number' ? 'num' : 'str'),
+                value: typeof value === 'string' ? value : String(value),
+                title: 'Edit ' + label
+            });
+            if (typeHint === 'number') input.step = 'any';
+
+            input.addEventListener('change', () => {
+                let raw = input.value;
+                let coerced = raw;
+                if (typeHint === 'number') {
+                    const n = Number(raw);
+                    if (!Number.isFinite(n)) {
+                        // Reject — revert
+                        input.value = String(value);
+                        return;
+                    }
+                    coerced = n;
+                }
+                if (coerced === value) return;
+                try {
+                    docSet(experiment, path, coerced);
+                    setDirty(true);
+                    // Re-render the inspector card area only — preserve focus elsewhere.
+                    renderInspector();
+                    renderTimeline();
+                } catch (err) {
+                    showError('Edit failed', err.message);
+                    input.value = String(value);
+                }
+            });
+            wrapper.appendChild(input);
+            return wrapper;
+        }
+
+        function renderCommandCard(cmd, cmdPath) {
             const card = el('div', { class: 'cmd-card ' + cmd.type });
             const head = el('div', { class: 'cmd-head' },
                 el('span', { class: 'ctype' }, cmd.type),
@@ -974,29 +1106,29 @@
                 cmd.command_name || ''
             );
             card.appendChild(head);
+
             const detailKeys = {
-                controller: ['pattern', 'pattern_ID', 'duration', 'mode', 'frame_index', 'frame_rate', 'gain'],
+                controller: ['command_name', 'pattern', 'pattern_ID', 'duration', 'mode', 'frame_index', 'frame_rate', 'gain'],
                 wait: ['duration'],
                 plugin: []
             }[cmd.type] || [];
+
             for (const k of detailKeys) {
-                if (cmd[k] !== undefined) {
-                    card.appendChild(el('div', { class: 'kv-line' },
-                        el('span', { class: 'k' }, k + ':'),
-                        el('span', { class: 'v' }, ' ' + (typeof cmd[k] === 'string' ? cmd[k] : String(cmd[k])))));
-                }
+                if (cmd[k] === undefined) continue;
+                card.appendChild(renderEditableField(k, [...cmdPath, k], cmd[k], FIELD_TYPES[k] || 'string'));
             }
+
             if (cmd.type === 'plugin' && cmd.params && Object.keys(cmd.params).length > 0) {
                 card.appendChild(el('div', { class: 'kv-line' }, el('span', { class: 'k' }, 'params:')));
                 for (const [pk, pv] of Object.entries(cmd.params)) {
-                    card.appendChild(el('div', { class: 'kv-line', style: 'padding-left: 1rem;' },
-                        el('span', { class: 'k' }, pk + ':'),
-                        el('span', { class: 'v' }, ' ' + (typeof pv === 'string' ? JSON.stringify(pv) : String(pv)))));
+                    const ptype = typeof pv === 'number' ? 'number' : 'string';
+                    card.appendChild(renderEditableField(pk, [...cmdPath, 'params', pk], pv, ptype, { indent: true }));
                 }
             }
+
             if (cmd._unknownKeys && Object.keys(cmd._unknownKeys).length > 0) {
                 card.appendChild(el('div', { class: 'kv-line', style: 'color: var(--warn); margin-top: 0.2rem;' },
-                    '⚠ unknown keys: ' + Object.keys(cmd._unknownKeys).join(', ')));
+                    '⚠ unknown keys (preserved on export): ' + Object.keys(cmd._unknownKeys).join(', ')));
             }
             return card;
         }

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -585,6 +585,8 @@
         <h1>v3 Experiment Designer</h1>
         <span class="beta-badge">Beta / Editor</span>
         <div class="header-spacer"></div>
+        <button id="undoBtn" class="header-btn" disabled title="Undo last edit (Ctrl+Z)">↶ Undo</button>
+        <button id="redoBtn" class="header-btn" disabled title="Redo (Ctrl+Y)">↷ Redo</button>
         <span id="dirtyIndicator" class="dirty-badge" style="display: none;" title="Unsaved edits — Export to save">● edited</span>
         <button id="settingsToggle" class="header-btn" title="Show/hide experiment metadata, rig, plugins, variables">Settings ▾</button>
         <input type="file" id="fileInput" accept=".yaml,.yml" style="display: none;">
@@ -707,10 +709,97 @@
         let librarySearchText = '';
         let dirty = false;             // true once the user has edited anything
 
+        // Undo/redo: each snapshot is the YAML text + selection. Restoring
+        // re-parses, so the doc/JS-model stay in sync. _restoring blocks
+        // focus-on-rerender from polluting the stacks.
+        let undoStack = [];
+        let redoStack = [];
+        let _restoring = false;
+        const UNDO_LIMIT = 50;
+
         function setDirty(val) {
             dirty = !!val;
             $('dirtyIndicator').style.display = dirty ? 'inline-block' : 'none';
         }
+
+        function updateUndoUI() {
+            document.getElementById('undoBtn').disabled = undoStack.length === 0;
+            document.getElementById('redoBtn').disabled = redoStack.length === 0;
+        }
+
+        function snapshotState() {
+            if (!experiment || !experiment._doc) return null;
+            return {
+                text: experiment._doc.toString(),
+                selection: selection ? JSON.parse(JSON.stringify(selection)) : null
+            };
+        }
+
+        // Push current state onto undoStack. Called BEFORE a mutation so
+        // undo restores the pre-mutation state. Clears redoStack — once a
+        // new branch is taken, the old "redo future" is gone.
+        function pushUndo() {
+            if (_restoring) return;
+            const snap = snapshotState();
+            if (!snap) return;
+            undoStack.push(snap);
+            if (undoStack.length > UNDO_LIMIT) undoStack.shift();
+            redoStack = [];
+            updateUndoUI();
+        }
+
+        function restoreSnapshot(snap) {
+            _restoring = true;
+            try {
+                experiment = parseV3Protocol(snap.text);
+                selection = snap.selection;
+                renderAll();
+            } catch (err) {
+                showError('Undo/redo restore failed', err.message);
+            } finally {
+                _restoring = false;
+            }
+        }
+
+        function undo() {
+            if (undoStack.length === 0) return;
+            const current = snapshotState();
+            const prev = undoStack.pop();
+            if (current) redoStack.push(current);
+            restoreSnapshot(prev);
+            updateUndoUI();
+        }
+
+        function redo() {
+            if (redoStack.length === 0) return;
+            const current = snapshotState();
+            const next = redoStack.pop();
+            if (current) undoStack.push(current);
+            restoreSnapshot(next);
+            updateUndoUI();
+        }
+
+        function clearUndo() {
+            undoStack = [];
+            redoStack = [];
+            updateUndoUI();
+        }
+
+        document.getElementById('undoBtn').addEventListener('click', undo);
+        document.getElementById('redoBtn').addEventListener('click', redo);
+
+        // Keyboard: Ctrl/Cmd+Z = undo, Ctrl/Cmd+Y or Ctrl/Cmd+Shift+Z = redo.
+        // Skip when focus is inside an editable text field — let the
+        // browser handle intra-field undo first.
+        document.addEventListener('keydown', (e) => {
+            const tag = document.activeElement?.tagName;
+            const inField = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+            if (inField) return;
+            const mod = e.ctrlKey || e.metaKey;
+            if (!mod) return;
+            if (e.key === 'z' && !e.shiftKey) { e.preventDefault(); undo(); }
+            else if (e.key === 'y' || (e.key === 'z' && e.shiftKey)) { e.preventDefault(); redo(); }
+        });
 
         // ═══════════════════════════════════════════════════════════════
         // DOM helpers
@@ -762,6 +851,7 @@
                 lastFilename = file.name;
                 selection = null;
                 setDirty(false);
+                clearUndo();
                 renderAll();
                 $('exportBtn').disabled = false;
             } catch (err) {
@@ -1174,23 +1264,25 @@
             });
             if (typeHint === 'number') input.step = 'any';
 
+            // Snapshot on commit-with-actual-change. Captures the pre-edit
+            // state so a single Ctrl+Z reverts the whole field visit. Browser
+            // native Ctrl+Z still works for intra-field keystroke undo.
             input.addEventListener('change', () => {
                 let raw = input.value;
                 let coerced = raw;
                 if (typeHint === 'number') {
                     const n = Number(raw);
                     if (!Number.isFinite(n)) {
-                        // Reject — revert
                         input.value = String(value);
                         return;
                     }
                     coerced = n;
                 }
                 if (coerced === value) return;
+                pushUndo();
                 try {
                     docSet(experiment, path, coerced);
                     setDirty(true);
-                    // Re-render the inspector card area only — preserve focus elsewhere.
                     renderInspector();
                     renderTimeline();
                 } catch (err) {
@@ -1227,13 +1319,15 @@
             });
             input.addEventListener('change', () => {
                 const v = input.value.trim();
+                const isClear = v === '' && entry.name;
+                const isChange = v !== '' && v !== entry.name;
+                if (!isClear && !isChange) return;
+                pushUndo();
                 try {
-                    if (v === '') {
-                        if (entry.name) docDelete(experiment, ['experiment', blockIdx, 'name']);
-                    } else if (v !== entry.name) {
-                        docSet(experiment, ['experiment', blockIdx, 'name'], v);
+                    if (isClear) {
+                        docDelete(experiment, ['experiment', blockIdx, 'name']);
                     } else {
-                        return;
+                        docSet(experiment, ['experiment', blockIdx, 'name'], v);
                     }
                     commitBlockEdit();
                 } catch (err) {
@@ -1275,6 +1369,7 @@
                     return;
                 }
                 if (n === entry.repetitions) return;
+                pushUndo();
                 try {
                     docSet(experiment, ['experiment', blockIdx, 'repetitions'], n);
                     commitBlockEdit();
@@ -1305,6 +1400,7 @@
                 title: 'When checked, trial order is shuffled per repetition (MATLAB randperm).'
             });
             input.addEventListener('change', () => {
+                pushUndo();
                 try {
                     docSet(experiment, ['experiment', blockIdx, 'randomize'], input.checked);
                     commitBlockEdit();
@@ -1335,13 +1431,13 @@
             }
             select.addEventListener('change', () => {
                 const v = select.value;
+                if ((v === '' && !entry.intertrial) || v === entry.intertrial) return;
+                pushUndo();
                 try {
                     if (v === '') {
-                        if (entry.intertrial) docDelete(experiment, ['experiment', blockIdx, 'intertrial']);
-                    } else if (v !== entry.intertrial) {
-                        docSet(experiment, ['experiment', blockIdx, 'intertrial'], v);
+                        docDelete(experiment, ['experiment', blockIdx, 'intertrial']);
                     } else {
-                        return;
+                        docSet(experiment, ['experiment', blockIdx, 'intertrial'], v);
                     }
                     commitBlockEdit();
                 } catch (err) {
@@ -1423,6 +1519,7 @@
         }
 
         function onMoveCommand(condIdx, fromIdx, toIdx) {
+            pushUndo();
             try {
                 docMoveCommand(experiment, condIdx, fromIdx, toIdx);
                 commitInspectorEdit();
@@ -1432,6 +1529,7 @@
         }
 
         function onDeleteCommand(condIdx, atIdx) {
+            pushUndo();
             try {
                 docDelete(experiment, ['conditions', condIdx, 'commands', atIdx]);
                 commitInspectorEdit();
@@ -1442,6 +1540,7 @@
 
         function onAddCommand(condIdx, addSelectValue) {
             // addSelectValue encoding: "wait" | "controller:<name>" | "plugin:<plugin>:<command>"
+            pushUndo();
             try {
                 let cmd;
                 if (addSelectValue === 'wait') {
@@ -1532,12 +1631,10 @@
             }, '↓');
             const delBtn = el('button', {
                 class: 'cmd-act-btn danger',
-                title: 'Delete command',
+                title: 'Delete command (Ctrl+Z to undo)',
                 onClick: (e) => {
                     e.stopPropagation();
-                    if (confirm('Delete this ' + cmd.type + ' command? (Undo not yet available.)')) {
-                        onDeleteCommand(cardMeta.condIdx, cardMeta.cmdIdx);
-                    }
+                    onDeleteCommand(cardMeta.condIdx, cardMeta.cmdIdx);
                 }
             }, '✕');
             actions.appendChild(upBtn);

--- a/index.html
+++ b/index.html
@@ -250,8 +250,8 @@
 
             <a href="experiment_designer_v3.html" class="tool-card">
                 <h2>v3 Experiment Designer</h2>
-                <p>New designer for Protocol v3 YAML (library of conditions + ordered sequence of blocks). Read-only viewer in v0.1; editor follows in v0.2.</p>
-                <span class="status beta">Beta / Viewer</span>
+                <p>New designer for Protocol v3 YAML (library of conditions + ordered sequence of blocks). v0.2 adds scalar field editing, command add / delete / reorder, block property edits, and undo / redo. Anchors and comments are preserved on every round-trip.</p>
+                <span class="status beta">Beta / Editor (early)</span>
             </a>
         </div>
 

--- a/js/plugin-registry.js
+++ b/js/plugin-registry.js
@@ -250,6 +250,70 @@ var BUILTIN_PLUGINS = {
         }
     },
 
+    thermometer: {
+        name: 'thermometer',
+        label: 'DAQ Thermometer',
+        type: 'class',
+        matlab: { class: 'DAQThermometerPlugin' },
+        color: '#ffa94d', // orange for UI
+        // Config per Lisa's yaml_protocol_documentation_v3.md (2026-05-26).
+        configFields: {
+            device_id: {
+                type: 'string',
+                label: 'NI DAQ device',
+                default: '',
+                placeholder: 'e.g. cDAQ1Mod4'
+            },
+            channels: {
+                type: 'string',
+                label: 'Channels (comma-separated)',
+                default: '',
+                placeholder: 'ai0, ai2'
+            },
+            thermocouple_type: {
+                type: 'string',
+                label: 'Thermocouple type',
+                default: 'K',
+                placeholder: 'K'
+            },
+            sample_rate: {
+                type: 'number',
+                label: 'Sample rate (Hz)',
+                default: 7,
+                placeholder: '7'
+            },
+            sample_duration: {
+                type: 'number',
+                label: 'Sample duration (s)',
+                default: 1.0,
+                placeholder: '1.0'
+            },
+            generate_plots: {
+                type: 'boolean',
+                label: 'Generate PNG on log',
+                default: true
+            }
+        },
+        commands: {
+            startContinuousLogging: {
+                label: 'Start Continuous Logging',
+                description: 'Begin background acquisition; logs to CSV at sample_rate Hz until stopped (recommended for long experiments).'
+            },
+            stopContinuousLogging: {
+                label: 'Stop Continuous Logging',
+                description: 'Stop background acquisition and close the CSV file.'
+            },
+            get_temperature: {
+                label: 'Get Temperature',
+                description: 'Read a single sample (blocks for sample_duration seconds).'
+            },
+            log_temperature: {
+                label: 'Log Temperature',
+                description: 'Read and log one sample (with optional PNG plot per generate_plots).'
+            }
+        }
+    },
+
     camera: {
         name: 'camera',
         label: 'BIAS Camera',
@@ -357,6 +421,46 @@ var BUILTIN_PLUGINS = {
             disconnect: {
                 label: 'Disconnect',
                 description: 'Disconnect from BIAS camera'
+            }
+        }
+    }
+};
+
+// ════════════════════════════════════════════════════
+// Built-in "log" plugin (v3) — always available, never declared.
+// ════════════════════════════════════════════════════
+// Per Lisa's yaml_protocol_documentation_v3.md (Special Plugin Command - Logging):
+// `plugin_name: "log"`, `command_name: "log"`. Not listed in `plugins:`.
+
+var LOG_PLUGIN = {
+    name: 'log',
+    label: 'Log (built-in)',
+    builtIn: true,
+    color: '#8b949e',
+    commands: {
+        log: {
+            label: 'Log message',
+            description: 'Append a line to the experiment log.',
+            params: {
+                message: {
+                    type: 'string',
+                    required: true,
+                    default: '',
+                    label: 'Message',
+                    placeholder: 'free text, up to 2000 chars'
+                },
+                level: {
+                    type: 'select',
+                    required: false,
+                    default: 'INFO',
+                    label: 'Level',
+                    options: [
+                        { value: 'DEBUG', label: 'DEBUG' },
+                        { value: 'INFO', label: 'INFO' },
+                        { value: 'WARNING', label: 'WARNING' },
+                        { value: 'ERROR', label: 'ERROR' }
+                    ]
+                }
             }
         }
     }
@@ -482,16 +586,107 @@ function createPluginEntry(pluginName) {
 }
 
 // ════════════════════════════════════════════════════
+// v3 Lookup — by matlab class, not by plugin name
+// ════════════════════════════════════════════════════
+// v2 keyed off plugin **name** (assuming canonical "camera", "backlight"
+// names). v3 lets users pick any name for a plugin entry, so lookups go via
+// matlab.class instead. The built-in `log` plugin is always available even
+// when not declared in the experiment's `plugins:` section.
+
+/**
+ * Find a built-in plugin definition whose matlab.class matches `className`.
+ * Returns the entry or null.
+ */
+function findPluginDefByClass(className) {
+    if (!className) return null;
+    var keys = Object.keys(BUILTIN_PLUGINS);
+    for (var i = 0; i < keys.length; i++) {
+        var def = BUILTIN_PLUGINS[keys[i]];
+        if (def.matlab && def.matlab.class === className) return def;
+    }
+    return null;
+}
+
+/**
+ * Return the command schema map for a given MATLAB plugin class.
+ * Returns {} when no registry entry matches.
+ */
+function getCommandsForClass(className) {
+    var def = findPluginDefByClass(className);
+    return def ? def.commands || {} : {};
+}
+
+/**
+ * Resolve commands available on the plugin named `pluginName` in `experiment`.
+ *
+ *   - "log" returns the built-in LOG_PLUGIN commands (always available).
+ *   - Otherwise: find the plugin entry by name in experiment.plugins, read
+ *     matlab.class, and look up the registry by class.
+ *   - Returns {} when the plugin isn't declared or the class isn't recognized.
+ */
+function getV3PluginCommands(experiment, pluginName) {
+    if (pluginName === 'log') return LOG_PLUGIN.commands;
+    if (!experiment || !Array.isArray(experiment.plugins)) return {};
+    for (var i = 0; i < experiment.plugins.length; i++) {
+        var p = experiment.plugins[i];
+        if (p.name === pluginName) {
+            var cls = p.matlab && p.matlab.class;
+            return getCommandsForClass(cls);
+        }
+    }
+    return {};
+}
+
+/**
+ * Ordered list of plugin names available to a v3 experiment for use as
+ * `plugin_name:` on a command. Includes user-declared plugins (in declared
+ * order) plus the always-available "log" plugin at the end.
+ */
+function listV3PluginNames(experiment) {
+    var names = [];
+    if (experiment && Array.isArray(experiment.plugins)) {
+        for (var i = 0; i < experiment.plugins.length; i++) {
+            names.push(experiment.plugins[i].name);
+        }
+    }
+    names.push('log');
+    return names;
+}
+
+/**
+ * v3 equivalent of getCommandParams — takes an `experiment` context so plugin
+ * lookups route through matlab.class instead of guessing by plugin name.
+ */
+function getV3CommandParams(experiment, type, pluginName, commandName) {
+    if (type === 'controller') {
+        var cmd = CONTROLLER_COMMANDS[commandName];
+        return cmd ? cmd.params || null : null;
+    }
+    if (type === 'plugin') {
+        var cmds = getV3PluginCommands(experiment, pluginName);
+        var pluginCmd = cmds[commandName];
+        return pluginCmd ? pluginCmd.params || null : null;
+    }
+    return null;
+}
+
+// ════════════════════════════════════════════════════
 // Exports
 // ════════════════════════════════════════════════════
 
 var PluginRegistry = {
     BUILTIN_PLUGINS: BUILTIN_PLUGINS,
     CONTROLLER_COMMANDS: CONTROLLER_COMMANDS,
+    LOG_PLUGIN: LOG_PLUGIN,
     getPluginCommands: getPluginCommands,
     getCommandParams: getCommandParams,
     getAllCommandOptions: getAllCommandOptions,
-    createPluginEntry: createPluginEntry
+    createPluginEntry: createPluginEntry,
+    findPluginDefByClass: findPluginDefByClass,
+    getCommandsForClass: getCommandsForClass,
+    getV3PluginCommands: getV3PluginCommands,
+    listV3PluginNames: listV3PluginNames,
+    getV3CommandParams: getV3CommandParams
 };
 
 // Browser global
@@ -508,9 +703,15 @@ if (typeof module !== 'undefined' && module.exports) {
 export {
     BUILTIN_PLUGINS,
     CONTROLLER_COMMANDS,
+    LOG_PLUGIN,
     getPluginCommands,
     getCommandParams,
     getAllCommandOptions,
-    createPluginEntry
+    createPluginEntry,
+    findPluginDefByClass,
+    getCommandsForClass,
+    getV3PluginCommands,
+    listV3PluginNames,
+    getV3CommandParams
 };
 export default PluginRegistry;

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -426,6 +426,86 @@ function generateV3Protocol(experiment) {
 }
 
 // ════════════════════════════════════════════════════
+// Editing — write a value back to both the YAML.Document and the JS model
+// ════════════════════════════════════════════════════
+
+/**
+ * docSet(experiment, path, value)
+ *
+ * Mutates the YAML.Document attached as `experiment._doc` at `path`, and
+ * mirrors the change in the JS data model so the UI stays in sync.
+ *
+ * `path` is an array of YAML-side keys/indices. Top-level keys in the
+ * YAML differ from our JS model in two places:
+ *   - 'experiment' (YAML) → 'sequence' (JS)
+ *   - 'rig'        (YAML) → 'rig_path' (JS)
+ * Use the YAML-side names in `path` — the JS-model mirror is translated below.
+ *
+ * Setting a primitive value through a scalar node that previously held a
+ * `*alias` reference replaces the alias with the literal. Comments attached
+ * to the node and its surroundings are preserved by yaml@2.
+ */
+function docSet(experiment, path, value) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docSet: experiment has no _doc handle', 'NO_DOC');
+    }
+    if (!Array.isArray(path) || path.length === 0) {
+        throw new V3ParseError('docSet: path must be a non-empty array', 'BAD_PATH');
+    }
+    experiment._doc.setIn(path, value);
+    mirrorIntoModel(experiment, path, value);
+}
+
+/**
+ * Returns true if the YAML node at `path` is an Alias reference (i.e., the
+ * scalar in the source YAML is `*name`, not a literal). Used by the editor
+ * to render anchor-bound fields as read-only badges instead of input boxes.
+ */
+function nodeIsAliasAt(experiment, path) {
+    if (!experiment || !experiment._doc) return false;
+    const node = experiment._doc.getIn(path, true);
+    if (!node) return false;
+    return YAML.isAlias ? YAML.isAlias(node) : node.type === 'ALIAS' || node.constructor?.name === 'Alias';
+}
+
+/**
+ * If the YAML node at `path` is an Alias, return its anchor name; else null.
+ * Lets the UI render `→ &dur_long` chips next to anchor-bound fields.
+ */
+function aliasNameAt(experiment, path) {
+    if (!experiment || !experiment._doc) return null;
+    const node = experiment._doc.getIn(path, true);
+    if (!node) return null;
+    if (YAML.isAlias && YAML.isAlias(node)) {
+        return node.source || null;
+    }
+    if (node.type === 'ALIAS' || node.constructor?.name === 'Alias') {
+        return node.source || null;
+    }
+    return null;
+}
+
+/**
+ * Translate a YAML-side path into the JS-side equivalent and write `value`
+ * along the chain. Returns silently if the path doesn't exist in the JS
+ * model (e.g., a passthrough-only key at an unsupported nesting level).
+ */
+function mirrorIntoModel(experiment, path, value) {
+    const jsPath = [...path];
+    if (jsPath[0] === 'experiment') jsPath[0] = 'sequence';
+    else if (jsPath[0] === 'rig') jsPath[0] = 'rig_path';
+
+    let cursor = experiment;
+    for (let i = 0; i < jsPath.length - 1; i++) {
+        if (cursor == null) return;
+        cursor = cursor[jsPath[i]];
+    }
+    if (cursor != null && jsPath.length > 0) {
+        cursor[jsPath[jsPath.length - 1]] = value;
+    }
+}
+
+// ════════════════════════════════════════════════════
 // Exports
 // ════════════════════════════════════════════════════
 
@@ -433,7 +513,10 @@ const ProtocolV3 = {
     parseV3Protocol,
     generateV3Protocol,
     validateReferences,
-    V3ParseError
+    V3ParseError,
+    docSet,
+    nodeIsAliasAt,
+    aliasNameAt
 };
 
 // Browser global
@@ -447,5 +530,13 @@ if (typeof module !== 'undefined' && module.exports) {
 }
 
 // ES module export
-export { parseV3Protocol, generateV3Protocol, validateReferences, V3ParseError };
+export {
+    parseV3Protocol,
+    generateV3Protocol,
+    validateReferences,
+    V3ParseError,
+    docSet,
+    nodeIsAliasAt,
+    aliasNameAt
+};
 export default ProtocolV3;

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -505,6 +505,51 @@ function mirrorIntoModel(experiment, path, value) {
     }
 }
 
+/**
+ * docDelete(experiment, path)
+ *
+ * Removes the key at `path` from both the YAML.Document and the JS data
+ * model. Used for clearing optional fields (e.g., block `intertrial` →
+ * "none", block `name` cleared). For our JS model, optional string fields
+ * that were `null` when absent get set back to `null` after delete; map
+ * keys that don't normalize to a model field are deleted outright.
+ */
+function docDelete(experiment, path) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docDelete: experiment has no _doc handle', 'NO_DOC');
+    }
+    if (!Array.isArray(path) || path.length === 0) {
+        throw new V3ParseError('docDelete: path must be a non-empty array', 'BAD_PATH');
+    }
+    experiment._doc.deleteIn(path);
+
+    const jsPath = [...path];
+    if (jsPath[0] === 'experiment') jsPath[0] = 'sequence';
+    else if (jsPath[0] === 'rig') jsPath[0] = 'rig_path';
+
+    let cursor = experiment;
+    for (let i = 0; i < jsPath.length - 1; i++) {
+        if (cursor == null) return;
+        cursor = cursor[jsPath[i]];
+    }
+    if (cursor != null && jsPath.length > 0) {
+        const lastKey = jsPath[jsPath.length - 1];
+        // Block-level optional fields parse to `null` when missing; mirror that.
+        const optionalNullableBlockFields = ['name', 'intertrial'];
+        if (
+            jsPath[0] === 'sequence' &&
+            jsPath.length === 3 &&
+            optionalNullableBlockFields.includes(lastKey)
+        ) {
+            cursor[lastKey] = null;
+        } else if (Array.isArray(cursor)) {
+            cursor.splice(lastKey, 1);
+        } else {
+            delete cursor[lastKey];
+        }
+    }
+}
+
 // ════════════════════════════════════════════════════
 // Exports
 // ════════════════════════════════════════════════════
@@ -515,6 +560,7 @@ const ProtocolV3 = {
     validateReferences,
     V3ParseError,
     docSet,
+    docDelete,
     nodeIsAliasAt,
     aliasNameAt
 };
@@ -536,6 +582,7 @@ export {
     validateReferences,
     V3ParseError,
     docSet,
+    docDelete,
     nodeIsAliasAt,
     aliasNameAt
 };

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -506,6 +506,65 @@ function mirrorIntoModel(experiment, path, value) {
 }
 
 /**
+ * docInsertCommand(experiment, condIdx, atIdx, command)
+ *
+ * Insert `command` (a plain JS object: {type, command_name, ...}) into the
+ * commands list at conditions[condIdx].commands[atIdx]. atIdx is clamped to
+ * [0, commands.length]; pass commands.length to append.
+ *
+ * Mirrors the change into the JS data model.
+ */
+function docInsertCommand(experiment, condIdx, atIdx, command) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docInsertCommand: experiment has no _doc handle', 'NO_DOC');
+    }
+    const cond = experiment.conditions[condIdx];
+    if (!cond) {
+        throw new V3ParseError('docInsertCommand: bad condition index ' + condIdx, 'BAD_PATH');
+    }
+    const clampedIdx = Math.max(0, Math.min(atIdx, cond.commands.length));
+
+    const cmdsNode = experiment._doc.getIn(['conditions', condIdx, 'commands'], true);
+    if (!cmdsNode || !Array.isArray(cmdsNode.items)) {
+        throw new V3ParseError(
+            'docInsertCommand: commands sequence node not found at conditions[' + condIdx + ']',
+            'BAD_PATH'
+        );
+    }
+    const newNode = experiment._doc.createNode(command);
+    cmdsNode.items.splice(clampedIdx, 0, newNode);
+
+    cond.commands.splice(clampedIdx, 0, command);
+}
+
+/**
+ * docMoveCommand(experiment, condIdx, fromIdx, toIdx)
+ *
+ * Move a command within conditions[condIdx].commands. Bounds-checked; a
+ * no-op if fromIdx === toIdx. Mirrors both YAML.Document and JS model.
+ */
+function docMoveCommand(experiment, condIdx, fromIdx, toIdx) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docMoveCommand: experiment has no _doc handle', 'NO_DOC');
+    }
+    const cond = experiment.conditions[condIdx];
+    if (!cond) {
+        throw new V3ParseError('docMoveCommand: bad condition index ' + condIdx, 'BAD_PATH');
+    }
+    const n = cond.commands.length;
+    if (fromIdx < 0 || fromIdx >= n || toIdx < 0 || toIdx >= n || fromIdx === toIdx) return;
+
+    const cmdsNode = experiment._doc.getIn(['conditions', condIdx, 'commands'], true);
+    if (!cmdsNode || !Array.isArray(cmdsNode.items)) return;
+
+    const movedNode = cmdsNode.items.splice(fromIdx, 1)[0];
+    cmdsNode.items.splice(toIdx, 0, movedNode);
+
+    const movedJs = cond.commands.splice(fromIdx, 1)[0];
+    cond.commands.splice(toIdx, 0, movedJs);
+}
+
+/**
  * docDelete(experiment, path)
  *
  * Removes the key at `path` from both the YAML.Document and the JS data
@@ -561,6 +620,8 @@ const ProtocolV3 = {
     V3ParseError,
     docSet,
     docDelete,
+    docInsertCommand,
+    docMoveCommand,
     nodeIsAliasAt,
     aliasNameAt
 };
@@ -583,6 +644,8 @@ export {
     V3ParseError,
     docSet,
     docDelete,
+    docInsertCommand,
+    docMoveCommand,
     nodeIsAliasAt,
     aliasNameAt
 };

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -316,11 +316,32 @@ function extractSequenceEntry(entry) {
                 'INVALID_SCHEMA'
             );
         }
+        // repetitions: optional, but if present must be a positive integer.
+        // Catches `0`, negatives, decimals (1.5) that would otherwise silently
+        // drop a block or loop a non-integer number of times.
+        let repetitions = 1;
+        if (entry.repetitions !== undefined) {
+            if (
+                typeof entry.repetitions !== 'number' ||
+                !Number.isInteger(entry.repetitions) ||
+                entry.repetitions < 1
+            ) {
+                throw new V3ParseError(
+                    'Block "' +
+                        (entry.name || '?') +
+                        '" has invalid `repetitions`: ' +
+                        JSON.stringify(entry.repetitions) +
+                        ' (must be a positive integer)',
+                    'INVALID_SCHEMA'
+                );
+            }
+            repetitions = entry.repetitions;
+        }
         return {
             kind: 'block',
             name: typeof entry.name === 'string' ? entry.name : null,
             trials: entry.trials.map(String),
-            repetitions: typeof entry.repetitions === 'number' ? entry.repetitions : 1,
+            repetitions: repetitions,
             randomize: entry.randomize === true,
             intertrial: typeof entry.intertrial === 'string' ? entry.intertrial : null,
             _unknownKeys: extractUnknownKeys(entry, KNOWN_BLOCK_KEYS)

--- a/tests/fixtures/matlab_normalized/v3_full_experiment.yaml
+++ b/tests/fixtures/matlab_normalized/v3_full_experiment.yaml
@@ -1,0 +1,545 @@
+version: 3
+
+# ============================================================================
+# EXPERIMENT METADATA
+# ============================================================================
+experiment_info:
+  name: "G4.1 Test Experiment using Bias and backlight"
+  date_created: "2026-03-23"
+  author: "Reiser Lab"
+  pattern_library: './patterns/reference/G41_2x12_cw'  # UPDATE THIS TO FULL PATH
+
+# ============================================================================
+# ARENA CONFIGURATION
+# ============================================================================
+rig: '/Users/reiserm/Documents/GitHub/maDisplayTools/configs/rigs/test_rig_1.yaml'  # UPDATE THIS TO FULL PATH BEFORE USE
+
+# ============================================================================
+# VARIABLES
+# ============================================================================
+variables:
+  IR_power:         &IR_power       50
+  trial_duration:   &trial_dur      10
+  trial_frame_rate: &fr_rate        10
+  led_power:        &led_power      5
+  baseline_wait:    &baseline_wait  10
+  intertrial_wait:  &inter_wait     2
+
+
+# ============================================================================
+# PLUGIN DEFINITIONS
+# ============================================================================
+plugins:
+# Class Plugin - Camera/video capture system
+  - name: "camera"
+    type: "class"
+    matlab:
+      class: "BiasPlugin"
+#    config: # Optional - required config is in rig yaml. This config is for optional settings that may 
+            # change between experiments. Values here that contradict rig yaml will override rig yaml.
+      #saveDir: 'path/to/save/videos' # Optional, default is in experiment yaml's location. 
+      #frame_rate: 150 # Optional, default is 100, a value outside of 10-200 will produce warning
+      #video_format: 'avi' #Optional, default is 'ufmf', only other option is 'avi'
+    # python: WOULD USE THIS IF PYTHON CLASS
+    #   module: "pyDisplayTools.plugins.SimpleBias"
+    #   class: "SimpleBias"
+    # config:   # config established in rig yaml but can add here to override
+
+  - name: "backlight"
+    type: "class"
+    matlab:
+      class: "LEDControllerPlugin"
+
+# ============================================================================
+# EXPERIMENT SEQUENCE
+# ============================================================================
+ 
+experiment: 
+  - "arena test"
+  - "IR on"
+  - "start recording"
+  - "baseline"
+
+  - name: "main block"
+    trials:
+      - "sq_grating_30deg_gs2 - red on/off during trial"
+      - "sq_grating_30deg_gs16 - Green on middle through end"
+      - "sq_grating_60deg_gs2 - blue beginning to middle"
+      - "sq_grating_60deg_gs16 - red full trial"
+      - "sine_grating_30deg_gs16 - no visible light"
+      - "sine_grating_60deg_gs16 - green on/off twice"
+      - "sine_grating_30deg_fine_gs16 - start red, add blue"
+      - "sine_grating_60deg_fine_gs16 - blue panel 1, then 3, then 5"
+      - "counter_0000_1000_gs2 - red 1,3,5, then blue 2,4,6"
+    repetitions: 3
+    randomize: false
+    intertrial: "intertrial"
+
+  - "shutdown"
+
+
+# ============================================================================
+# CONDITIONS LIBRARY
+# ============================================================================
+
+conditions: 
+
+  - name: "arena test"
+    commands:
+    - type: "controller"
+      command_name: "allOn"
+
+    - type: "wait"
+      duration: 1
+
+    - type: "controller"
+      command_name: "allOff"
+
+  - name: "IR on"
+    commands:
+    - type: "plugin"      
+      plugin_name: "backlight"
+      command_name: "setVisibleBacklightsOff"
+
+    - type: "plugin"
+      plugin_name: "backlight"
+      command_name: "setIRLEDPower"
+      params:
+        power: *IR_power
+
+    - type: "plugin"
+      plugin_name: "backlight"
+      command_name: "turnOnLED"
+
+    - type: "wait"
+      duration: 0.5
+
+  - name: "start recording"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "startRecording"
+        params:
+          filename: 'testExperiment'
+
+  - name: "baseline"
+    # 10 s baseline wait after recording starts, before any stimuli.
+    commands:
+      - type: "wait"
+        duration: *baseline_wait
+
+ # --- GRATINGS ---
+  - name: "sq_grating_30deg_gs2 - red on/off during trial"
+    commands:
+        # Getting timestamp at start of trial instead of end for better consistency
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"         
+        pattern_ID: 1
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 3
+
+  - name: "sq_grating_30deg_gs16 - Green on middle through end"
+    commands:
+    
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+    
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat02_sq_grating_30deg_gs16_G4.pat"
+        pattern_ID: 2
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+    
+      - type: "wait"
+        duration: 3
+    
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+  
+      - type: "wait"
+        duration: 7
+  
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "sq_grating_60deg_gs2 - blue beginning to middle"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat03_sq_grating_60deg_gs2_G4.pat"
+        pattern_ID: 3
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 5
+
+      
+  - name: "sq_grating_60deg_gs16 - red full trial"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 4
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: *trial_dur
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+      
+
+  - name: "sine_grating_30deg_gs16 - no visible light"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat05_sine_grating_30deg_gs16_G4.pat"
+        pattern_ID: 5
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: *trial_dur
+
+
+
+  - name: "sine_grating_60deg_gs16 - green on/off twice"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat06_sine_grating_60deg_gs16_G4.pat"
+        pattern_ID: 6
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "sine_grating_30deg_fine_gs16 - start red, add blue"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat07_sine_grating_30deg_fine_gs16_G4.pat"
+        pattern_ID: 7
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+
+  - name: "sine_grating_60deg_fine_gs16 - blue panel 1, then 3, then 5"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 1
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat08_sine_grating_60deg_fine_gs16_G4.pat"
+        pattern_ID: 8
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 3
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 5
+
+      - type: "wait"
+        duration: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+      
+
+  # --- COUNTERS ---
+
+  - name: "counter_0000_1000_gs2 - red 1,3,5, then blue 2,4,6"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 1
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 5
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat09_counter_0000_1000_gs2_G4.pat"
+        pattern_ID: 9
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 6
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "intertrial"
+    commands: 
+      - type: "controller"
+        command_name: "allOff"
+  
+      - type: "wait"
+        duration: *inter_wait
+
+  - name: "shutdown"
+    commands: 
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOffLED"
+      
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopRecording"
+  
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopCapture"
+  
+      - type: "wait"
+        duration: 1

--- a/tests/fixtures/v3_full_experiment.yaml
+++ b/tests/fixtures/v3_full_experiment.yaml
@@ -1,0 +1,545 @@
+version: 3
+
+# ============================================================================
+# EXPERIMENT METADATA
+# ============================================================================
+experiment_info:
+  name: "G4.1 Test Experiment using Bias and backlight"
+  date_created: "2026-03-23"
+  author: "Reiser Lab"
+  pattern_library: './patterns/reference/G41_2x12_cw'  # UPDATE THIS TO FULL PATH
+
+# ============================================================================
+# ARENA CONFIGURATION
+# ============================================================================
+rig: './configs/rigs/test_rig_1.yaml'  # UPDATE THIS TO FULL PATH BEFORE USE
+
+# ============================================================================
+# VARIABLES
+# ============================================================================
+variables:
+  IR_power:         &IR_power       50
+  trial_duration:   &trial_dur      10
+  trial_frame_rate: &fr_rate        10
+  led_power:        &led_power      5
+  baseline_wait:    &baseline_wait  10
+  intertrial_wait:  &inter_wait     2
+
+
+# ============================================================================
+# PLUGIN DEFINITIONS
+# ============================================================================
+plugins:
+# Class Plugin - Camera/video capture system
+  - name: "camera"
+    type: "class"
+    matlab:
+      class: "BiasPlugin"
+#    config: # Optional - required config is in rig yaml. This config is for optional settings that may 
+            # change between experiments. Values here that contradict rig yaml will override rig yaml.
+      #saveDir: 'path/to/save/videos' # Optional, default is in experiment yaml's location. 
+      #frame_rate: 150 # Optional, default is 100, a value outside of 10-200 will produce warning
+      #video_format: 'avi' #Optional, default is 'ufmf', only other option is 'avi'
+    # python: WOULD USE THIS IF PYTHON CLASS
+    #   module: "pyDisplayTools.plugins.SimpleBias"
+    #   class: "SimpleBias"
+    # config:   # config established in rig yaml but can add here to override
+
+  - name: "backlight"
+    type: "class"
+    matlab:
+      class: "LEDControllerPlugin"
+
+# ============================================================================
+# EXPERIMENT SEQUENCE
+# ============================================================================
+ 
+experiment: 
+  - "arena test"
+  - "IR on"
+  - "start recording"
+  - "baseline"
+
+  - name: "main block"
+    trials:
+      - "sq_grating_30deg_gs2 - red on/off during trial"
+      - "sq_grating_30deg_gs16 - Green on middle through end"
+      - "sq_grating_60deg_gs2 - blue beginning to middle"
+      - "sq_grating_60deg_gs16 - red full trial"
+      - "sine_grating_30deg_gs16 - no visible light"
+      - "sine_grating_60deg_gs16 - green on/off twice"
+      - "sine_grating_30deg_fine_gs16 - start red, add blue"
+      - "sine_grating_60deg_fine_gs16 - blue panel 1, then 3, then 5"
+      - "counter_0000_1000_gs2 - red 1,3,5, then blue 2,4,6"
+    repetitions: 3
+    randomize: false
+    intertrial: "intertrial"
+
+  - "shutdown"
+
+
+# ============================================================================
+# CONDITIONS LIBRARY
+# ============================================================================
+
+conditions: 
+
+  - name: "arena test"
+    commands:
+    - type: "controller"
+      command_name: "allOn"
+
+    - type: "wait"
+      duration: 1
+
+    - type: "controller"
+      command_name: "allOff"
+
+  - name: "IR on"
+    commands:
+    - type: "plugin"      
+      plugin_name: "backlight"
+      command_name: "setVisibleBacklightsOff"
+
+    - type: "plugin"
+      plugin_name: "backlight"
+      command_name: "setIRLEDPower"
+      params:
+        power: *IR_power
+
+    - type: "plugin"
+      plugin_name: "backlight"
+      command_name: "turnOnLED"
+
+    - type: "wait"
+      duration: 0.5
+
+  - name: "start recording"
+    commands:
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "startRecording"
+        params:
+          filename: 'testExperiment'
+
+  - name: "baseline"
+    # 10 s baseline wait after recording starts, before any stimuli.
+    commands:
+      - type: "wait"
+        duration: *baseline_wait
+
+ # --- GRATINGS ---
+  - name: "sq_grating_30deg_gs2 - red on/off during trial"
+    commands:
+        # Getting timestamp at start of trial instead of end for better consistency
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat01_sq_grating_30deg_gs2_G4.pat"         
+        pattern_ID: 1
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 3
+
+  - name: "sq_grating_30deg_gs16 - Green on middle through end"
+    commands:
+    
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+    
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat02_sq_grating_30deg_gs16_G4.pat"
+        pattern_ID: 2
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+    
+      - type: "wait"
+        duration: 3
+    
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+  
+      - type: "wait"
+        duration: 7
+  
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "sq_grating_60deg_gs2 - blue beginning to middle"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat03_sq_grating_60deg_gs2_G4.pat"
+        pattern_ID: 3
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 5
+
+      
+  - name: "sq_grating_60deg_gs16 - red full trial"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat04_sq_grating_60deg_gs16_G4.pat"
+        pattern_ID: 4
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: *trial_dur
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+      
+
+  - name: "sine_grating_30deg_gs16 - no visible light"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat05_sine_grating_30deg_gs16_G4.pat"
+        pattern_ID: 5
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: *trial_dur
+
+
+
+  - name: "sine_grating_60deg_gs16 - green on/off twice"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat06_sine_grating_60deg_gs16_G4.pat"
+        pattern_ID: 6
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params:
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setGreenLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+      - type: "wait"
+        duration: 2
+
+  - name: "sine_grating_30deg_fine_gs16 - start red, add blue"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat07_sine_grating_30deg_fine_gs16_G4.pat"
+        pattern_ID: 7
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 0
+          pattern: "1010"
+
+      - type: "wait"
+        duration: 7
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+
+  - name: "sine_grating_60deg_fine_gs16 - blue panel 1, then 3, then 5"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 1
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat08_sine_grating_60deg_fine_gs16_G4.pat"
+        pattern_ID: 8
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 3
+
+      - type: "wait"
+        duration: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 5
+
+      - type: "wait"
+        duration: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+      
+
+  # --- COUNTERS ---
+
+  - name: "counter_0000_1000_gs2 - red 1,3,5, then blue 2,4,6"
+    commands:
+
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 1
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 3
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 5
+
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "pat09_counter_0000_1000_gs2_G4.pat"
+        pattern_ID: 9
+        duration: *trial_dur
+        mode: 2
+        frame_index: 1
+        frame_rate: *fr_rate
+        gain: 0
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 2
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 4
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setBlueLEDPower"
+        params: 
+          power: *led_power
+          panel_num: 6
+
+      - type: "wait"
+        duration: 5
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setVisibleBacklightsOff"
+
+  - name: "intertrial"
+    commands: 
+      - type: "controller"
+        command_name: "allOff"
+  
+      - type: "wait"
+        duration: *inter_wait
+
+  - name: "shutdown"
+    commands: 
+      - type: "controller"
+        command_name: "allOff"
+
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "turnOffLED"
+      
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopRecording"
+  
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "stopCapture"
+  
+      - type: "wait"
+        duration: 1

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -27,6 +27,7 @@ const {
     validateReferences,
     V3ParseError,
     docSet,
+    docDelete,
     nodeIsAliasAt,
     aliasNameAt
 } = require('../js/protocol-yaml-v3.js');
@@ -491,6 +492,64 @@ console.log('\n--- Suite 9: docSet edits + alias detection ---');
         reparsed.conditions[condIdx].commands[ctrlIdx].command_name,
         'allOff'
     );
+}
+
+{
+    // 4. Block property edits — repetitions, randomize, intertrial set + delete
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex((e) => e.kind === 'block');
+    checkTrue('block edit: block found in canonical_a sequence', blockIdx >= 0);
+
+    docSet(exp, ['experiment', blockIdx, 'repetitions'], 5);
+    docSet(exp, ['experiment', blockIdx, 'randomize'], false);
+    check('block edit: JS reps mirrored', exp.sequence[blockIdx].repetitions, 5);
+    check('block edit: JS randomize mirrored', exp.sequence[blockIdx].randomize, false);
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('block edit: reps round-trip', reparsed.sequence[blockIdx].repetitions, 5);
+    check('block edit: randomize round-trip', reparsed.sequence[blockIdx].randomize, false);
+}
+
+{
+    // 5. docDelete — clear block intertrial back to "none"
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex((e) => e.kind === 'block');
+    check('delete: pre-delete intertrial', exp.sequence[blockIdx].intertrial, 'intertrial');
+
+    docDelete(exp, ['experiment', blockIdx, 'intertrial']);
+    check('delete: JS intertrial cleared to null', exp.sequence[blockIdx].intertrial, null);
+
+    const regen = generateV3Protocol(exp);
+    checkTrue(
+        'delete: intertrial line removed from YAML',
+        !regen.includes('intertrial: "intertrial"')
+    );
+    const reparsed = parseV3Protocol(regen);
+    check(
+        'delete: reparsed intertrial is null',
+        reparsed.sequence[blockIdx].intertrial,
+        null
+    );
+    // Anchors/comments still intact through a delete
+    checkTrue('delete: &dur_long preserved', regen.includes('&dur_long'));
+    checkTrue('delete: comment block preserved', regen.includes('# EXPERIMENT METADATA'));
+}
+
+{
+    // 6. Block name — set and clear
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex((e) => e.kind === 'block');
+    check('block name: pre-edit', exp.sequence[blockIdx].name, 'main block');
+
+    docSet(exp, ['experiment', blockIdx, 'name'], 'renamed block');
+    check('block name: set JS', exp.sequence[blockIdx].name, 'renamed block');
+    let reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('block name: set round-trip', reparsed.sequence[blockIdx].name, 'renamed block');
+
+    docDelete(exp, ['experiment', blockIdx, 'name']);
+    check('block name: clear JS', exp.sequence[blockIdx].name, null);
+    reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('block name: clear round-trip', reparsed.sequence[blockIdx].name, null);
 }
 
 // ─── Results ────────────────────────────────────────────────────────────────

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -28,6 +28,8 @@ const {
     V3ParseError,
     docSet,
     docDelete,
+    docInsertCommand,
+    docMoveCommand,
     nodeIsAliasAt,
     aliasNameAt
 } = require('../js/protocol-yaml-v3.js');
@@ -676,6 +678,124 @@ console.log('\n--- Suite 10: v3 plugin registry (class-based lookup + log) ---')
 
     const nope = getV3CommandParams(exp, 'plugin', 'camera', 'bogusCommand');
     check('params: unknown plugin command returns null', nope, null);
+}
+
+// ─── Test Suite 11: docInsertCommand / docMoveCommand / delete-command ────
+console.log('\n--- Suite 11: command add / move / delete ---');
+
+{
+    // Insert a new wait command in the middle of "arena check"
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const condIdx = exp.conditions.findIndex((c) => c.name === 'arena check');
+    const before = exp.conditions[condIdx].commands.length;
+
+    docInsertCommand(exp, condIdx, 1, { type: 'wait', duration: 0.25 });
+    check('insert: JS length grew by 1', exp.conditions[condIdx].commands.length, before + 1);
+    check(
+        'insert: at index 1 is the new wait',
+        exp.conditions[condIdx].commands[1].type,
+        'wait'
+    );
+    check(
+        'insert: duration preserved',
+        exp.conditions[condIdx].commands[1].duration,
+        0.25
+    );
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check(
+        'insert: round-trip length',
+        reparsed.conditions[condIdx].commands.length,
+        before + 1
+    );
+    check(
+        'insert: round-trip new command type',
+        reparsed.conditions[condIdx].commands[1].type,
+        'wait'
+    );
+    check(
+        'insert: round-trip new command duration',
+        reparsed.conditions[condIdx].commands[1].duration,
+        0.25
+    );
+
+    // Anchors/comments still alive after insert
+    const regen = generateV3Protocol(exp);
+    checkTrue('insert: anchors preserved', regen.includes('&dur_short') && regen.includes('*dur_short'));
+    checkTrue('insert: comments preserved', regen.includes('# EXPERIMENT METADATA'));
+}
+
+{
+    // Append a plugin command (uses createNode with nested params map)
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const condIdx = exp.conditions.findIndex((c) => c.name === 'arena check');
+    const before = exp.conditions[condIdx].commands.length;
+    docInsertCommand(exp, condIdx, before, {
+        type: 'plugin',
+        plugin_name: 'log',
+        command_name: 'log',
+        params: { message: 'arena check done', level: 'INFO' }
+    });
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    const appended = reparsed.conditions[condIdx].commands[before];
+    check('insert plugin: type', appended.type, 'plugin');
+    check('insert plugin: plugin_name', appended.plugin_name, 'log');
+    check('insert plugin: command_name', appended.command_name, 'log');
+    check('insert plugin: params.message', appended.params.message, 'arena check done');
+    check('insert plugin: params.level', appended.params.level, 'INFO');
+}
+
+{
+    // Move first command to last (swap arena check's allOn → allOff order)
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const condIdx = exp.conditions.findIndex((c) => c.name === 'arena check');
+    const cmds = exp.conditions[condIdx].commands;
+    const origFirstName = cmds[0].command_name;
+    const origLastName = cmds[cmds.length - 1].command_name;
+
+    docMoveCommand(exp, condIdx, 0, cmds.length - 1);
+    // After moving [0] (controller allOn) to the end, the new order is:
+    // [wait, controller allOff, controller allOn]
+    check('move: JS new first is the wait', cmds[0].type, 'wait');
+    check('move: original first is now at end', cmds[cmds.length - 1].command_name, origFirstName);
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    const reparsedCmds = reparsed.conditions[condIdx].commands;
+    check('move: round-trip last is original first', reparsedCmds[reparsedCmds.length - 1].command_name, origFirstName);
+}
+
+{
+    // Delete a command via docDelete
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const condIdx = exp.conditions.findIndex((c) => c.name === 'arena check');
+    const before = exp.conditions[condIdx].commands.length;
+    docDelete(exp, ['conditions', condIdx, 'commands', 1]); // delete middle (the wait)
+
+    check('delete cmd: JS length shrank', exp.conditions[condIdx].commands.length, before - 1);
+    check('delete cmd: middle is now what was last', exp.conditions[condIdx].commands[1].command_name, 'allOff');
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('delete cmd: round-trip length', reparsed.conditions[condIdx].commands.length, before - 1);
+    // The *dur_short anchor was previously used in the deleted wait; *dur_short
+    // is still defined in `variables:` and used by no one (now orphaned).
+    // Generation should still succeed.
+    checkTrue('delete cmd: regen succeeds', generateV3Protocol(exp).length > 0);
+}
+
+{
+    // Bounds-check: docMoveCommand with bad indices is a no-op
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const condIdx = exp.conditions.findIndex((c) => c.name === 'arena check');
+    const before = JSON.stringify(exp.conditions[condIdx].commands.map((c) => c.type));
+    docMoveCommand(exp, condIdx, 0, 0); // no-op
+    docMoveCommand(exp, condIdx, 99, 0); // out of bounds
+    docMoveCommand(exp, condIdx, -1, 0); // negative
+    check(
+        'move: no-op / bad indices preserve order',
+        JSON.stringify(exp.conditions[condIdx].commands.map((c) => c.type)),
+        before
+    );
 }
 
 // ─── Results ────────────────────────────────────────────────────────────────

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -25,7 +25,10 @@ const {
     parseV3Protocol,
     generateV3Protocol,
     validateReferences,
-    V3ParseError
+    V3ParseError,
+    docSet,
+    nodeIsAliasAt,
+    aliasNameAt
 } = require('../js/protocol-yaml-v3.js');
 
 // ─── Counters & helpers ─────────────────────────────────────────────────────
@@ -144,7 +147,8 @@ const coverageFixtures = [
     'v3_no_intertrial.yaml',
     'v3_consecutive_refs.yaml',
     'v3_future_keys.yaml',
-    'v3_plugin_config.yaml'
+    'v3_plugin_config.yaml',
+    'v3_full_experiment.yaml'
 ];
 
 for (const fname of coverageFixtures) {
@@ -330,6 +334,39 @@ checkThrows(
     );
 }
 
+// ─── Test Suite 8b: Full-experiment fixture (Lisa, 2026-05-26) ──────────────
+console.log('\n--- Suite 8b: Lisa\'s full_experiment_test_v3 fixture ---');
+
+{
+    const text = readFixture('v3_full_experiment.yaml');
+    const exp = parseV3Protocol(text);
+    check('full_exp: version', exp.version, 3);
+    check('full_exp: conditions count', exp.conditions.length, 15);
+    check('full_exp: variables count', exp.variables.length, 6);
+    check('full_exp: sequence length', exp.sequence.length, 6);
+    check('full_exp: seq[0] bare ref', exp.sequence[0].kind, 'ref');
+    check('full_exp: seq[4] is block', exp.sequence[4].kind, 'block');
+    check('full_exp: main block trials', exp.sequence[4].trials.length, 9);
+    check('full_exp: main block reps', exp.sequence[4].repetitions, 3);
+    check('full_exp: main block randomize', exp.sequence[4].randomize, false);
+    check('full_exp: main block intertrial', exp.sequence[4].intertrial, 'intertrial');
+    check('full_exp: seq[5] bare ref "shutdown"', exp.sequence[5].condition_name, 'shutdown');
+
+    const refs = validateReferences(exp);
+    checkTrue(
+        'full_exp: all references resolve',
+        refs.ok,
+        refs.ok ? '' : refs.errors.join('; ')
+    );
+
+    // Anchor survival (variable names from Lisa's fixture)
+    const regen = generateV3Protocol(exp);
+    for (const anchor of ['IR_power', 'trial_dur', 'fr_rate', 'led_power', 'baseline_wait', 'inter_wait']) {
+        checkTrue('full_exp: anchor &' + anchor + ' in regen', regen.includes('&' + anchor));
+        checkTrue('full_exp: alias *' + anchor + ' in regen', regen.includes('*' + anchor));
+    }
+}
+
 // ─── Test Suite 8: Numeric type preservation ────────────────────────────────
 console.log('\n--- Suite 8: Numeric type preservation ---');
 
@@ -347,6 +384,113 @@ console.log('\n--- Suite 8: Numeric type preservation ---');
     // Variable value (number)
     check('numeric: variable dur_long is number', typeof exp.variables[0].value, 'number');
     check('numeric: variable color_power value', exp.variables[3].value, 5);
+}
+
+// ─── Test Suite 9: Editing — docSet, alias detection, comment survival ─────
+console.log('\n--- Suite 9: docSet edits + alias detection ---');
+
+{
+    // 1. Edit a wait.duration in canonical_a and verify it round-trips.
+    const orig = readFixture('v3_canonical_a.yaml');
+    const exp = parseV3Protocol(orig);
+
+    // Find condition "arena check" and its wait command
+    const condIdx = exp.conditions.findIndex((c) => c.name === 'arena check');
+    checkTrue('edit: arena check condition found', condIdx >= 0);
+    const cmdIdx = exp.conditions[condIdx].commands.findIndex((c) => c.type === 'wait');
+    checkTrue('edit: wait command found in arena check', cmdIdx >= 0);
+
+    const oldDur = exp.conditions[condIdx].commands[cmdIdx].duration;
+    check('edit: pre-edit wait.duration', oldDur, 3);
+
+    // docSet to change the duration to 7
+    docSet(exp, ['conditions', condIdx, 'commands', cmdIdx, 'duration'], 7);
+
+    // JS model mirrored
+    check('edit: JS model updated', exp.conditions[condIdx].commands[cmdIdx].duration, 7);
+
+    // YAML emit contains the new value, not the old one (in the right place)
+    const regen = generateV3Protocol(exp);
+    const reparsed = parseV3Protocol(regen);
+    check(
+        'edit: reparsed wait.duration is 7',
+        reparsed.conditions[condIdx].commands[cmdIdx].duration,
+        7
+    );
+
+    // Comments survive the edit (count check)
+    const origComments = orig.split('\n').filter((l) => l.trimStart().startsWith('#')).length;
+    const regenComments = regen.split('\n').filter((l) => l.trimStart().startsWith('#')).length;
+    checkTrue(
+        'edit: comment count preserved through edit',
+        origComments === regenComments,
+        'orig=' + origComments + ', after-edit=' + regenComments
+    );
+
+    // Other anchors/aliases still intact in the regen
+    checkTrue('edit: anchor &dur_long still in regen', regen.includes('&dur_long'));
+    checkTrue('edit: alias *dur_long still in regen', regen.includes('*dur_long'));
+}
+
+{
+    // 2. Alias detection — arena check's wait is *dur_short (alias);
+    // start light and camera's wait is literal 0.5.
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+
+    const arenaCheckIdx = exp.conditions.findIndex((c) => c.name === 'arena check');
+    const arenaWaitIdx = exp.conditions[arenaCheckIdx].commands.findIndex(
+        (c) => c.type === 'wait'
+    );
+    const aliasPath = [
+        'conditions',
+        arenaCheckIdx,
+        'commands',
+        arenaWaitIdx,
+        'duration'
+    ];
+
+    checkTrue('alias: nodeIsAliasAt detects *dur_short binding', nodeIsAliasAt(exp, aliasPath));
+    check('alias: aliasNameAt returns "dur_short"', aliasNameAt(exp, aliasPath), 'dur_short');
+
+    const litCond = exp.conditions.find((c) => c.name === 'start light and camera');
+    const litCondIdx = exp.conditions.indexOf(litCond);
+    const litWaitIdx = litCond.commands.findIndex((c) => c.type === 'wait');
+    const literalPath = ['conditions', litCondIdx, 'commands', litWaitIdx, 'duration'];
+
+    check(
+        'alias: literal scalar returns null aliasName',
+        aliasNameAt(exp, literalPath),
+        null
+    );
+    checkTrue(
+        'alias: literal scalar is NOT detected as alias',
+        !nodeIsAliasAt(exp, literalPath)
+    );
+}
+
+{
+    // 3. Edit a string field (controller.command_name) — string round-trip
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const condIdx = exp.conditions.findIndex((c) => c.name === 'arena check');
+    const ctrlIdx = exp.conditions[condIdx].commands.findIndex(
+        (c) => c.type === 'controller'
+    );
+    docSet(
+        exp,
+        ['conditions', condIdx, 'commands', ctrlIdx, 'command_name'],
+        'allOff'
+    );
+    check(
+        'edit: string field JS model',
+        exp.conditions[condIdx].commands[ctrlIdx].command_name,
+        'allOff'
+    );
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check(
+        'edit: string field reparsed',
+        reparsed.conditions[condIdx].commands[ctrlIdx].command_name,
+        'allOff'
+    );
 }
 
 // ─── Results ────────────────────────────────────────────────────────────────

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -3,7 +3,7 @@
  * Protocol v3 Roundtrip Tests
  *
  * Phase 1 gate: round-trip the two canonical v3 YAMLs from origin/version3
- * @ 00c8f95, plus all 7 coverage-gap fixtures, preserving anchors and comments.
+ * @ 649d7ef, plus all coverage-gap fixtures, preserving anchors and comments.
  *
  * MATLAB-side cross-check (Phase 1 gate item 4) lives in a separate manual
  * script (docs/development/v3-matlab-validation.md and Phase 8 work);
@@ -678,6 +678,55 @@ console.log('\n--- Suite 10: v3 plugin registry (class-based lookup + log) ---')
 
     const nope = getV3CommandParams(exp, 'plugin', 'camera', 'bogusCommand');
     check('params: unknown plugin command returns null', nope, null);
+}
+
+// ─── Test Suite 10b: Block `repetitions` validation ────────────────────────
+console.log("\n--- Suite 10b: repetitions validation ---");
+
+function v3WithReps(repsLiteral) {
+    return [
+        'version: 3',
+        'experiment_info: {name: x}',
+        'rig: "/tmp/r.yaml"',
+        'experiment:',
+        '  - name: blk',
+        '    trials: [c]',
+        '    repetitions: ' + repsLiteral,
+        'conditions:',
+        '  - name: c',
+        '    commands: [{type: wait, duration: 1}]'
+    ].join('\n') + '\n';
+}
+
+checkThrows('reps validation: rejects 0', () => parseV3Protocol(v3WithReps('0')), 'INVALID_SCHEMA');
+checkThrows('reps validation: rejects -1', () => parseV3Protocol(v3WithReps('-1')), 'INVALID_SCHEMA');
+checkThrows('reps validation: rejects 1.5', () => parseV3Protocol(v3WithReps('1.5')), 'INVALID_SCHEMA');
+checkThrows(
+    'reps validation: rejects non-numeric string',
+    () => parseV3Protocol(v3WithReps('"three"')),
+    'INVALID_SCHEMA'
+);
+
+{
+    // Positive integer accepted
+    const exp = parseV3Protocol(v3WithReps('3'));
+    check('reps validation: accepts positive integer 3', exp.sequence[0].repetitions, 3);
+}
+{
+    // Omitted → default 1
+    const yamlNoReps = [
+        'version: 3',
+        'experiment_info: {name: x}',
+        'rig: "/tmp/r.yaml"',
+        'experiment:',
+        '  - name: blk',
+        '    trials: [c]',
+        'conditions:',
+        '  - name: c',
+        '    commands: [{type: wait, duration: 1}]'
+    ].join('\n') + '\n';
+    const exp = parseV3Protocol(yamlNoReps);
+    check('reps validation: omitted defaults to 1', exp.sequence[0].repetitions, 1);
 }
 
 // ─── Test Suite 11: docInsertCommand / docMoveCommand / delete-command ────

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -32,6 +32,15 @@ const {
     aliasNameAt
 } = require('../js/protocol-yaml-v3.js');
 
+const {
+    findPluginDefByClass,
+    getCommandsForClass,
+    getV3PluginCommands,
+    listV3PluginNames,
+    getV3CommandParams,
+    LOG_PLUGIN
+} = require('../js/plugin-registry.js');
+
 // ─── Counters & helpers ─────────────────────────────────────────────────────
 
 let totalTests = 0;
@@ -550,6 +559,123 @@ console.log('\n--- Suite 9: docSet edits + alias detection ---');
     check('block name: clear JS', exp.sequence[blockIdx].name, null);
     reparsed = parseV3Protocol(generateV3Protocol(exp));
     check('block name: clear round-trip', reparsed.sequence[blockIdx].name, null);
+}
+
+// ─── Test Suite 10: v3 plugin-registry lookups ──────────────────────────────
+console.log('\n--- Suite 10: v3 plugin registry (class-based lookup + log) ---');
+
+{
+    // findPluginDefByClass — finds DAQ, Bias; returns null for unknown
+    check(
+        'registry: findPluginDefByClass(DAQThermometerPlugin)',
+        findPluginDefByClass('DAQThermometerPlugin')?.name,
+        'thermometer'
+    );
+    check(
+        'registry: findPluginDefByClass(BiasPlugin)',
+        findPluginDefByClass('BiasPlugin')?.name,
+        'camera'
+    );
+    check(
+        'registry: findPluginDefByClass(LEDControllerPlugin)',
+        findPluginDefByClass('LEDControllerPlugin')?.name,
+        'backlight'
+    );
+    check('registry: findPluginDefByClass(Unknown) is null', findPluginDefByClass('Nope'), null);
+    check('registry: findPluginDefByClass(undef) is null', findPluginDefByClass(undefined), null);
+}
+
+{
+    // DAQ commands & log plugin shape
+    const daqCmds = getCommandsForClass('DAQThermometerPlugin');
+    check('registry: DAQ has 4 commands', Object.keys(daqCmds).length, 4);
+    checkTrue('registry: DAQ.startContinuousLogging defined', !!daqCmds.startContinuousLogging);
+    checkTrue('registry: DAQ.stopContinuousLogging defined', !!daqCmds.stopContinuousLogging);
+    checkTrue('registry: DAQ.get_temperature defined', !!daqCmds.get_temperature);
+    checkTrue('registry: DAQ.log_temperature defined', !!daqCmds.log_temperature);
+
+    check('registry: LOG_PLUGIN.name', LOG_PLUGIN.name, 'log');
+    check('registry: LOG_PLUGIN has 1 command', Object.keys(LOG_PLUGIN.commands).length, 1);
+    check(
+        'registry: LOG_PLUGIN.log.params.message.required',
+        LOG_PLUGIN.commands.log.params.message.required,
+        true
+    );
+    check(
+        'registry: LOG_PLUGIN.log.params.level default',
+        LOG_PLUGIN.commands.log.params.level.default,
+        'INFO'
+    );
+}
+
+{
+    // Class-based resolution within a parsed experiment (canonical_a has camera + backlight)
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+
+    // listV3PluginNames includes the user's declared names + "log" at the end
+    const names = listV3PluginNames(exp);
+    check('lookup: list ends with "log"', names[names.length - 1], 'log');
+    checkTrue('lookup: list includes camera', names.includes('camera'));
+    checkTrue('lookup: list includes backlight', names.includes('backlight'));
+
+    // getV3PluginCommands resolves via matlab.class
+    const camCmds = getV3PluginCommands(exp, 'camera');
+    checkTrue('lookup: camera resolves to BiasPlugin commands', !!camCmds.startRecording);
+    checkTrue('lookup: camera has getTimestamp', !!camCmds.getTimestamp);
+
+    const blCmds = getV3PluginCommands(exp, 'backlight');
+    checkTrue('lookup: backlight resolves to LEDControllerPlugin commands', !!blCmds.setIRLEDPower);
+    checkTrue('lookup: backlight has setRedLEDPower', !!blCmds.setRedLEDPower);
+
+    // "log" always available even without declaration
+    const logCmds = getV3PluginCommands(exp, 'log');
+    checkTrue('lookup: "log" returns LOG_PLUGIN.commands', !!logCmds.log);
+
+    // Unknown plugin name returns empty (designer should disable the picker)
+    const noCmds = getV3PluginCommands(exp, 'nonexistent');
+    check('lookup: unknown plugin name returns empty map', Object.keys(noCmds).length, 0);
+}
+
+{
+    // User can name a plugin anything — class-based lookup still resolves it
+    const customYaml = [
+        'version: 3',
+        'experiment_info: {name: x}',
+        'rig: "/tmp/r.yaml"',
+        'plugins:',
+        '  - name: my_cam',
+        '    type: class',
+        '    matlab: {class: BiasPlugin}',
+        'experiment: [setup]',
+        'conditions:',
+        '  - name: setup',
+        '    commands: [{type: wait, duration: 1}]'
+    ].join('\n') + '\n';
+    const exp = parseV3Protocol(customYaml);
+    const cmds = getV3PluginCommands(exp, 'my_cam');
+    checkTrue('custom name: my_cam resolves Bias commands via class', !!cmds.startRecording);
+    check(
+        'custom name: listV3PluginNames returns ["my_cam", "log"]',
+        JSON.stringify(listV3PluginNames(exp)),
+        '["my_cam","log"]'
+    );
+}
+
+{
+    // getV3CommandParams routes controller, plugin, log all correctly
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+
+    const ctrlParams = getV3CommandParams(exp, 'controller', null, 'trialParams');
+    checkTrue('params: controller.trialParams has pattern param', !!ctrlParams?.pattern);
+
+    const startRec = getV3CommandParams(exp, 'plugin', 'camera', 'startRecording');
+    checkTrue('params: plugin camera.startRecording has filename param', !!startRec?.filename);
+
+    const logParams = getV3CommandParams(exp, 'plugin', 'log', 'log');
+    checkTrue('params: plugin log.log has message + level', !!logParams?.message && !!logParams?.level);
+
+    const nope = getV3CommandParams(exp, 'plugin', 'camera', 'bogusCommand');
+    check('params: unknown plugin command returns null', nope, null);
 }
 
 // ─── Results ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR2 of the v3 designer plan: makes the inspector editable. Builds on the v0.1 viewer ([#62](https://github.com/reiserlab/webDisplayTools/pull/62)) with five focused slices.

- **Scalar field editing** — All literal scalar fields in command cards (controller `pattern`/`mode`/`duration`/etc., wait `duration`, plugin params) are editable inline. Anchor-bound scalars render as read-only `→ &name` chips until the Variables editor lands (Phase 5).
- **Block property editing** — Inspector for a block exposes editable `name`, `repetitions`, `randomize`, and `intertrial` (dropdown from declared conditions).
- **Command add / delete / reorder** — Per-card ↑ ↓ ✕ buttons plus an "+ add" picker grouped by Timing / Controller / Plugin: \<name\> / log. New commands use the plugin-registry to populate sensible default params.
- **Undo / redo** — YAML-text snapshots before every mutation. `Ctrl+Z` / `Cmd+Z` / `Ctrl+Y` / `Ctrl+Shift+Z` keybinds. Anchors and comments survive every undo cycle.
- **Plugin-registry v3 helpers** — Adds DAQThermometerPlugin (4 commands) and the built-in `log` plugin to the registry. New class-based lookup functions resolve plugin commands by `matlab.class` rather than by name, so v3's user-named plugins work correctly.

The editor mutates a `YAML.Document` in place, so anchors, comments, unknown future-compat keys, and pattern_ID values all survive any sequence of edits and round-trip exports.

## Pre-merge fixes from Codex review

Independent Codex review (standard + adversarial) plus Claude's own pass flagged a small batch of items, all addressed in the final commit:

- Reject invalid `repetitions` (0 / negative / decimal / non-numeric) at parse time.
- Reject empty-string commits on numeric inputs (was silently committing 0).
- `beforeunload` warning when there are unsaved edits.
- Import-while-dirty confirmation before overwriting.
- `commitBlockEdit` re-renders the library so usage counts stay accurate after an intertrial change.
- Doc/SHA consistency across `index.html`, `ROADMAP.md`, test file headers.

Full reconciliation report kept at `.codex-review/report-20260527-105056.md` for traceability (not committed — repo gitignores `.codex-review/`).

## Test plan

- [x] **Node:** `npm test` — arena calc (10/10), v2 (137/137), v3 (210/210).
- [x] **Browser smoke, all 10 v3 fixtures:** import → populate → export with anchors + comments preserved at original counts.
- [x] **Multi-block selection:** 3 distinct blocks in `v3_multi_block.yaml`; editing one block's reps doesn't affect siblings.
- [x] **Anchor preservation across edits** (canonical_a): edit literal fields, all 4 anchors still appear as `&def` + `*use` in export.
- [x] **Unknown-keys passthrough** (future_keys): `retry_on_fail`, `abort_if`, `max_retries_per_trial` survive edit + undo + export.
- [x] **Undo/redo cycle:** add → edit → delete → undo×3 → redo×1 walks through each pre-mutation state correctly; button enable/disable accurate.
- [x] **v2 regression:** v2 designer loads cleanly, no console errors (`js/plugin-registry.js` is shared).
- [x] **`Beta / Editor (early)`** label and updated description on the index card.

## Known follow-ups (post-merge)

- `select` schema fields render as text inputs, not `<select>` (affects `mode`, `gs_val`, `level`).
- New commands emit bare scalars (`type: plugin`) rather than quoted (`type: "plugin"`). Both parse identically; cosmetic only.
- Plugin command head fields (`plugin_name`, `command_name`) and param add/remove not yet editable.
- `yaml@2.9.0` still loaded from jsDelivr CDN — vendor locally before lab/offline rollout.
- `extractCommand` rejects unknown command `type:` outright; forward-compat passthrough is a future improvement.
- Sequence editing (add/remove block, add/remove ref, drag/drop) — Phase 4.
- Variables UX with rename cascade — Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)