### PR TITLE
chore(v3): preamble — CI hardening + unknown-type passthrough + select dropdown

### DIFF
--- a/.github/workflows/validate-protocol-roundtrip.yml
+++ b/.github/workflows/validate-protocol-roundtrip.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/fixtures/v2_*.yaml'
       - 'tests/fixtures/v3_*.yaml'
       - 'package.json'
+      - 'package-lock.json'
       - '.github/workflows/validate-protocol-roundtrip.yml'
   pull_request:
     paths:
@@ -28,6 +29,7 @@ on:
       - 'tests/fixtures/v2_*.yaml'
       - 'tests/fixtures/v3_*.yaml'
       - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch:
 
 jobs:
@@ -44,7 +46,7 @@ jobs:
           node-version: '24'
 
       - name: Install dependencies
-        run: npm ci || npm install
+        run: npm ci
 
       - name: Run v2 protocol roundtrip tests
         run: node tests/test-protocol-roundtrip.js

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -335,6 +335,28 @@
         .cmd-card.controller { border-left: 3px solid var(--accent); }
         .cmd-card.wait { border-left: 3px solid var(--text-dim); }
         .cmd-card.plugin { border-left: 3px solid var(--beta); }
+        .cmd-card.raw {
+            border-left: 3px solid var(--warn);
+            background: rgba(255, 152, 0, 0.04);
+        }
+        .cmd-card.raw .cmd-head .ctype { color: var(--warn); }
+        .cmd-card .raw-badge {
+            display: inline-block;
+            padding: 0.05rem 0.4rem;
+            background: rgba(255, 152, 0, 0.12);
+            color: var(--warn);
+            border: 1px solid var(--warn);
+            border-radius: 8px;
+            font-size: 0.6rem;
+            margin-left: 0.4rem;
+            cursor: help;
+            font-weight: 400;
+        }
+        .cmd-card.raw .kv-line .v-readonly {
+            color: var(--text);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.7rem;
+        }
         .cmd-card .cmd-head { font-weight: 600; margin-bottom: 0.2rem; }
         .cmd-card .cmd-head .ctype { color: var(--text-dim); font-weight: 400; font-size: 0.65rem; text-transform: uppercase; margin-right: 0.3rem; }
         .cmd-card .kv-line { font-size: 0.7rem; color: var(--text-dim); display: flex; align-items: center; gap: 0.3rem; }
@@ -354,6 +376,18 @@
         .cmd-card .kv-line input.field-edit:focus { outline: none; border-color: var(--accent); }
         .cmd-card .kv-line input.field-edit.num { width: 70px; text-align: right; color: var(--accent); }
         .cmd-card .kv-line input.field-edit.str { color: var(--accent); }
+        .cmd-card .kv-line select.field-edit {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            color: var(--accent);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.7rem;
+            padding: 0.1rem 0.35rem;
+            border-radius: 2px;
+            min-width: 120px;
+            max-width: 220px;
+        }
+        .cmd-card .kv-line select.field-edit:focus { outline: none; border-color: var(--accent); }
         .cmd-card .kv-line .alias-chip {
             display: inline-flex;
             align-items: center;
@@ -679,7 +713,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.2 | <span id="footerTimestamp">2026-05-27 08:56 ET</span>
+        v3 Experiment Designer v0.2.1 | <span id="footerTimestamp">2026-05-27 14:03 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -1290,6 +1324,8 @@
             'frame_index': 'number',
             'frame_rate': 'number',
             'gain': 'number',
+            'gs_val': 'number',
+            'posX': 'number',
             'command_name': 'string',
             'plugin_name': 'string'
         };
@@ -1297,10 +1333,26 @@
         // Render a single editable scalar field. If the underlying YAML node is
         // an Alias, show a read-only badge instead of an input. Otherwise, an
         // input that calls docSet() on commit.
