### PR TITLE
docs(v3): D4 cross-library import design + review history (deferred)

### DIFF
--- a/docs/development/v3-d4-design-reviews.md
+++ b/docs/development/v3-d4-design-reviews.md
@@ -1,0 +1,167 @@
+# D4 design — Codex cross-review (preserved)
+
+This document preserves the round-2 Codex pressure-test of `v3-d4-design.md` so
+the synthesis isn't lost when D4 is picked back up. Two rounds of review ran
+on the design before it landed on the shelf.
+
+**Status outcome (2026-05-27):** D4 deferred. Pivoting to Phase 4 (sequence
+drag/drop) first; the design + this review history sit on the shelf until the
+order is reassessed.
+
+---
+
+## Evolution from rev 1 → rev 2 (round 1 review)
+
+The first version of `v3-d4-design.md` proposed a **merge-by-default** import:
+when an imported condition references `&dur_short` and the user's doc also has
+`&dur_short`, the design tried to detect equality (structural comparison) and
+either merge or rename. Round 1 review caught:
+
+- The anchor-resolution API was wrong — used name-based lookup instead of
+  `alias.resolve(doc)`, which would silently bind to the wrong anchor value on
+  duplicate names.
+- `NodeBase.toJS()` requires a document argument; the equality check would have
+  thrown.
+- `docInsertCondition` (existing) builds nodes from JS objects, destroying
+  imported comments and aliases. Needed new node-based helpers.
+- Missing helpers for `variables:` and `plugins:` sections (and creating them
+  when absent — `v3_no_variables.yaml` fixture proves the need).
+- "Cross-condition trial reference" conflict was wrong scope (blocks/intertrials
+  live in `experiment:`, not `conditions:`).
+- "Pattern-missing" conflict had no source-of-truth — there's no validator for
+  pattern-library contents in the current codebase.
+- Bigger product question from Codex-adv: anchor name collisions in cross-lab
+  YAMLs are usually **semantic** (same name, mechanically different value), not
+  cosmetic. Silent merge by name+value equality is the worst-case footgun.
+
+Rev 2 switched the product shape to **namespaced-default**: imported anchors
+get a source-filename prefix (e.g., `&sibling_lab__dur_short`), imported plugins
+get the same treatment, imported conditions keep their names (with suggested
+suffix on collision). Eliminates the entire "value equality merge" path. Also
+applied all the API fixes, dropped the wrong-scope conflicts, moved staging
+into a new `js/v3-import.js` module so Node tests can exercise it, and bumped
+realistic milestone estimates from 3 days to 5.
+
+Rev 2 is the current state of `v3-d4-design.md`.
+
+---
+
+## Round 2 reconciliation (against rev 2 — the current doc)
+
+### Where all three voices agree
+
+- **Staging-buffer substrate (Option B) is correct.** Settled in round 1; no
+  revision needed in round 2.
+- **Cycle detection must use a visited-set, not depth-cap.** Rev 2's depth-of-10
+  cap would reject a legitimate chain of 11 anchors and doesn't actually prevent
+  cycles. Fix: track visited anchor names (or source node identities) in a Set
+  and break when revisiting.
+- **Per-batch dependency tracking, not per-item.** If two staged conditions
+  reference the same source anchor `&dur_short`, the per-item `anchorsToImport`
+  in rev 2 would try to insert two copies. Need a global dependency registry
+  across the whole batch.
+
+### New bugs in rev 2 (Codex-std caught)
+
+- **Commit step doesn't rewrite the cloned condition's `name:` field.** Rev 2
+  §5 step 5 clones the condition node, rewires aliases, splices in. But it
+  never rewrites the cloned node's `name:` from `originalName` to `targetName`.
+  The JS mirror would say `arena check_2` while the YAML still has
+  `name: "arena check"`. Existing `docCloneCondition` has this rewrite — D4
+  needs the same.
+- **Transitive anchor cloning uses an empty rewrite map.** Rev 2 calls
+  `cloneNodeAcrossDocs(srcValueNode, yoursDoc, {})` for value-node clones — but
+  the value nodes themselves may contain aliases that need rewriting too. The
+  fix: build `aliasRewriteMap` once after the closure walk completes; use the
+  same map for the condition AND all of its value-node clones.
+- **Aliases must appear after their anchors in document order.** yaml@2 enforces
+  this at stringify time. Rev 2's closure walk produces
+  dependency-after-dependent insertion order naturally (we walk the condition
+  first, then its anchors, then their nested anchors), so insertion needs an
+  explicit topological sort.
+- **"Broken alias = informational" is impossible.** `parseV3Protocol` calls
+  `doc.toJS()` immediately, which throws on unresolved aliases at the source.
+  So a source with a broken alias would never even enter import mode. Make
+  broken source aliases a hard-block, drop the "informational" framing.
+- **`plugin_name` can itself be alias-bound.** If a condition has
+  `plugin_name: *camera_plugin` and the anchor's value is the literal string
+  `"camera"`, namespacing the *declaration* to `sibling__camera` but leaving
+  the alias resolving to `"camera"` means the condition references a plugin
+  that doesn't exist. Block this case at staging time for v1.
+- **Lock should guard UI handlers, not `pushUndo()` globally.** Rev 2 said
+  `pushUndo` triggers respect the import lock — but commit *itself* calls
+  pushUndo. Globally locking pushUndo would break commit's own undo snapshot.
+  Lock via UI event handlers instead.
+
+### Bigger product question (Codex-adv pushed hard)
+
+- **Plugin namespacing as default is the wrong call (vs anchors).** Anchors are
+  data aliases — safe to namespace. Plugins are *runtime resources* representing
+  physical hardware (cameras, controllers, serial ports). Duplicating `camera`
+  → `sibling__camera` doesn't isolate the hardware; both YAML entries might
+  point at the same physical device. Two declarations for one device is a real
+  runtime problem.
+  - **Recommendation:** anchors namespace by default; plugins *merge* by default
+    when `matlab.class` + `config` match, namespace only on mismatch. This
+    asymmetry is honest — anchors and plugins have different operational
+    semantics. Cost: brings back a small structural-equality path scoped to
+    plugins only.
+
+- **Auto-add bare refs to sequence loses block/repetition/intertrial context.**
+  Source condition may have run with `repetitions: 3` and `randomize: true` in
+  its original sequence; auto-bare-ref strips all of that. Don't change the
+  default (orphan conditions are worse), but make the lossy nature visible in
+  the checkbox label: "Append bare refs to sequence (source block/repetition
+  context is not preserved)."
+
+- **Defer D4 until Phase 5 (Variables editor + rename cascade) ships.** D4
+  creates the cleanup problem that Phase 5 solves. Doing them in the right
+  order (Phase 5 first) means D4's prefix-noise is fixable in-tool. Doing D4
+  first means users live with permanent prefix clutter until Phase 5 ships.
+  - This is the strongest scope-level argument from round 2. Combined with
+    "Phase 4 (drag/drop) is also a more universally-needed feature," the case
+    for **pivoting to Phase 4 then Phase 5 first** is strong. That's the
+    decision recorded at the top of this doc.
+
+### Fix list that must apply before any D4 code lands
+
+Even if D4 is picked up later and the rev 2 substrate is retained, the design
+doc itself needs these corrections first:
+
+1. Commit must rewrite the cloned condition node's `name:` field to `targetName`.
+2. `cloneNodeAcrossDocs` must use the *same* `aliasRewriteMap` across the
+   condition AND all of its value-node clones — not empty maps for each.
+3. Topological sort of imported anchors by dependency order before insertion.
+4. Per-batch dependency registry (anchors + plugins shared across staged items,
+   not per-item).
+5. Visited-set cycle detection (not depth-cap).
+6. Block broken-alias source YAMLs at enter-import-mode (probably already
+   happens via parse-throw).
+7. Block alias-bound `plugin_name` at staging time.
+8. Lock via UI handlers, not via global `pushUndo()` suppression.
+9. Fix `sortedJson` pseudo-code (if structural equality is kept for plugin
+   merge).
+10. Add cross-buffer name collision check.
+11. **If plugin-merge-by-default is adopted** (recommended), redesign §5 and §6
+    around it. Anchors namespace by default; plugins merge when class+config
+    match.
+
+### What to do when D4 is picked up again
+
+1. Re-read `v3-d4-design.md` (rev 2) — the staging buffer + module-first split
+   + namespaced-anchor default are still the right substrate.
+2. Apply the fix list above to produce rev 3.
+3. Adopt the plugin-merge-by-default asymmetry.
+4. **Verify Phase 4 (sequence drag/drop) and Phase 5 (Variables editor + rename
+   cascade) ship first** — D4's biggest mitigations depend on them.
+5. Re-run Codex on rev 3 before starting Milestone 1.
+
+---
+
+## Why this artifact exists
+
+The raw Codex outputs lived under `.codex-review/` (gitignored). Without checking
+the synthesis into the repo, the analysis would have been lost the moment the
+branch was deleted or the working tree wiped. Future sessions that touch D4 can
+read this doc + `v3-d4-design.md` and pick up exactly where round 2 left off,
+without re-deriving the substrate decisions from scratch.

