### PR TITLE
feat(v3): sequence reorder + Add ref/block + delete (Phase 4a)

### DIFF
--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -328,6 +328,45 @@
         }
         .seq-entry:hover { border-color: var(--accent); }
         .seq-entry.selected { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(0, 230, 118, 0.15); }
+        .seq-entry[draggable="true"] { cursor: grab; }
+        .seq-entry[draggable="true"]:active { cursor: grabbing; }
+        .seq-entry.dragging { opacity: 0.5; }
+        .seq-entry.drop-before { box-shadow: 0 -2px 0 0 var(--accent); }
+        .seq-entry.drop-after { box-shadow: 0 2px 0 0 var(--accent); }
+        .seq-entry .seq-actions {
+            display: flex;
+            gap: 0.2rem;
+            margin-left: auto;
+            opacity: 0;
+            transition: opacity 0.1s;
+        }
+        .seq-entry:hover .seq-actions { opacity: 1; }
+        .seq-entry .seq-act-btn {
+            background: transparent;
+            border: 1px solid transparent;
+            color: var(--text-dim);
+            font-family: inherit;
+            font-size: 0.7rem;
+            width: 20px;
+            height: 20px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            border-radius: 3px;
+            padding: 0;
+            line-height: 1;
+        }
+        .seq-entry .seq-act-btn:hover {
+            background: var(--surface-2);
+            color: var(--accent);
+            border-color: var(--border);
+        }
+        .seq-entry .seq-act-btn.danger:hover {
+            background: rgba(244, 67, 54, 0.12);
+            color: var(--error);
+            border-color: var(--error);
+        }
         .seq-entry.ref {
             background: var(--ref-bg);
             padding: 0.5rem 0.75rem;
@@ -840,6 +879,8 @@
             <div class="zone-header">
                 <span>Experiment Sequence</span>
                 <span class="count" id="seqCount">0</span>
+                <button id="addRefBtn" class="zone-head-btn" title="Append a bare reference to an existing condition" disabled>+ Ref</button>
+                <button id="addBlockBtn" class="zone-head-btn" title="Append a new block (group of trials with optional repetition / intertrial)" disabled>+ Block</button>
             </div>
             <div class="zone-body">
                 <div id="sequenceList">
@@ -873,7 +914,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.4 | <span id="footerTimestamp">2026-05-27 14:40 ET</span>
+        v3 Experiment Designer v0.5 | <span id="footerTimestamp">2026-05-27 15:45 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -901,6 +942,9 @@
             docInsertCondition,
             docCloneCondition,
             docAppendSequenceEntry,
+            docInsertSequenceEntry,
+            docMoveSequenceEntry,
+            docRemoveSequenceEntry,
             docSetPluginCommandHead,
             docAddPluginParam,
             docDeletePluginParam,
@@ -1077,6 +1121,8 @@
                 renderAll();
                 $('exportBtn').disabled = false;
                 $('addCondBtn').disabled = false;
+                $('addRefBtn').disabled = false;
+                $('addBlockBtn').disabled = false;
                 return true;
             } catch (err) {
                 showError(
@@ -1278,6 +1324,121 @@
 
         $('addCondBtn').addEventListener('click', onAddCondition);
 
+        // ─── Sequence: + Ref / + Block / drag / delete ─────────────────────
+
+        function onAddSeqRef() {
+            if (!experiment) return;
+            if (experiment.conditions.length === 0) {
+                showError('Add ref failed', 'No conditions in the library yet. Add a condition first.');
+                return;
+            }
+            const names = experiment.conditions.map((c) => c.name);
+            const suggestion = names[0];
+            const promptText =
+                'Reference which condition?\n\n' +
+                'Available: ' + names.slice(0, 12).join(', ') +
+                (names.length > 12 ? `, ... (${names.length - 12} more)` : '');
+            const name = prompt(promptText, suggestion);
+            if (name === null) return;
+            const trimmed = name.trim();
+            if (!trimmed) {
+                showError('Add ref failed', 'Name cannot be empty.');
+                return;
+            }
+            if (!names.includes(trimmed)) {
+                showError(
+                    'Add ref failed',
+                    'Condition "' + trimmed + '" is not in the library. The ref would be marked missing on import.'
+                );
+                return;
+            }
+            pushUndo();
+            try {
+                docAppendSequenceEntry(experiment, { kind: 'ref', condition_name: trimmed });
+                setDirty(true);
+                selection = { kind: 'ref', index: experiment.sequence.length - 1 };
+                renderAll();
+            } catch (err) {
+                showError('Add ref failed', err.message);
+            }
+        }
+
+        function onAddSeqBlock() {
+            if (!experiment) return;
+            if (experiment.conditions.length === 0) {
+                showError('Add block failed', 'No conditions in the library yet. Add a condition first.');
+                return;
+            }
+            const names = experiment.conditions.map((c) => c.name);
+            const trial = prompt(
+                'First trial condition for the new block?\n\n' +
+                'Available: ' + names.slice(0, 12).join(', ') +
+                (names.length > 12 ? `, ... (${names.length - 12} more)` : ''),
+                names[0]
+            );
+            if (trial === null) return;
+            const trimmedTrial = trial.trim();
+            if (!trimmedTrial || !names.includes(trimmedTrial)) {
+                showError('Add block failed', 'First trial must be an existing library condition.');
+                return;
+            }
+            const blockName = prompt('Block name (optional, auto-numbered if blank):', '');
+            if (blockName === null) return;
+            const trimmedBlockName = blockName.trim();
+            pushUndo();
+            try {
+                const entry = {
+                    kind: 'block',
+                    trials: [trimmedTrial],
+                    repetitions: 1
+                };
+                if (trimmedBlockName) entry.name = trimmedBlockName;
+                docAppendSequenceEntry(experiment, entry);
+                setDirty(true);
+                selection = { kind: 'block', index: experiment.sequence.length - 1 };
+                renderAll();
+            } catch (err) {
+                showError('Add block failed', err.message);
+            }
+        }
+
+        $('addRefBtn').addEventListener('click', onAddSeqRef);
+        $('addBlockBtn').addEventListener('click', onAddSeqBlock);
+
+        function onMoveSequenceEntry(fromIdx, toIdx) {
+            if (fromIdx === toIdx) return;
+            pushUndo();
+            try {
+                docMoveSequenceEntry(experiment, fromIdx, toIdx);
+                setDirty(true);
+                // Update selection if it was on the moved entry
+                if (selection && (selection.kind === 'ref' || selection.kind === 'block') && selection.index === fromIdx) {
+                    selection = { ...selection, index: toIdx };
+                }
+                renderAll();
+            } catch (err) {
+                showError('Move failed', err.message);
+            }
+        }
+
+        function onRemoveSequenceEntry(idx) {
+            pushUndo();
+            try {
+                // Clear selection first if it's about to vanish; renderAll picks up the change.
+                if (selection && (selection.kind === 'ref' || selection.kind === 'block') && selection.index === idx) {
+                    selection = null;
+                } else if (selection && (selection.kind === 'ref' || selection.kind === 'block') && selection.index > idx) {
+                    // Adjust later-index selection to account for the shift
+                    selection = { ...selection, index: selection.index - 1 };
+                }
+                docRemoveSequenceEntry(experiment, idx);
+                setDirty(true);
+                renderAll();
+            } catch (err) {
+                showError('Remove failed', err.message);
+            }
+        }
+
         function computeUsage() {
             const usage = new Map();
             if (!experiment) return usage;
@@ -1363,6 +1524,65 @@
 
             const knownConds = new Set(experiment.conditions.map(c => c.name));
 
+            // Per-entry action button factory — reused for refs and blocks
+            const makeActions = (idx) => {
+                const actions = el('div', { class: 'seq-actions' });
+                const delBtn = el('button', {
+                    class: 'seq-act-btn danger',
+                    title: 'Remove this entry from the sequence (Ctrl+Z to undo)',
+                    onClick: (e) => {
+                        e.stopPropagation();
+                        onRemoveSequenceEntry(idx);
+                    }
+                }, '✕');
+                actions.appendChild(delBtn);
+                return actions;
+            };
+
+            // Native HTML5 drag/drop. dragstart sets the source index;
+            // dragover on a target shows a drop indicator (before/after based
+            // on cursor y vs row midpoint); drop calls onMoveSequenceEntry.
+            const attachDrag = (card, idx) => {
+                card.setAttribute('draggable', 'true');
+                card.dataset.seqIdx = String(idx);
+                card.addEventListener('dragstart', (e) => {
+                    e.dataTransfer.effectAllowed = 'move';
+                    e.dataTransfer.setData('text/x-seq-idx', String(idx));
+                    card.classList.add('dragging');
+                });
+                card.addEventListener('dragend', () => {
+                    card.classList.remove('dragging');
+                    // Clear any lingering drop-indicator classes
+                    list.querySelectorAll('.seq-entry').forEach((el) => {
+                        el.classList.remove('drop-before', 'drop-after');
+                    });
+                });
+                card.addEventListener('dragover', (e) => {
+                    e.preventDefault();  // allow drop
+                    e.dataTransfer.dropEffect = 'move';
+                    const rect = card.getBoundingClientRect();
+                    const before = e.clientY < rect.top + rect.height / 2;
+                    list.querySelectorAll('.seq-entry').forEach((el) => {
+                        el.classList.remove('drop-before', 'drop-after');
+                    });
+                    card.classList.add(before ? 'drop-before' : 'drop-after');
+                });
+                card.addEventListener('dragleave', () => {
+                    card.classList.remove('drop-before', 'drop-after');
+                });
+                card.addEventListener('drop', (e) => {
+                    e.preventDefault();
+                    const fromIdx = Number(e.dataTransfer.getData('text/x-seq-idx'));
+                    if (!Number.isFinite(fromIdx) || fromIdx === idx) return;
+                    const rect = card.getBoundingClientRect();
+                    const dropBefore = e.clientY < rect.top + rect.height / 2;
+                    // toIdx for splice-after-removal: if dropping below the source, the index shifts by 1
+                    let toIdx = dropBefore ? idx : idx + 1;
+                    if (fromIdx < toIdx) toIdx -= 1;
+                    onMoveSequenceEntry(fromIdx, toIdx);
+                });
+            };
+
             experiment.sequence.forEach((entry, idx) => {
                 const isSelected = selection && (
                     (selection.kind === 'ref' && selection.index === idx) ||
@@ -1376,8 +1596,10 @@
                     },
                         el('span', { class: 'marker' }, '▸'),
                         el('span', { class: 'name' }, entry.condition_name),
-                        !knownConds.has(entry.condition_name) ? el('span', { class: 'trial-chip missing', style: 'margin-left: auto;' }, 'missing') : null
+                        !knownConds.has(entry.condition_name) ? el('span', { class: 'trial-chip missing' }, 'missing') : null,
+                        makeActions(idx)
                     );
+                    attachDrag(card, idx);
                     list.appendChild(card);
                 } else if (entry.kind === 'block') {
                     const meta = el('div', { class: 'block-meta' });
@@ -1412,16 +1634,21 @@
                             '⚠ ' + Object.keys(entry._unknownKeys).length + ' future-compat key' + (Object.keys(entry._unknownKeys).length === 1 ? '' : 's'))
                         : null;
 
+                    const blockHead = el('div', { class: 'block-name-row', style: 'display: flex; align-items: center;' },
+                        el('div', { class: 'block-name' }, '▾ ' + (entry.name || 'block_' + (idx + 1))),
+                        makeActions(idx)
+                    );
                     const card = el('div', {
                         class: 'seq-entry block' + (isSelected ? ' selected' : ''),
                         onClick: () => { selection = { kind: 'block', index: idx }; renderSequence(); renderInspector(); renderLibrary(); }
                     },
-                        el('div', { class: 'block-name' }, '▾ ' + (entry.name || 'block_' + (idx + 1))),
+                        blockHead,
                         meta,
                         trialsRow,
                         itiRow,
                         unknownPill
                     );
+                    attachDrag(card, idx);
                     list.appendChild(card);
                 }
             });

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -994,6 +994,136 @@ function docCloneCondition(experiment, srcIdx, newName) {
 }
 
 /**
+ * Internal helper: build a YAMLSeq item and JS-mirror entry from a JS-side
+ * sequence entry shape. Used by both docAppendSequenceEntry and
+ * docInsertSequenceEntry so they construct identical structures.
+ *
+ * Returns { node, jsEntry } or throws V3ParseError on bad input.
+ */
+function _buildSequenceEntry(doc, entry) {
+    if (!entry || typeof entry !== 'object') {
+        throw new V3ParseError('sequence entry must be an object', 'INVALID_INPUT');
+    }
+    if (entry.kind === 'ref') {
+        if (typeof entry.condition_name !== 'string' || !entry.condition_name) {
+            throw new V3ParseError('ref entry needs a condition_name', 'INVALID_INPUT');
+        }
+        return {
+            node: doc.createNode(entry.condition_name),
+            jsEntry: { kind: 'ref', condition_name: entry.condition_name }
+        };
+    }
+    if (entry.kind === 'block') {
+        if (!Array.isArray(entry.trials) || entry.trials.length === 0) {
+            throw new V3ParseError('block entry needs a non-empty trials list', 'INVALID_INPUT');
+        }
+        const blockShape = { trials: entry.trials.slice() };
+        if (typeof entry.name === 'string' && entry.name) blockShape.name = entry.name;
+        if (typeof entry.repetitions === 'number') blockShape.repetitions = entry.repetitions;
+        if (entry.randomize === true) blockShape.randomize = true;
+        if (typeof entry.intertrial === 'string' && entry.intertrial) blockShape.intertrial = entry.intertrial;
+        return {
+            node: doc.createNode(blockShape),
+            jsEntry: {
+                kind: 'block',
+                name: blockShape.name || null,
+                trials: blockShape.trials,
+                repetitions: blockShape.repetitions || 1,
+                randomize: blockShape.randomize === true,
+                intertrial: blockShape.intertrial || null,
+                _unknownKeys: {}
+            }
+        };
+    }
+    throw new V3ParseError('entry.kind must be "ref" or "block"', 'INVALID_INPUT');
+}
+
+/**
+ * docInsertSequenceEntry(experiment, atIdx, entry)
+ *
+ * Insert a sequence entry at position `atIdx`. atIdx is clamped to
+ * [0, sequence.length] so passing sequence.length is equivalent to
+ * docAppendSequenceEntry.
+ *
+ * Used by the +Add UI in the sequence pane and (in Phase 4b) by
+ * library-to-sequence drag/drop with a target index.
+ */
+function docInsertSequenceEntry(experiment, atIdx, entry) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docInsertSequenceEntry: experiment has no _doc handle', 'NO_DOC');
+    }
+    const seqNode = experiment._doc.getIn(['experiment'], true);
+    if (!seqNode || !Array.isArray(seqNode.items)) {
+        throw new V3ParseError(
+            'docInsertSequenceEntry: experiment seq node not found',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+    const built = _buildSequenceEntry(experiment._doc, entry);
+    const clamped = Math.max(0, Math.min(atIdx, experiment.sequence.length));
+    seqNode.items.splice(clamped, 0, built.node);
+    experiment.sequence.splice(clamped, 0, built.jsEntry);
+}
+
+/**
+ * docMoveSequenceEntry(experiment, fromIdx, toIdx)
+ *
+ * Reorder a top-level sequence entry from fromIdx to toIdx. Both indices are
+ * bounds-checked; no-op if out of range or fromIdx === toIdx. Throws on
+ * doc/model divergence (matching docMoveCommand's contract).
+ */
+function docMoveSequenceEntry(experiment, fromIdx, toIdx) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docMoveSequenceEntry: experiment has no _doc handle', 'NO_DOC');
+    }
+    const n = experiment.sequence.length;
+    if (fromIdx < 0 || fromIdx >= n || toIdx < 0 || toIdx >= n || fromIdx === toIdx) return;
+
+    const seqNode = experiment._doc.getIn(['experiment'], true);
+    if (!seqNode || !Array.isArray(seqNode.items)) {
+        throw new V3ParseError(
+            'docMoveSequenceEntry: doc/model divergence — no experiment seq node',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+
+    const movedNode = seqNode.items.splice(fromIdx, 1)[0];
+    seqNode.items.splice(toIdx, 0, movedNode);
+
+    const movedJs = experiment.sequence.splice(fromIdx, 1)[0];
+    experiment.sequence.splice(toIdx, 0, movedJs);
+}
+
+/**
+ * docRemoveSequenceEntry(experiment, idx)
+ *
+ * Remove the sequence entry at `idx` from both _doc and the JS mirror.
+ * Throws on out-of-bounds rather than silently no-op'ing — accidental
+ * deletes should surface immediately.
+ */
+function docRemoveSequenceEntry(experiment, idx) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docRemoveSequenceEntry: experiment has no _doc handle', 'NO_DOC');
+    }
+    const n = experiment.sequence.length;
+    if (idx < 0 || idx >= n) {
+        throw new V3ParseError(
+            'docRemoveSequenceEntry: idx ' + idx + ' out of bounds [0, ' + n + ')',
+            'BAD_PATH'
+        );
+    }
+    const seqNode = experiment._doc.getIn(['experiment'], true);
+    if (!seqNode || !Array.isArray(seqNode.items)) {
+        throw new V3ParseError(
+            'docRemoveSequenceEntry: doc/model divergence — no experiment seq node',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+    seqNode.items.splice(idx, 1);
+    experiment.sequence.splice(idx, 1);
+}
+
+/**
  * docAppendSequenceEntry(experiment, entry)
  *
  * Append an entry to `experiment:` (the sequence). `entry` can be a ref —
@@ -1007,10 +1137,6 @@ function docAppendSequenceEntry(experiment, entry) {
     if (!experiment || !experiment._doc) {
         throw new V3ParseError('docAppendSequenceEntry: experiment has no _doc handle', 'NO_DOC');
     }
-    if (!entry || typeof entry !== 'object') {
-        throw new V3ParseError('docAppendSequenceEntry: entry must be an object', 'INVALID_INPUT');
-    }
-
     const seqNode = experiment._doc.getIn(['experiment'], true);
     if (!seqNode || !Array.isArray(seqNode.items)) {
         throw new V3ParseError(
@@ -1018,47 +1144,11 @@ function docAppendSequenceEntry(experiment, entry) {
             'DOC_MODEL_DIVERGENCE'
         );
     }
-
-    if (entry.kind === 'ref') {
-        if (typeof entry.condition_name !== 'string' || !entry.condition_name) {
-            throw new V3ParseError(
-                'docAppendSequenceEntry: ref entry needs a condition_name',
-                'INVALID_INPUT'
-            );
-        }
-        seqNode.items.push(experiment._doc.createNode(entry.condition_name));
-        experiment.sequence.push({ kind: 'ref', condition_name: entry.condition_name });
-    } else if (entry.kind === 'block') {
-        if (!Array.isArray(entry.trials) || entry.trials.length === 0) {
-            throw new V3ParseError(
-                'docAppendSequenceEntry: block entry needs a non-empty trials list',
-                'INVALID_INPUT'
-            );
-        }
-        const blockShape = {
-            trials: entry.trials.slice()
-        };
-        if (typeof entry.name === 'string' && entry.name) blockShape.name = entry.name;
-        if (typeof entry.repetitions === 'number') blockShape.repetitions = entry.repetitions;
-        if (entry.randomize === true) blockShape.randomize = true;
-        if (typeof entry.intertrial === 'string' && entry.intertrial) blockShape.intertrial = entry.intertrial;
-        seqNode.items.push(experiment._doc.createNode(blockShape));
-        experiment.sequence.push({
-            kind: 'block',
-            name: blockShape.name || null,
-            trials: blockShape.trials,
-            repetitions: blockShape.repetitions || 1,
-            randomize: blockShape.randomize === true,
-            intertrial: blockShape.intertrial || null,
-            _unknownKeys: {}
-        });
-    } else {
-        throw new V3ParseError(
-            'docAppendSequenceEntry: entry.kind must be "ref" or "block"',
-            'INVALID_INPUT'
-        );
-    }
+    const built = _buildSequenceEntry(experiment._doc, entry);
+    seqNode.items.push(built.node);
+    experiment.sequence.push(built.jsEntry);
 }
+
 
 /**
  * docDelete(experiment, path)
@@ -1122,6 +1212,9 @@ const ProtocolV3 = {
     docInsertCondition,
     docCloneCondition,
     docAppendSequenceEntry,
+    docInsertSequenceEntry,
+    docMoveSequenceEntry,
+    docRemoveSequenceEntry,
     docSetPluginCommandHead,
     docAddPluginParam,
     docDeletePluginParam,
@@ -1153,6 +1246,9 @@ export {
     docInsertCondition,
     docCloneCondition,
     docAppendSequenceEntry,
+    docInsertSequenceEntry,
+    docMoveSequenceEntry,
+    docRemoveSequenceEntry,
     docSetPluginCommandHead,
     docAddPluginParam,
     docDeletePluginParam,

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -34,6 +34,9 @@ const {
     docInsertCondition,
     docCloneCondition,
     docAppendSequenceEntry,
+    docInsertSequenceEntry,
+    docMoveSequenceEntry,
+    docRemoveSequenceEntry,
     docSetPluginCommandHead,
     docAddPluginParam,
     docDeletePluginParam,
@@ -1480,6 +1483,163 @@ console.log('\n--- Suite 21: BLANK_TEMPLATE skeleton parses + round-trips ---');
     const reparsed = parseV3Protocol(generateV3Protocol(exp));
     check('blank: round-trip stable', reparsed.conditions.length, 1);
 }
+
+// ─── Test Suite 22: docInsertSequenceEntry ─────────────────────────────────
+console.log('\n--- Suite 22: docInsertSequenceEntry (insert anywhere) ---');
+
+{
+    // Insert at start, middle, end of canonical_a's sequence (length 4).
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const before = exp.sequence.length;
+    docInsertSequenceEntry(exp, 0, { kind: 'ref', condition_name: 'arena check' });
+    check('insert-seq: at start grows length', exp.sequence.length, before + 1);
+    check('insert-seq: idx 0 is the new ref', exp.sequence[0].condition_name, 'arena check');
+
+    docInsertSequenceEntry(exp, 2, { kind: 'ref', condition_name: 'arena check' });
+    check('insert-seq: middle places ref', exp.sequence[2].condition_name, 'arena check');
+
+    docInsertSequenceEntry(exp, exp.sequence.length, { kind: 'ref', condition_name: 'arena check' });
+    check('insert-seq: at end appends', exp.sequence[exp.sequence.length - 1].condition_name, 'arena check');
+
+    // Round-trip stable
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('insert-seq: round-trip length', reparsed.sequence.length, before + 3);
+}
+
+{
+    // Insert a block
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    docInsertSequenceEntry(exp, 1, {
+        kind: 'block',
+        name: 'extras',
+        trials: ['arena check'],
+        repetitions: 2
+    });
+    check('insert-seq-block: at idx 1 is block', exp.sequence[1].kind, 'block');
+    check('insert-seq-block: name', exp.sequence[1].name, 'extras');
+    check('insert-seq-block: reps', exp.sequence[1].repetitions, 2);
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('insert-seq-block: round-trip name', reparsed.sequence[1].name, 'extras');
+}
+
+{
+    // Out-of-range atIdx is clamped (no throw)
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    docInsertSequenceEntry(exp, -5, { kind: 'ref', condition_name: 'arena check' });
+    check('insert-seq: negative idx clamps to 0', exp.sequence[0].condition_name, 'arena check');
+
+    const exp2 = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const len2 = exp2.sequence.length;
+    docInsertSequenceEntry(exp2, 999, { kind: 'ref', condition_name: 'arena check' });
+    check('insert-seq: too-large idx clamps to length', exp2.sequence[len2].condition_name, 'arena check');
+}
+
+checkThrows(
+    'insert-seq: rejects bad entry kind',
+    () => {
+        const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+        docInsertSequenceEntry(exp, 0, { kind: 'bogus' });
+    },
+    'INVALID_INPUT'
+);
+
+// ─── Test Suite 23: docMoveSequenceEntry ───────────────────────────────────
+console.log('\n--- Suite 23: docMoveSequenceEntry (reorder) ---');
+
+{
+    // canonical_a sequence: [ref arena_check, ref start_light, block main_block, ref posttrial]
+    // Move idx 0 to idx 2 — order becomes [start_light, main_block, arena_check, posttrial]
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const origNames = exp.sequence.map(e => e.kind === 'ref' ? e.condition_name : e.name);
+    docMoveSequenceEntry(exp, 0, 2);
+    check(
+        'move-seq: first moves to position 2',
+        exp.sequence.map(e => e.kind === 'ref' ? e.condition_name : e.name).join('|'),
+        [origNames[1], origNames[2], origNames[0], origNames[3]].join('|')
+    );
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check(
+        'move-seq: round-trip preserves new order',
+        reparsed.sequence.map(e => e.kind === 'ref' ? e.condition_name : e.name).join('|'),
+        [origNames[1], origNames[2], origNames[0], origNames[3]].join('|')
+    );
+}
+
+{
+    // No-op cases: same index, out-of-range
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const before = JSON.stringify(exp.sequence.map(e => e.kind === 'ref' ? e.condition_name : e.name));
+    docMoveSequenceEntry(exp, 1, 1);
+    docMoveSequenceEntry(exp, 99, 0);
+    docMoveSequenceEntry(exp, -1, 0);
+    check(
+        'move-seq: no-op / out-of-range preserves order',
+        JSON.stringify(exp.sequence.map(e => e.kind === 'ref' ? e.condition_name : e.name)),
+        before
+    );
+}
+
+{
+    // Doc/model divergence throws
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    exp._doc.delete('experiment');  // nuke the doc-side sequence
+    let threw = false;
+    let code = null;
+    try {
+        docMoveSequenceEntry(exp, 0, 1);
+    } catch (e) {
+        threw = true;
+        code = e.code;
+    }
+    checkTrue('move-seq: throws on doc/model divergence', threw);
+    check('move-seq: error code DOC_MODEL_DIVERGENCE', code, 'DOC_MODEL_DIVERGENCE');
+}
+
+// ─── Test Suite 24: docRemoveSequenceEntry ─────────────────────────────────
+console.log('\n--- Suite 24: docRemoveSequenceEntry (delete) ---');
+
+{
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const before = exp.sequence.length;
+    const removedName = exp.sequence[0].condition_name;
+    docRemoveSequenceEntry(exp, 0);
+    check('remove-seq: length shrinks', exp.sequence.length, before - 1);
+    checkTrue(
+        'remove-seq: removed entry gone from JS model',
+        !exp.sequence.some(e => e.kind === 'ref' && e.condition_name === removedName)
+    );
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('remove-seq: round-trip length', reparsed.sequence.length, before - 1);
+}
+
+{
+    // Remove a block
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex(e => e.kind === 'block');
+    docRemoveSequenceEntry(exp, blockIdx);
+    checkTrue('remove-seq-block: block gone', !exp.sequence.some(e => e.kind === 'block'));
+}
+
+checkThrows(
+    'remove-seq: rejects out-of-bounds',
+    () => {
+        const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+        docRemoveSequenceEntry(exp, 999);
+    },
+    'BAD_PATH'
+);
+
+checkThrows(
+    'remove-seq: rejects negative idx',
+    () => {
+        const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+        docRemoveSequenceEntry(exp, -1);
+    },
+    'BAD_PATH'
+);
 
 // ─── Results ────────────────────────────────────────────────────────────────
 console.log('\n=== Results: ' + passedTests + '/' + totalTests + ' passed ===');


### PR DESCRIPTION
## Summary

First slice of Phase 4 (sequence editing). Users can now build out the experiment sequence without hand-editing YAML — add refs and blocks from buttons, drag-to-reorder, delete with a per-row ✕. Library→sequence drag and ref↔block convert come in Phase 4b / 4c.

- **3 new doc helpers** (\`docInsertSequenceEntry\`, \`docMoveSequenceEntry\`, \`docRemoveSequenceEntry\`) following the existing \`docInsertCommand\`/\`docMoveCommand\` pattern: throw on doc/model divergence, bounds-check, mirror both \`_doc\` and the JS model. Refactored \`docAppendSequenceEntry\` through a shared \`_buildSequenceEntry\` factory so all four insertion paths construct identical JS-mirror shapes.
- **+ Ref / + Block buttons** in the sequence zone-header. \`+ Ref\` prompts for an existing condition name with a short available-names list. \`+ Block\` does a two-step prompt (first trial + optional block name) and appends with sensible defaults (reps=1, randomize=false, no iti); the rest of the block properties stay editable in the existing inspector.
- **Native HTML5 drag-to-reorder** on every \`.seq-entry\`. Dragover shows a green top/bottom drop indicator based on cursor position; drop computes the post-splice target index and calls \`onMoveSequenceEntry\`. Selection follows the moved entry across the reorder.
- **✕ delete button** per row (visible on hover). Clears selection if the deleted entry was selected; shifts \`selection.index\` down if a later entry was deleted.

## Test plan

- [x] \`npm test\` — arena 10/10, v2 137/137, v3 **341/341** (+23 across Suites 22/23/24)
  - Suite 22: \`docInsertSequenceEntry\` — start/middle/end inserts, block insert, idx clamping, bad-kind rejection, round-trip stable
  - Suite 23: \`docMoveSequenceEntry\` — reorder ref, no-op on same idx / OOR, throws on doc/model divergence, round-trip stable
  - Suite 24: \`docRemoveSequenceEntry\` — remove ref/block, rejects OOB (positive and negative), round-trip stable
- [x] Browser (v3_canonical_a): \`+ Ref\` appends \"arena check\" and selects it (now shows the inline ref view with \"shared with 2 refs\" badge); \`+ Block\` creates a 1-trial \"extras\" block; ✕ removes and exports cleanly
- [x] Drag events fire on every \`.seq-entry\` (verified via DOM inspection)
- [x] No console errors
- [ ] Hard-refresh on GitHub Pages after merge

Footer: \`v3 Experiment Designer v0.5 | 2026-05-27 15:45 ET\`

## Next

Phase 4b — library→sequence drag (drop a library row onto the sequence to create a ref at that position; drop onto a block's trial strip to add a trial); trial-within-block reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)