-        function renderEditableField(label, path, value, typeHint, opts) {
+        //
+        // `schemaOrTypeHint` accepts either:
+        //   - a string 'number' / 'string' (legacy callers, freeform params)
+        //   - a schema object { type, options, default, ... } from the plugin
+        //     registry. `type === 'select'` renders a <select> dropdown; the
+        //     picked value is coerced back to the option's original value type
+        //     (so a numeric `mode: 2` stays a number, not "2").
+        function renderEditableField(label, path, value, schemaOrTypeHint, opts) {
             opts = opts || {};
             const wrapper = el('div', { class: 'kv-line', style: opts.indent ? 'padding-left: 1rem;' : '' });
             wrapper.appendChild(el('span', { class: 'k' }, label + ':'));
+
+            let schema = null;
+            let typeHint = 'string';
+            if (typeof schemaOrTypeHint === 'string') {
+                typeHint = schemaOrTypeHint;
+            } else if (schemaOrTypeHint && typeof schemaOrTypeHint === 'object') {
+                schema = schemaOrTypeHint;
+                typeHint = schema.type === 'number' ? 'number' : (schema.type === 'select' ? 'select' : 'string');
+            }
 
             const aliasName = aliasNameAt(experiment, path);
             if (aliasName) {
@@ -1312,6 +1364,42 @@
                     el('span', { class: 'resolved-val' }, '= ' + (typeof value === 'string' ? JSON.stringify(value) : String(value)))
                 );
                 wrapper.appendChild(chip);
+                return wrapper;
+            }
+
+            if (schema && schema.type === 'select' && Array.isArray(schema.options)) {
+                const select = el('select', {
+                    class: 'field-edit',
+                    title: 'Edit ' + label
+                });
+                for (const opt of schema.options) {
+                    const optEl = el('option', { value: String(opt.value) }, opt.label || String(opt.value));
+                    if (opt.value === value) optEl.selected = true;
+                    select.appendChild(optEl);
+                }
+                select.addEventListener('change', () => {
+                    // Match the picked string back to the option's original
+                    // value type (numeric for mode/gs_val, string for log.level)
+                    const picked = schema.options.find((o) => String(o.value) === select.value);
+                    if (!picked) return;
+                    if (picked.value === value) return;
+                    pushUndo();
+                    try {
+                        docSet(experiment, path, picked.value);
+                        setDirty(true);
+                        renderInspector();
+                        renderTimeline();
+                    } catch (err) {
+                        showError('Edit failed', err.message);
+                        for (const o of select.options) {
+                            if (o.value === String(value)) {
+                                o.selected = true;
+                                break;
+                            }
+                        }
+                    }
+                });
+                wrapper.appendChild(select);
                 return wrapper;
             }
 
@@ -1674,6 +1762,33 @@
 
         function renderCommandCard(cmd, cmdPath, cardMeta) {
             // cardMeta: { condIdx, cmdIdx, total } — required for action buttons
+
+            // Forward-compat: unknown command types (e.g., a future `branch` or
+            // `loop` from MATLAB) render as read-only "raw" cards. Export
+            // preserves them verbatim via _doc.toString(); editing happens in
+            // YAML for now.
+            if (cmd._rawUnknownType) {
+                const rawCard = el('div', { class: 'cmd-card raw' });
+                const rawHead = el('div', { class: 'cmd-head' },
+                    el('span', { class: 'ctype' }, cmd.type),
+                    el('span', {
+                        class: 'raw-badge',
+                        title: 'Unknown command type — preserved on export. Edit in YAML.'
+                    }, 'raw')
+                );
+                rawCard.appendChild(rawHead);
+                for (const k of Object.keys(cmd)) {
+                    if (k === 'type' || k === '_rawUnknownType' || k === '_unknownKeys') continue;
+                    const v = cmd[k];
+                    const line = el('div', { class: 'kv-line' },
+                        el('span', { class: 'k' }, k + ':'),
+                        el('span', { class: 'v-readonly' }, typeof v === 'string' ? v : JSON.stringify(v))
+                    );
+                    rawCard.appendChild(line);
+                }
+                return rawCard;
+            }
+
             const card = el('div', { class: 'cmd-card ' + cmd.type });
             const head = el('div', { class: 'cmd-head' },
                 el('span', { class: 'ctype' }, cmd.type),
@@ -1711,21 +1826,47 @@
             card.appendChild(actions);
 
             const detailKeys = {
-                controller: ['command_name', 'pattern', 'pattern_ID', 'duration', 'mode', 'frame_index', 'frame_rate', 'gain'],
+                controller: ['command_name', 'pattern', 'pattern_ID', 'duration', 'mode', 'frame_index', 'frame_rate', 'gain', 'gs_val', 'posX'],
                 wait: ['duration'],
                 plugin: []
             }[cmd.type] || [];
 
+            // Schema for this command's params (controller or plugin). Used so
+            // `mode` / `gs_val` / `level` render as <select> with type-correct
+            // coercion. Falls back to the freeform FIELD_TYPES map.
+            const paramsSchema =
+                cmd.type === 'controller'
+                    ? getV3CommandParams(experiment, 'controller', null, cmd.command_name)
+                    : null;
+
             for (const k of detailKeys) {
                 if (cmd[k] === undefined) continue;
-                card.appendChild(renderEditableField(k, [...cmdPath, k], cmd[k], FIELD_TYPES[k] || 'string'));
+                const fieldSchema = paramsSchema && paramsSchema[k];
+                card.appendChild(
+                    renderEditableField(
+                        k,
+                        [...cmdPath, k],
+                        cmd[k],
+                        fieldSchema || FIELD_TYPES[k] || 'string'
+                    )
+                );
             }
 
             if (cmd.type === 'plugin' && cmd.params && Object.keys(cmd.params).length > 0) {
+                const pluginParamsSchema = getV3CommandParams(experiment, 'plugin', cmd.plugin_name, cmd.command_name);
                 card.appendChild(el('div', { class: 'kv-line' }, el('span', { class: 'k' }, 'params:')));
                 for (const [pk, pv] of Object.entries(cmd.params)) {
-                    const ptype = typeof pv === 'number' ? 'number' : 'string';
-                    card.appendChild(renderEditableField(pk, [...cmdPath, 'params', pk], pv, ptype, { indent: true }));
+                    const fieldSchema = pluginParamsSchema && pluginParamsSchema[pk];
+                    const fallback = typeof pv === 'number' ? 'number' : 'string';
+                    card.appendChild(
+                        renderEditableField(
+                            pk,
+                            [...cmdPath, 'params', pk],
+                            pv,
+                            fieldSchema || fallback,
+                            { indent: true }
+                        )
+                    );
                 }
             }
 

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -64,7 +64,9 @@ const KNOWN_COMMAND_KEYS_BY_TYPE = {
         'mode',
         'frame_index',
         'frame_rate',
-        'gain'
+        'gain',
+        'gs_val',
+        'posX'
     ],
     wait: ['type', 'duration'],
     plugin: ['type', 'plugin_name', 'command_name', 'params']
@@ -273,16 +275,27 @@ function extractCommand(cmd) {
         throw new V3ParseError('Command entry must be a mapping', 'INVALID_SCHEMA');
     }
     const t = cmd.type;
-    const known = KNOWN_COMMAND_KEYS_BY_TYPE[t];
-    if (!known) {
+    if (typeof t !== 'string' || !t.trim()) {
         throw new V3ParseError(
-            'Unknown command type: ' +
-                JSON.stringify(t) +
-                ' (expected one of: ' +
-                Object.keys(KNOWN_COMMAND_KEYS_BY_TYPE).join(', ') +
-                ')',
+            'Command is missing a string `type` field',
             'INVALID_SCHEMA'
         );
+    }
+    const known = KNOWN_COMMAND_KEYS_BY_TYPE[t];
+    if (!known) {
+        // Forward-compat passthrough: round-trip unknown command types so
+        // future MATLAB additions (branch, loop, etc.) don't break import.
+        // The renderer shows these as read-only "raw" cards; export uses
+        // _doc.toString() which preserves the original YAML node verbatim.
+        const raw = { type: t, _rawUnknownType: true, _unknownKeys: {} };
+        for (const k of Object.keys(cmd)) {
+            if (k === 'type') continue;
+            raw[k] =
+                cmd[k] !== null && typeof cmd[k] === 'object'
+                    ? JSON.parse(JSON.stringify(cmd[k]))
+                    : cmd[k];
+        }
+        return raw;
     }
     const out = {};
     for (const k of known) {
@@ -576,7 +589,18 @@ function docMoveCommand(experiment, condIdx, fromIdx, toIdx) {
     if (fromIdx < 0 || fromIdx >= n || toIdx < 0 || toIdx >= n || fromIdx === toIdx) return;
 
     const cmdsNode = experiment._doc.getIn(['conditions', condIdx, 'commands'], true);
-    if (!cmdsNode || !Array.isArray(cmdsNode.items)) return;
+    if (!cmdsNode || !Array.isArray(cmdsNode.items)) {
+        // Doc/model divergence: the JS model claims a commands array at this
+        // condition but the YAML.Document has no matching seq node. Silent
+        // return would update the JS model while leaving the doc stale, then
+        // export incorrect YAML. Throw so the bug surfaces immediately.
+        throw new V3ParseError(
+            'docMoveCommand: doc/model divergence — no commands seq node at conditions[' +
+                condIdx +
+                ']',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
 
     const movedNode = cmdsNode.items.splice(fromIdx, 1)[0];
     cmdsNode.items.splice(toIdx, 0, movedNode);

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -283,8 +283,46 @@ checkThrows(
     'INVALID_SCHEMA'
 );
 
+// Unknown command types passthrough (forward-compat) — preserves type and all
+// fields so future MATLAB additions (branch, loop, etc.) round-trip safely.
+{
+    const yaml = [
+        'version: 3',
+        'experiment_info: {name: x}',
+        'rig: "/tmp/r.yaml"',
+        'experiment: [foo]',
+        'conditions:',
+        '  - name: foo',
+        '    commands:',
+        '      - {type: "branch", condition: "x > 0", goto: "next"}',
+        '      - {type: "wait", duration: 1}'
+    ].join('\n') + '\n';
+    const exp = parseV3Protocol(yaml);
+    const cmds = exp.conditions[0].commands;
+    check('passthrough: unknown type preserved', cmds[0].type, 'branch');
+    checkTrue('passthrough: _rawUnknownType flag set', !!cmds[0]._rawUnknownType);
+    check('passthrough: extra field condition preserved', cmds[0].condition, 'x > 0');
+    check('passthrough: extra field goto preserved', cmds[0].goto, 'next');
+    check('passthrough: subsequent known command still parses', cmds[1].type, 'wait');
+
+    // Round-trip via _doc.toString preserves unknown fields verbatim
+    const regen = generateV3Protocol(exp);
+    checkTrue('passthrough: "branch" survives in regen YAML', regen.includes('branch'));
+    checkTrue(
+        'passthrough: extra fields survive in regen YAML',
+        regen.includes('condition') && regen.includes('goto')
+    );
+
+    const reparsed = parseV3Protocol(regen);
+    const branch2 = reparsed.conditions[0].commands[0];
+    check('passthrough: reparse preserves type', branch2.type, 'branch');
+    check('passthrough: reparse preserves condition', branch2.condition, 'x > 0');
+    check('passthrough: reparse preserves goto', branch2.goto, 'next');
+}
+
+// Still reject malformed commands — missing type entirely
 checkThrows(
-    'rejects unknown command type',
+    'rejects command with no type field',
     () =>
         parseV3Protocol(
             [
@@ -295,7 +333,26 @@ checkThrows(
                 'conditions:',
                 '  - name: foo',
                 '    commands:',
-                '      - {type: "bogus", duration: 1}'
+                '      - {duration: 1}'
+            ].join('\n') + '\n'
+        ),
+    'INVALID_SCHEMA'
+);
+
+// Still reject malformed commands — non-string type (number, bool, null)
+checkThrows(
+    'rejects command with non-string type',
+    () =>
+        parseV3Protocol(
+            [
+                'version: 3',
+                'experiment_info: {name: x}',
+                'rig: "/tmp/r.yaml"',
+                'experiment: [foo]',
+                'conditions:',
+                '  - name: foo',
+                '    commands:',
+                '      - {type: 42, duration: 1}'
             ].join('\n') + '\n'
         ),
     'INVALID_SCHEMA'
@@ -845,6 +902,115 @@ console.log('\n--- Suite 11: command add / move / delete ---');
         JSON.stringify(exp.conditions[condIdx].commands.map((c) => c.type)),
         before
     );
+}
+
+// ─── Test Suite 12: B1 select-typed schema fields preserve types ──────────
+console.log('\n--- Suite 12: select-typed schema field type preservation ---');
+
+{
+    const yaml = [
+        'version: 3',
+        'experiment_info: {name: x}',
+        'rig: "/tmp/r.yaml"',
+        'experiment: [show]',
+        'conditions:',
+        '  - name: show',
+        '    commands:',
+        '      - type: controller',
+        '        command_name: trialParams',
+        '        pattern: "test.pat"',
+        '        pattern_ID: 1',
+        '        duration: 5',
+        '        mode: 2',
+        '        frame_index: 1',
+        '        frame_rate: 60',
+        '        gain: 0',
+        '      - type: controller',
+        '        command_name: setColorDepth',
+        '        gs_val: 16',
+        '      - type: plugin',
+        '        plugin_name: log',
+        '        command_name: log',
+        '        params:',
+        '          message: "starting"',
+        '          level: "DEBUG"'
+    ].join('\n') + '\n';
+    const exp = parseV3Protocol(yaml);
+    const cmds = exp.conditions[0].commands;
+
+    // 1. Initial types preserved through parse
+    check('select: trialParams.mode is number', typeof cmds[0].mode, 'number');
+    check('select: trialParams.mode value', cmds[0].mode, 2);
+    check('select: setColorDepth.gs_val is number', typeof cmds[1].gs_val, 'number');
+    check('select: setColorDepth.gs_val value', cmds[1].gs_val, 16);
+    check('select: log.level is string', typeof cmds[2].params.level, 'string');
+    check('select: log.level value', cmds[2].params.level, 'DEBUG');
+
+    // 2. Schema lookup returns the right type info
+    const trialParamsSchema = getV3CommandParams(exp, 'controller', null, 'trialParams');
+    check('select: trialParams.mode schema.type', trialParamsSchema.mode.type, 'select');
+    check('select: trialParams.mode schema.options[0].value type',
+        typeof trialParamsSchema.mode.options[0].value, 'number');
+
+    const setColorDepthSchema = getV3CommandParams(exp, 'controller', null, 'setColorDepth');
+    check('select: setColorDepth.gs_val schema.type', setColorDepthSchema.gs_val.type, 'select');
+    check('select: setColorDepth.gs_val schema.options[0].value type',
+        typeof setColorDepthSchema.gs_val.options[0].value, 'number');
+
+    const logSchema = getV3CommandParams(exp, 'plugin', 'log', 'log');
+    check('select: log.level schema.type', logSchema.level.type, 'select');
+    check('select: log.level schema.options[0].value type',
+        typeof logSchema.level.options[0].value, 'string');
+
+    // 3. docSet with the right type preserves it through round-trip
+    docSet(exp, ['conditions', 0, 'commands', 0, 'mode'], 4);
+    docSet(exp, ['conditions', 0, 'commands', 1, 'gs_val'], 2);
+    docSet(exp, ['conditions', 0, 'commands', 2, 'params', 'level'], 'WARNING');
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    const r = reparsed.conditions[0].commands;
+    check('select: round-trip mode stays number', typeof r[0].mode, 'number');
+    check('select: round-trip mode value', r[0].mode, 4);
+    check('select: round-trip gs_val stays number', typeof r[1].gs_val, 'number');
+    check('select: round-trip gs_val value', r[1].gs_val, 2);
+    check('select: round-trip level stays string', typeof r[2].params.level, 'string');
+    check('select: round-trip level value', r[2].params.level, 'WARNING');
+
+    // 4. The exported YAML should NOT quote the numeric selects
+    const regen = generateV3Protocol(exp);
+    checkTrue(
+        'select: regen YAML has unquoted numeric mode',
+        /mode:\s*4\b/.test(regen)
+    );
+    checkTrue(
+        'select: regen YAML has unquoted numeric gs_val',
+        /gs_val:\s*2\b/.test(regen)
+    );
+}
+
+// ─── Test Suite 13: docMoveCommand throws on doc/model divergence ──────────
+console.log('\n--- Suite 13: docMoveCommand doc/model divergence is loud ---');
+
+{
+    // Synthesize divergence: parse normally, then nuke the commands node from
+    // the YAML.Document while leaving the JS model intact. docMoveCommand
+    // should surface this as a thrown error, not a silent no-op.
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const condIdx = exp.conditions.findIndex((c) => c.name === 'arena check');
+    const condNode = exp._doc.getIn(['conditions', condIdx], true);
+    // Delete the commands key from the YAML.Document only
+    condNode.delete('commands');
+
+    let threw = false;
+    let code = null;
+    try {
+        docMoveCommand(exp, condIdx, 0, 1);
+    } catch (e) {
+        threw = true;
+        code = e.code;
+    }
+    checkTrue('divergence: docMoveCommand throws', threw);
+    check('divergence: error code is DOC_MODEL_DIVERGENCE', code, 'DOC_MODEL_DIVERGENCE');
 }
 
 // ─── Results ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Tier 1 of the post-v0.2 next-step plan (`.claude/plans/read-docs-development-v3-editor-handoff-composed-cosmos.md`). Four small items grouped as one PR to clear the correctness backlog from the Codex cross-review of PR #63 before the A–D editor work lands.

- **CI hardening** — `validate-protocol-roundtrip.yml` drops the `npm ci || npm install` fallback (was masking lockfile drift) and adds `package-lock.json` to both push + pull_request path filters so lockfile-only dependency bumps actually trigger validation.
- **`docMoveCommand` doc/model divergence is loud** — `js/protocol-yaml-v3.js:567` now throws `DOC_MODEL_DIVERGENCE` instead of silently returning when the YAML.Document is missing the commands seq node. Silent return would have updated the JS model while leaving the doc stale → wrong export.
- **B5 — unknown command-type passthrough** — `extractCommand` preserves unknown command types (`type: "branch"`, `type: "loop"`, etc.) with `_rawUnknownType: true` so future MATLAB additions round-trip safely. `renderCommandCard` shows them as read-only "raw" cards (orange badge, no ↑↓✕ buttons) with an "edit in YAML" hint. Still rejects missing or non-string `type` fields.
- **B1 — `select` schema → real dropdown** — `renderEditableField` now accepts a schema object and renders `<select>` for `schema.type === 'select'`, coercing the picked value back to the option's original type. Fixes silent string-vs-number drift for `controller.trialParams.mode`, `controller.setColorDepth.gs_val`, and `plugin log.level`. Expanded controller known-keys to include `gs_val` and `posX` so those commands now round-trip fully through the data model.

## Test plan

- [x] `npm test` — arena 10/10, v2 137/137, v3 **243/243** (was 210, +33 new assertions)
  - Suite 7: passthrough round-trip for unknown command type + missing-type + non-string-type rejections
  - Suite 12: select-typed schema round-trip — `mode`, `gs_val`, `level` preserve their original types through `docSet` + export + reparse; regen YAML has `mode: 4` and `gs_val: 2` unquoted
  - Suite 13: `docMoveCommand` throws `DOC_MODEL_DIVERGENCE` on synthetic doc/model split
- [x] Browser smoke (localhost:8080): load `v3_canonical_a.yaml` → click `sine_grating_60deg_fine_gs16` → mode dropdown shows both options, changing to Mode 4 → Closed Loop and exporting writes `mode: 4` (unquoted numeric) in the YAML
- [x] Browser smoke: import a synthetic YAML containing `type: "branch"` → renders as `BRANCH [raw]` card with read-only `condition` + `goto` fields, no action buttons; export preserves `{ type: "branch", condition: "trial > 5", goto: "next_block" }` verbatim
- [ ] Hard-refresh on GitHub Pages after merge to confirm no ES6 cache surprises

Footer: `v3 Experiment Designer v0.2.1 | 2026-05-27 14:03 ET`

🤖 Generated with [Claude Code](https://claude.com/claude-code)