--- a/docs/development/v3-d4-design.md
+++ b/docs/development/v3-d4-design.md
@@ -1,0 +1,480 @@
+# D4 — Cross-Library Import Design Doc (revision 2)
+
+**Status:** **DEFERRED** (2026-05-27). Phase 4 (sequence drag/drop) takes
+priority; D4 will be reassessed after Phase 4 + Phase 5 (Variables editor +
+rename cascade) ship. See `v3-d4-design-reviews.md` for the round-2 review
+that drove the deferral.
+
+**When D4 is picked up again, this doc still needs corrections.** The fix list
+is in `v3-d4-design-reviews.md` — read that *before* using this doc as the
+implementation spec. The biggest one: plugin namespacing should NOT be the
+default; plugins should merge-when-class+config-match.
+
+**Owner:** Next session that touches D4.
+**History:**
+- rev 1 (2026-05-27): merge-by-default, monolithic helpers, optimistic milestones.
+- **rev 2 (2026-05-27, current):** namespaced-default, module-first helpers, alias-node API, transitive closure, revised milestones.
+- Round 2 review (2026-05-27): caught further bugs (see `v3-d4-design-reviews.md`); D4 deferred.
+**Supersedes:** the D4 sketch in `docs/development/v3-editor-handoff.md` (lines 209–260).
+
+---
+
+## 1. Why we're stopping to design
+
+D4 is the editor's first feature where *two parsed `YAML.Document`s coexist in memory simultaneously*. Every previous feature mutates one document at a time. D4 lets the user open a *second* "theirs" YAML, browse its conditions side-by-side, and copy selected ones into "yours."
+
+This crosses a substrate boundary because:
+
+- **`yaml@2`'s anchors are document-local.** A `&dur_short` in `theirs._doc` is unrelated to a `&dur_short` in `yours._doc`. The `Alias` node `*dur_short` carries only a string `source` — it dangles the moment its containing node lands in a different document.
+- **`node.clone(schema)` is intra-document and shallow on `Alias` nodes.** It copies the `source` string but does not rewire it.
+- **`yaml@2` resolves aliases by *last matching anchor before the alias in document order*, not by a global anchor table.** Name-based lookup is wrong; alias-node resolution via `alias.resolve(doc)` is the correct API.
+- **The path-based mirror model works because paths are stable.** They stop being stable the moment a user can stage selections from one doc and commit a subset.
+
+This doc is the substrate reassessment Codex flagged in the PR #63 review. The goal of D4 itself is unchanged: let a user import conditions from a sibling lab's protocol (or an earlier version of their own) without rewriting them by hand, preserving the anchors and plugin declarations those conditions depend on.
+
+---
+
+## 2. Constraints and assumptions
+
+- **Single user, single tab.** No multi-user reconciliation, no real-time collaboration.
+- **Hand-edited YAML is the user's source of truth.** The editor must preserve anchors, comments, formatting on round-trip. Load-bearing for every architectural choice so far.
+- **`yaml@2.9.0` is the substrate.** Vendored in PR #68. Replacing it is out of scope.
+- **The JS-side mirror is for UI rendering only.** All mutations go through helpers that touch `_doc` first.
+- **Imports are additive.** D4 brings conditions *into* the user's document. It does not modify "theirs."
+- **Anchor namespaces in cross-lab YAML are not guaranteed cosmetic.** Two labs may use `&dur_short` for *semantically different* values. Silent merge based on name + value equality is a footgun. *(Driver of rev 2's namespaced-default design.)*
+
+---
+
+## 3. Substrate: staging buffer with namespaced-default imports
+
+### The substrate decision (Option B, staging buffer)
+
+Settled in rev 1; no revision needed. The user enters import mode, browses "theirs," adds candidate conditions to a *staging buffer*, optionally adjusts what their imported names look like, then **Commit** in one batch (one undo step) or **Cancel** to discard. The buffer never mutates `yours._doc` until commit. Cross-doc primitives + commit pipeline live in a new `js/v3-import.js` module so Node tests can exercise them directly.
+
+### The product-shape decision (namespaced-default)
+
+When the user adds a "theirs" condition to the buffer, the defaults are:
+
+- **Imported condition name** keeps its original name unless that name already exists in "yours." Conditions are user-facing and renaming the condition is more disruptive than namespacing — so for conditions we accept the risk of a name suggestion-with-suffix (e.g., `arena check_2`) on collision and don't prefix by default.
+- **Imported anchor names** get a **source prefix** by default (e.g., `&sibling__dur_short`). The user must *opt in* to merging with an existing anchor.
+- **Imported plugin names** get a **source prefix** by default (e.g., `sibling__camera`). The user must *opt in* to merging with an existing plugin entry.
+
+The source prefix derives from the imported filename, sanitized to anchor-safe characters and stripped of extension: `sibling_lab.yaml` → `sibling_lab__`. User can override the prefix when entering import mode (default value pre-filled from the filename, editable).
+
+**Why this defaults to namespacing for anchors/plugins but not conditions:**
+- Conditions are *named tasks* the user picks from a list. A user importing "arena check" from a sibling lab wants to see "arena check" or "arena check_2" — not "sibling__arena check," which would just be confusing.
+- Anchors are *internal references* the user mostly doesn't see except when something breaks. A user importing condition X doesn't care if X's internal `*dur_short` reference is to `&dur_short` or to `&sibling__dur_short` — they just want X to work. The cost of `sibling__` prefix is "slightly noisier YAML"; the benefit is no silent semantic merge.
+- Plugins are *infrastructure* the user declares in `plugins:` but rarely thinks about command-by-command. Similar tradeoff as anchors.
+
+**What namespaced-default eliminates:**
+- "Anchor value mismatch" as a conflict kind — the import gets its own anchor namespace, no comparison needed.
+- "Plugin class mismatch" as a conflict kind — the import gets its own plugin entry, no compatibility check needed.
+- Structural-equality checks via `toJS(doc)` + `JSON.stringify` — no longer needed for the default path. (Still optional if the user *explicitly* asks to merge.)
+- Duplicate anchor names in "theirs" — each anchor gets a unique prefixed name on the user's side, so source-side duplicates don't matter.
+
+**What namespaced-default keeps as conflicts:**
+- **Condition name collision** (still real — conditions aren't prefixed). Resolution: suggest `<name>_2`, user accepts or edits.
+- **Unknown command type** (informational only — preserved as raw card).
+
+**What namespaced-default trades away:**
+- Slightly noisier YAML on import (`&sibling_lab__dur_short` vs `&dur_short`).
+- The "merge equivalent anchors" optimization that rev 1 had as default is now an opt-in. Users who really do want to share anchors between source and target click a "merge with existing &dur_short" toggle per-anchor.
+
+---
+
+## 4. Cross-doc primitives — the right API
+
+These live in a new `js/v3-import.js` module (so Node tests can exercise them) and are exported alongside the existing `js/protocol-yaml-v3.js` helpers.
+
+### Primitive: walk a node tree for Alias references
+
+```js
+function collectAliasReferences(rootNode) {
+    const aliases = [];  // Alias node refs
+    YAML.visit(rootNode, {
+        Alias(_, node) { aliases.push(node); }
+    });
+    return aliases;
+}
+```
+
+Works on any node tree (`YAML.visit` accepts a subtree, not just a Document — confirmed against `js/vendor/yaml/browser/dist/visit.js`).
+
+### Primitive: resolve an Alias to its actual source-doc value node
+
+```js
+function resolveAlias(aliasNode, sourceDoc) {
+    return aliasNode.resolve(sourceDoc) || null;
+}
+```
+
+This is the correct API per `js/vendor/yaml/browser/dist/nodes/Alias.js`. It implements yaml@2's last-wins resolution semantics. Returning `null` indicates an unresolvable alias (broken source YAML).
+
+### Primitive: clone a node tree across documents with explicit alias rewriting
+
+```js
+function cloneNodeAcrossDocs(srcNode, targetDoc, aliasRewriteMap) {
+    // aliasRewriteMap: { oldAnchorName: newAnchorName, ... }
+    const cloned = srcNode.clone(targetDoc.schema);  // intra-doc clone; aliases still dangle
+    YAML.visit(cloned, {
+        Alias(_, node) {
+            if (aliasRewriteMap[node.source]) {
+                node.source = aliasRewriteMap[node.source];
+            }
+        }
+    });
+    return cloned;
+}
+```
+
+`clone()` is intra-document; `cloned` lives logically in the target doc but its `Alias.source` strings still point at the *source* doc's anchor names. We rewrite them per the map provided. After rewriting, the cloned node's aliases will resolve against the target doc's anchors (which we'll insert separately).
+
+### Primitive: insert a top-level section if it doesn't exist
+
+```js
+function ensureTopLevelSection(doc, key, defaultShape) {
+    // defaultShape: 'map' or 'seq'
+    const existing = doc.getIn([key], true);
+    if (existing) return existing;
+    const node = doc.createNode(defaultShape === 'seq' ? [] : {});
+    doc.setIn([key], node);
+    return doc.getIn([key], true);
+}
+```
+
+Needed because some target YAMLs don't have a `variables:` section (e.g., `v3_no_variables.yaml`). Import must create it before splicing.
+
+### Primitive: splice an already-cloned condition node into the target
+
+```js
+function docInsertConditionNode(experiment, clonedCondNode, derivedJsCond) {
+    const condsNode = experiment._doc.getIn(['conditions'], true);
+    if (!condsNode || !Array.isArray(condsNode.items)) {
+        throw new V3ParseError('docInsertConditionNode: conditions seq missing', 'DOC_MODEL_DIVERGENCE');
+    }
+    condsNode.items.push(clonedCondNode);
+    experiment.conditions.push(derivedJsCond);
+}
+```
+
+Distinct from existing `docInsertCondition`, which builds a fresh YAML node from JS objects (losing imported comments/style). The new helper takes the already-cloned-and-rewired node and just splices.
+
+Similar parallel helpers: `docInsertVariableNode`, `docInsertPluginNode`.
+
+### Primitive: structural equality (only used on explicit merge path)
+
+```js
+function yamlNodeStructuralEquals(aNode, aDoc, bNode, bDoc) {
+    try {
+        const a = sortedJson(aNode.toJS(aDoc));
+        const b = sortedJson(bNode.toJS(bDoc));
+        return a === b;
+    } catch {
+        return false;  // unresolvable alias → not equal
+    }
+}
+
+function sortedJson(value) {
+    // JSON.stringify with deterministic key order — sort each object's keys
+    return JSON.stringify(value, Object.keys(value).sort?.bind(Object.keys(value)) || null);
+    // (Implementation note: use a custom replacer that sorts object keys recursively.
+    //  Many libraries provide this; we'll handroll a small one.)
+}
+```
+
+Only used when the user *explicitly* asks to merge an imported anchor with an existing one. Catches `toJS()` errors from unresolved aliases. Sorts keys to avoid key-order false-negatives.
+
+---
+
+## 5. Anchor handling — concrete algorithm
+
+When the user adds a condition `srcCond` (a YAMLMap from `theirs._doc`) to the staging buffer:
+
+1. **Find all aliases the condition uses.** `aliases = collectAliasReferences(srcCond)`.
+
+2. **For each `aliasNode` in `aliases`:**
+   - **Resolve to source value node.** `srcValueNode = resolveAlias(aliasNode, theirsDoc)`.
+   - If `srcValueNode` is null: mark as `{kind: 'broken-alias', sourceName: aliasNode.source}` — informational; the imported alias will dangle in `yours._doc` and trigger an existing `unused-anchor` warning on export.
+   - **Record the planned anchor name.** Default: `<prefix> + aliasNode.source` (e.g., `sibling_lab__dur_short`). User can override per-anchor in the staging UI.
+   - **Record dependencies.** Each `srcValueNode` may itself contain Aliases. Recursively collect them.
+
+3. **Transitive closure.** For each new source value node discovered in step 2, run steps 1–2 on it. Iterate until no new anchors discovered. Cap depth at 10 to detect cycles.
+
+4. **Build the import plan for this condition:**
+   ```js
+   {
+       sourceCondNode: srcCond,
+       originalName: 'arena check',
+       targetName: 'arena check',  // user-editable if collision
+       conditionNameCollision: false | 'arena check_2',
+       anchorsToImport: [
+           { srcAnchor: 'dur_short', srcValueNode: <Node>, plannedName: 'sibling_lab__dur_short', action: 'add', mergeWith: null },
+           ...
+       ],
+       pluginsToImport: [
+           { srcName: 'camera', srcEntry: <plugin object>, plannedName: 'sibling_lab__camera', action: 'add', mergeWith: null },
+           ...
+       ],
+       unknownCommandTypes: ['branch'],  // informational
+       brokenAliases: []  // informational
+   }
+   ```
+
+5. **Commit translates the plan into mutations:**
+   - For each `anchorsToImport[i]`:
+     - `cloneNodeAcrossDocs(srcValueNode, yoursDoc, {})` — recursive aliases inside the value node also need their `source` strings rewritten per the user's chosen names.
+     - Tag the cloned value node with `clonedValueNode.anchor = plannedName`.
+     - Insert into `yours._doc`'s `variables:` map with key `plannedName` (via `ensureTopLevelSection` then `docInsertVariableNode`).
+   - For each `pluginsToImport[i]`:
+     - Clone the plugin entry node, rewrite any internal aliases, tag with `plannedName`.
+     - Insert into `yours._doc`'s `plugins:` seq via `docInsertPluginNode`.
+   - For the condition itself:
+     - Build the `aliasRewriteMap` from `anchorsToImport` (`{srcAnchor → plannedName}`).
+     - `cloneNodeAcrossDocs(srcCond, yoursDoc, aliasRewriteMap)`.
+     - Rewrite any `plugin_name` strings inside the cloned condition's commands per `pluginsToImport`.
+     - Splice via `docInsertConditionNode`.
+
+6. **Optional: append bare refs to sequence.** A checkbox in the staging UI (default ON) appends a bare ref to `yours.sequence` for each committed condition, via the existing `docAppendSequenceEntry`. See §7 for rationale.
+
+---
+
+## 6. Conflict kinds (much reduced post-namespacing)
+
+The aggressive conflict catalog of rev 1 collapses to two real conflicts:
+
+- **Condition name collision.** Imported condition name already exists in `yours.conditions[]`. Resolution: suggest `<name>_2`, `_3`, etc. User can edit. Mandatory before commit.
+- **Plugin namespace collision** (rare). Imported plugin's prefixed name (`sibling__camera`) somehow already exists in `yours.plugins[]` — would only happen if the user had previously imported from the same source and renamed. Resolution: bump prefix to `sibling__camera_2`. Mandatory before commit.
+
+Plus three informational annotations (not blocking conflicts):
+
+- **Unknown command type** in an imported condition — preserved as raw card, shows up in `collectExportWarnings` after commit. No resolution required.
+- **Broken alias in source YAML** (alias points at a non-existent anchor in `theirs`) — informational. The cloned node will have a dangling alias; `collectExportWarnings` will flag it post-commit. User can decide whether to import anyway.
+- **Pattern file reference** like `pattern: "lisa_specific.pat"` — soft warning ("verify this pattern exists on your machine"). No blocking behavior.
+
+Removed conflict kinds (vs rev 1):
+
+- ❌ "Anchor value mismatch" — eliminated by namespacing.
+- ❌ "Anchor name collision" — eliminated by namespacing.
+- ❌ "Plugin class mismatch" — eliminated by namespacing.
+- ❌ "Undeclared plugin" — irrelevant once we import plugin declarations alongside.
+- ❌ "Override existing anchor" — removed entirely (was dangerous + underspecified per Codex-std).
+- ❌ "Cross-condition trial reference" — wrong scope (blocks/intertrials live in `experiment:`, not `conditions:`).
+
+---
+
+## 7. Staging buffer — shape and lifecycle
+
+### Data shape
+
+```js
+const staging = {
+    src: { doc, conditions, variables, plugins, filename },  // parsed "theirs"
+    prefix: 'sibling_lab__',  // user-editable, derived from filename
+    items: [
+        // one entry per condition the user has chosen to import
+        {
+            sourceCondIdx: 4,
+            originalName: 'arena check',
+            targetName: 'arena check',  // editable for collision
+            conditionNameCollision: false | <suggestion>,
+            anchorsToImport: [...],  // see §5 step 4
+            pluginsToImport: [...],
+            unknownCommandTypes: [...],
+            brokenAliases: [...]
+        },
+        ...
+    ],
+    addBareRefs: true,  // checkbox state, default true
+    locked: true  // "yours" pane is read-only while in import mode
+};
+```
+
+### Lifecycle
+
+- **Enter import mode** → file picker → parse + reject if duplicate anchors in source (preflight) → `staging.src` populated, three-pane layout swaps in, `staging.locked = true` disables `+ Add`, `dup`, inspector edits in "yours."
+- **Add to buffer** → on ← click, compute the import plan for that source condition (§5 steps 1–4). Push into `staging.items`.
+- **Adjust per-item** → user can edit the planned target name, individual anchor names, individual plugin names from the inspector. Each adjustment re-validates collision in `staging`. Bulk options (toolbar): "Reset all to default prefixes," "Use shorter prefix" (prompt for new prefix string, recompute all planned names).
+- **Commit** → `pushUndo()` once → walk `staging.items[]` and apply §5 step 5 for each → if `addBareRefs`, append refs via existing helper → exit import mode → `selection` points to the first committed condition.
+- **Cancel** → discard `staging`, exit import mode, restore the two-pane layout. No mutations.
+
+### Re-using existing renderers (with caveats from Codex-std)
+
+`renderLibrary` is too tightly bound to the global `experiment` for direct reuse. Tier 2's extraction-pattern applies: lift a `renderConditionList(conditions, opts)` helper that takes the conditions array + display options (`editable`, `showUsage`, `onClick`, `extraButtons`). Both the existing library and the new "theirs" library use the new helper. ~½ day of refactor in Milestone 3.
+
+### Auto-add bare refs (the orphan problem)
+
+Without auto-add, imported conditions land in `yours.conditions[]` but aren't referenced from `yours.sequence`. The user can't actually *run* the imported condition without editing YAML by hand (no "+ Use in sequence" UI for an existing condition exists yet). Solution: a default-on checkbox in the staging buffer ("Append bare refs to sequence after commit"). Toggleable per-session. If user unchecks it, the imported conditions show as unused in the warnings banner post-commit — they know what they're getting into.
+
+### Locking "yours" during import
+
+While `staging.locked === true`:
+- `+ Add condition` button is disabled.
+- Library row dup buttons are disabled.
+- Inspector edits return early (no commit, show a tooltip "import mode — finish or cancel first").
+- Export button is disabled.
+- `addCondBtn`, `exportBtn`, command-card actions, `pushUndo` triggers all respect the flag.
+
+This avoids the stale-resolution problem Codex-adv flagged: staged target-name suggestions become invalid if "yours" mutates underneath.
+
+---
+
+## 8. Three-pane import-mode UI
+
+```
+┌──────────────┬─────────────────────┬─────────────────┐
+│ LIBRARY      │ LIBRARY (theirs) — │ INSPECTOR        │
+│ (yours)      │ read-only           │ — staging-item   │
+│              │                     │   detail OR      │
+│ locked       │      ←              │   theirs-preview │
+│              │      arrows         │                  │
+│              │                     │                  │
+└──────────────┴─────────────────────┴─────────────────┘
+[Top banner: Importing from sibling_lab.yaml  Prefix: sibling_lab__ [edit]  3 staged  [✓ Add to sequence]  [Cancel] [Commit]]
+```
+
+Layout maps onto existing zones:
+- "Yours" library → existing `libraryZone` (re-rendered with `locked` class for muted styling).
+- "Theirs" library → existing `sequenceZone` repurposed for import mode (swap the contents, not the DOM node).
+- Inspector → existing `inspectorZone`, renders either a staging-item detail panel (when buffer item selected) or a read-only "theirs" condition preview (when a "theirs" row hovered/selected).
+
+Selection scope: a new `selection.kind = 'staging-item'` with `stagingIdx`, plus `selection.kind = 'theirs-preview'` with `theirsCondIdx`. The existing `selection.kind` values are still supported but disabled-via-locking.
+
+The top banner above the panes carries the global import-mode controls (prefix edit, add-to-sequence toggle, Commit/Cancel).
+
+---
+
+## 9. Incremental implementation order (revised estimates)
+
+### Milestone 1 — Cross-doc primitives + new node-based helpers (~1 day)
+
+In a new module `js/v3-import.js`:
+- `collectAliasReferences(node) → AliasNode[]`
+- `resolveAlias(alias, doc) → ValueNode | null`
+- `cloneNodeAcrossDocs(srcNode, targetDoc, aliasRewriteMap) → clonedNode`
+- `yamlNodeStructuralEquals(aNode, aDoc, bNode, bDoc) → boolean`
+- `sortedJson(value)` helper.
+
+Add to `js/protocol-yaml-v3.js`:
+- `ensureTopLevelSection(experiment, key, defaultShape)`
+- `docInsertConditionNode(experiment, clonedCondNode, derivedJsCond)`
+- `docInsertVariableNode(experiment, name, clonedValueNode)`
+- `docInsertPluginNode(experiment, clonedPluginNode)`
+
+Tests:
+- Suite for the primitive functions: cross-doc clone with rewrite, alias resolution against last-wins ordering, transitive walks find nested anchors.
+- Suite for the new doc helpers: insert into existing `variables:`, insert when `variables:` is absent (creates section), round-trip stable.
+
+### Milestone 2 — Staging buffer + commit pipeline (no UI yet) (~1.5 days)
+
+In `js/v3-import.js`:
+- `createStagingBuffer(srcDoc, srcFilename, opts) → staging`
+- `addToStaging(staging, sourceCondIdx, yoursExperiment) → updated staging`
+- `removeFromStaging(staging, itemIdx) → updated staging`
+- `setStagingPrefix(staging, newPrefix) → updated staging` (recomputes all planned anchor/plugin names)
+- `setItemTargetName(staging, itemIdx, newName) → updated staging`
+- `commitStaging(staging, yoursExperiment) → mutates yours._doc + yoursExperiment, returns commit summary`
+- Conflict detection runs inside these helpers.
+- Preflight: reject source YAMLs with duplicate anchor names.
+
+Tests:
+- Build staging in Node (no DOM), add items, verify planned names, commit, assert `yours._doc.toString()` matches expectations.
+- Edge cases: source with no `variables:`, source with no `plugins:`, target with no `variables:`, condition with no aliases, condition with transitive aliases, broken alias, unknown command type, condition name collision.
+
+### Milestone 3 — Three-pane UI + staging interactions (~2 days)
+
+In `experiment_designer_v3.html`:
+- "Import conditions from another YAML…" button + file picker.
+- `enterImportMode(srcYamlText, srcFilename)`, `exitImportMode()`, `commitImport()`.
+- New layout swap function: hides existing layout, renders three-pane import view in same DOM nodes.
+- Extract `renderConditionList(conditions, opts)` helper. Refactor existing `renderLibrary` to use it.
+- New `renderTheirsLibrary(staging)`, `renderStagingBuffer(staging)`, `renderStagingItemInspector(stagingItem)`, `renderTheirsPreview(theirsCondIdx)`.
+- Inspector edit forms: condition target name input, per-anchor name input, per-plugin name input. Bulk: prefix input.
+- Locking: `+ Add` / `dup` / inspector / Export disabled when `staging.locked`.
+
+Browser smoke tests:
+- Import a synthetic source with one clean condition → commit → verify.
+- Import with a condition name collision → resolve → commit.
+- Import with an anchor → verify namespaced anchor lands in `variables:` with prefix.
+- Cancel mid-session → no mutations.
+- Undo after commit → reverts everything in one step.
+
+### Milestone 4 — Polish + docs (~½ day)
+
+- `beforeunload` warning during import mode.
+- CLAUDE.md updates documenting the import flow.
+- Footer bump.
+
+**Total: ~5 days realistic** (rev 1 said 3; the 50% bump matches what the review caught).
+
+---
+
+## 10. Test plan (consolidated)
+
+### Node-side (run via `npm test`):
+
+- **Suite N1 — `collectAliasReferences`:** finds direct + transitive aliases, deterministic order.
+- **Suite N2 — `resolveAlias`:** correctly resolves against last-matching semantics; returns null on broken aliases.
+- **Suite N3 — `cloneNodeAcrossDocs`:** clones structure; rewrites Alias `source` per map; leaves non-rewritten sources alone.
+- **Suite N4 — `yamlNodeStructuralEquals`:** detects key-order-irrelevant equality; returns false on broken aliases; returns false on different types.
+- **Suite N5 — `ensureTopLevelSection`:** idempotent on existing section; creates missing section.
+- **Suite N6 — `docInsertConditionNode` + variable + plugin:** all three add to doc + mirror; round-trip stable.
+- **Suite N7 — Staging buffer dry-run:** synthetic add + adjust prefix + commit → assert `yours._doc.toString()`.
+- **Suite N8 — Each conflict kind triggered:** condition name collision, plugin namespace collision, broken alias, unknown command, transitive alias closure.
+- **Suite N9 — Edge cases:** no `variables:` section, no `plugins:` section, condition with zero aliases, anchor → anchor → anchor chain (depth 3).
+- **Suite N10 — Preflight rejection:** source YAML with duplicate anchor names is rejected at `enterImportMode`.
+
+### Browser-side (manual checklist in PR):
+
+- Clean import (no collisions) → commit → confirm conditions/anchors/plugins land with prefix on anchors/plugins, no prefix on conditions.
+- Condition name collision → resolve via inline input → commit.
+- Edit prefix mid-session → all planned names recompute → commit reflects new prefix.
+- Toggle "Add to sequence" checkbox off → commit → conditions present in library, no new refs in sequence, warnings banner flags unused conditions.
+- Cancel mid-session → no doc mutations.
+- Undo immediately after commit → fully reverts.
+- Lock check: try `+ Add` or Export during import mode → both disabled.
+
+---
+
+## 11. Open questions for the user
+
+These can still be settled in-flight without blocking Milestone 1.
+
+1. **Default prefix derivation.** Filename `sibling_lab.yaml` → `sibling_lab__`. Acceptable, or do you want shorter / different default?
+2. **"Merge with existing" opt-in path.** Should v1 ship the per-anchor "merge with `&dur_short` from yours" toggle, or defer to v1.1? It's a small surface (one button per anchor row) but requires the `yamlNodeStructuralEquals` path. Defer if simpler.
+3. **Bulk prefix override scope.** Editing the prefix mid-session recomputes ALL planned anchor/plugin names. Should per-item overrides persist across a prefix change, or get reset? Recommend: persist (user explicitly typed those names; respect their intent).
+4. **Sequence ref auto-add default.** Defaults ON in this design. OK?
+5. **What happens to imported plugin commands referencing controllers not in the registry?** E.g., source uses `command_name: foo` on a plugin and `foo` isn't in `getV3PluginCommands(yours, plugin)`. Currently: it imports as-is, `collectExportWarnings` doesn't flag (existing gap). Soft warning at commit?
+
+---
+
+## 12. What this doc still does NOT cover
+
+- **Variables editor (Phase 5).** A read-only view of imported variables in Settings would mitigate the "user can't see what got namespaced" issue post-D4. Cheap to add but not strictly D4's job.
+- **Rename cascade (Phase 5).** Once `sibling__dur_short` is in the user's doc, they have no in-tool way to rename it to something shorter. Cascading rename is Phase 5.
+- **Sequence drag/drop (Phase 4).** Imported conditions are wired to the sequence end via auto-bare-ref; reordering them within the sequence is Phase 4.
+- **Multi-doc YAML streams.** One doc per file assumed.
+- **Pattern file path resolution.** Soft warning only; no validation.
+- **Plugin command schema drift.** If "theirs" uses a plugin command the registry doesn't know about, it imports as-is. The export-warnings system catches some of this but not all.
+
+---
+
+## 13. Risk register (revised)
+
+- **YAML library edge cases.** `clone(schema)` + `anchor` mutation + `createAlias`. Mitigation: Milestone 1's primitive tests cover the API surface before any commit logic uses them. Targeted edge cases: anchors on collection nodes, anchors on scalar nodes, anchor-points-at-alias chains.
+- **Staging buffer becoming a parallel architecture.** Mitigation: explicit rule (in §7 and §13) — staging touches only its own state + commits via the documented primitives. No new undo/selection/validation paths.
+- **Renderer reuse underestimated.** Codex-std flagged `renderLibrary` is tightly bound; my rev 2 explicitly budgets the `renderConditionList` extraction. Mitigation: extract early in Milestone 3, before per-pane rendering.
+- **User confusion about prefix-by-default.** Some users will dislike noisy anchor names. Mitigation: the prefix-edit UI is prominent at the top of the buffer; users can shorten or use empty prefix if they want. Documentation in CLAUDE.md after Milestone 4.
+- **Locking "yours" is restrictive.** A user mid-edit who wants to import will lose their place. Mitigation: enter import mode also calls `setDirty(true)` and the `beforeunload` is already set. Optionally: a "discard staging" Cancel that doesn't lose pre-import edits (already the default).
+- **`alias.resolve` vs duplicate-anchor preflight.** We reject duplicate-anchor sources at enter, then use `alias.resolve` (which respects last-wins) for everything else. If a corner-case duplicate slips past (e.g., due to mid-stream additions to the source), `alias.resolve` will still give a defined answer. Belt-and-suspenders.
+
+---
+
+## 14. Decision needed before any code lands
+
+Read this doc + (re-running Codex on this revision is included in the same PR). Then either:
+
+- **Approve** — Milestone 1 starts.
+- **Push back on the substrate or product shape** — revisit (return to merge-by-default, try Option C refactor, etc.).
+- **Defer D4** — pivot to Phase 4 (sequence drag/drop) or Phase 5 (Variables editor) on the current architecture.
+
+No code until we've explicitly picked one.


### PR DESCRIPTION
## Summary

Docs-only PR preserving the D4 (cross-library import) design exploration so it isn't lost when the next session picks it up. **D4 is deferred** — pivoting to Phase 4 (sequence drag/drop) next instead. The design doc and the two-round Codex pressure-test synthesis are checked in so future-us can resume cleanly.

## What's in this PR

- **\`docs/development/v3-d4-design.md\`** — revision 2 of the design (staging-buffer substrate + namespaced-default anchors + module-first split + alias-node API + transitive closure). Now has a \"DEFERRED\" status banner at the top pointing at the review doc.
- **\`docs/development/v3-d4-design-reviews.md\`** — preserved synthesis of the two-round Codex review. Captures the rev 1 → rev 2 evolution, the round-2 corrections that still need to be applied, the plugin-namespacing-vs-merge question (Codex-adv recommends merge-by-default for plugins specifically), and the \"defer until Phase 5\" argument.

## Why deferred

Round 2 review surfaced that D4's mitigations (auto-add to sequence, prefix cleanup) depend on features that don't exist yet — Phase 4 (sequence drag/drop) and Phase 5 (Variables editor + rename cascade). Building D4 first means users live with permanent prefix clutter and orphaned conditions until Phase 5 ships. Building Phase 4 + Phase 5 first means D4 ships against a stronger base.

Phase 4 (drag/drop) is also a smaller, more universally-needed feature — every user edits the sequence. D4's cross-lab use case has no concrete current driver.

## Next next

Phase 4 — sequence drag/drop. Separate PR after this docs-only one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)