### PR TITLE
feat(v3): drag library row to sequence + block trial editing (Phase 4b)

### DIFF
--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -396,7 +396,18 @@
             color: var(--warn);
             font-weight: 600;
         }
-        .seq-entry.block .trials-row { display: flex; flex-wrap: wrap; gap: 0.25rem; }
+        .seq-entry.block .trials-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+            min-height: 1.6rem;
+            padding: 0.15rem;
+            border-radius: 3px;
+        }
+        .seq-entry.block .trials-row.drop-target {
+            background: rgba(0, 230, 118, 0.08);
+            outline: 1px dashed var(--accent);
+        }
         .trial-chip {
             background: var(--surface-2);
             border: 1px solid var(--border);
@@ -404,8 +415,36 @@
             border-radius: 10px;
             font-size: 0.7rem;
             font-family: 'JetBrains Mono', monospace;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.2rem;
         }
+        .trial-chip[draggable="true"] { cursor: grab; }
+        .trial-chip[draggable="true"]:active { cursor: grabbing; }
+        .trial-chip.dragging { opacity: 0.5; }
+        .trial-chip.drop-before { box-shadow: -2px 0 0 0 var(--accent); }
+        .trial-chip.drop-after { box-shadow: 2px 0 0 0 var(--accent); }
         .trial-chip.missing { color: var(--error); border-color: var(--error); }
+        .trial-chip .chip-x-btn {
+            background: transparent;
+            border: none;
+            color: var(--text-dim);
+            font-size: 0.65rem;
+            cursor: pointer;
+            padding: 0;
+            line-height: 1;
+            opacity: 0;
+            transition: opacity 0.1s;
+        }
+        .trial-chip:hover .chip-x-btn { opacity: 1; }
+        .trial-chip .chip-x-btn:hover { color: var(--error); }
+        .lib-row[draggable="true"] { cursor: grab; }
+        .lib-row[draggable="true"]:active { cursor: grabbing; }
+        .lib-row.dragging { opacity: 0.5; }
+        #sequenceList.lib-drop-target {
+            outline: 1px dashed var(--accent);
+            border-radius: 4px;
+        }
         .iti-row {
             margin-top: 0.4rem;
             font-size: 0.7rem;
@@ -914,7 +953,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.5 | <span id="footerTimestamp">2026-05-27 15:45 ET</span>
+        v3 Experiment Designer v0.6 | <span id="footerTimestamp">2026-05-27 16:05 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -945,6 +984,9 @@
             docInsertSequenceEntry,
             docMoveSequenceEntry,
             docRemoveSequenceEntry,
+            docInsertTrialInBlock,
+            docMoveTrialInBlock,
+            docRemoveTrialFromBlock,
             docSetPluginCommandHead,
             docAddPluginParam,
             docDeletePluginParam,
@@ -1421,6 +1463,53 @@
             }
         }
 
+        function onInsertSequenceRefFromLib(condName, atIdx) {
+            pushUndo();
+            try {
+                docInsertSequenceEntry(experiment, atIdx, { kind: 'ref', condition_name: condName });
+                setDirty(true);
+                const clamped = Math.max(0, Math.min(atIdx, experiment.sequence.length - 1));
+                selection = { kind: 'ref', index: clamped };
+                renderAll();
+            } catch (err) {
+                showError('Add ref failed', err.message);
+            }
+        }
+
+        function onInsertTrialFromLib(blockIdx, atIdx, condName) {
+            pushUndo();
+            try {
+                docInsertTrialInBlock(experiment, blockIdx, atIdx, condName);
+                setDirty(true);
+                renderAll();
+            } catch (err) {
+                showError('Add trial failed', err.message);
+            }
+        }
+
+        function onMoveTrialInBlock(blockIdx, fromIdx, toIdx) {
+            if (fromIdx === toIdx) return;
+            pushUndo();
+            try {
+                docMoveTrialInBlock(experiment, blockIdx, fromIdx, toIdx);
+                setDirty(true);
+                renderAll();
+            } catch (err) {
+                showError('Move trial failed', err.message);
+            }
+        }
+
+        function onRemoveTrialFromBlock(blockIdx, trialIdx) {
+            pushUndo();
+            try {
+                docRemoveTrialFromBlock(experiment, blockIdx, trialIdx);
+                setDirty(true);
+                renderAll();
+            } catch (err) {
+                showError('Remove trial failed', err.message);
+            }
+        }
+
         function onRemoveSequenceEntry(idx) {
             pushUndo();
             try {
@@ -1499,6 +1588,21 @@
                     }, 'dup'),
                     el('span', { class: 'usage' }, useCount + '×')
                 );
+                // Drag source — library row → drop on sequence creates a ref,
+                // drop on a block's trial strip adds a trial. dataTransfer
+                // mime distinguishes from sequence-entry drags.
+                row.setAttribute('draggable', 'true');
+                row.addEventListener('dragstart', (e) => {
+                    e.dataTransfer.effectAllowed = 'copy';
+                    e.dataTransfer.setData('text/x-library-cond', cond.name);
+                    row.classList.add('dragging');
+                });
+                row.addEventListener('dragend', () => {
+                    row.classList.remove('dragging');
+                    document.querySelectorAll('.drop-target, .lib-drop-target, .drop-before, .drop-after').forEach((el) => {
+                        el.classList.remove('drop-target', 'lib-drop-target', 'drop-before', 'drop-after');
+                    });
+                });
                 list.appendChild(row);
                 shown++;
             }
@@ -1539,9 +1643,11 @@
                 return actions;
             };
 
-            // Native HTML5 drag/drop. dragstart sets the source index;
-            // dragover on a target shows a drop indicator (before/after based
-            // on cursor y vs row midpoint); drop calls onMoveSequenceEntry.
+            // Native HTML5 drag/drop. Two drag sources land on sequence entries:
+            //   - existing seq entry (mime text/x-seq-idx)  → reorder
+            //   - library row       (mime text/x-library-cond) → insert ref
+            // dragover shows a top/bottom drop indicator based on cursor y;
+            // drop dispatches based on which mime arrived.
             const attachDrag = (card, idx) => {
                 card.setAttribute('draggable', 'true');
                 card.dataset.seqIdx = String(idx);
@@ -1552,14 +1658,17 @@
                 });
                 card.addEventListener('dragend', () => {
                     card.classList.remove('dragging');
-                    // Clear any lingering drop-indicator classes
                     list.querySelectorAll('.seq-entry').forEach((el) => {
                         el.classList.remove('drop-before', 'drop-after');
                     });
                 });
                 card.addEventListener('dragover', (e) => {
+                    const types = e.dataTransfer.types;
+                    const isLib = types.includes('text/x-library-cond');
+                    const isSeq = types.includes('text/x-seq-idx');
+                    if (!isLib && !isSeq) return;
                     e.preventDefault();  // allow drop
-                    e.dataTransfer.dropEffect = 'move';
+                    e.dataTransfer.dropEffect = isLib ? 'copy' : 'move';
                     const rect = card.getBoundingClientRect();
                     const before = e.clientY < rect.top + rect.height / 2;
                     list.querySelectorAll('.seq-entry').forEach((el) => {
@@ -1572,16 +1681,43 @@
                 });
                 card.addEventListener('drop', (e) => {
                     e.preventDefault();
-                    const fromIdx = Number(e.dataTransfer.getData('text/x-seq-idx'));
-                    if (!Number.isFinite(fromIdx) || fromIdx === idx) return;
+                    const libCond = e.dataTransfer.getData('text/x-library-cond');
+                    const seqIdxRaw = e.dataTransfer.getData('text/x-seq-idx');
                     const rect = card.getBoundingClientRect();
                     const dropBefore = e.clientY < rect.top + rect.height / 2;
-                    // toIdx for splice-after-removal: if dropping below the source, the index shifts by 1
-                    let toIdx = dropBefore ? idx : idx + 1;
-                    if (fromIdx < toIdx) toIdx -= 1;
-                    onMoveSequenceEntry(fromIdx, toIdx);
+                    if (libCond) {
+                        const insertAt = dropBefore ? idx : idx + 1;
+                        onInsertSequenceRefFromLib(libCond, insertAt);
+                    } else if (seqIdxRaw) {
+                        const fromIdx = Number(seqIdxRaw);
+                        if (!Number.isFinite(fromIdx) || fromIdx === idx) return;
+                        let toIdx = dropBefore ? idx : idx + 1;
+                        if (fromIdx < toIdx) toIdx -= 1;
+                        onMoveSequenceEntry(fromIdx, toIdx);
+                    }
                 });
             };
+
+            // List-level drop target for the empty-list / append-past-end case.
+            list.addEventListener('dragover', (e) => {
+                if (!e.dataTransfer.types.includes('text/x-library-cond')) return;
+                // Only highlight when we're not over an existing entry (entries handle their own)
+                if (e.target.closest('.seq-entry')) return;
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'copy';
+                list.classList.add('lib-drop-target');
+            });
+            list.addEventListener('dragleave', (e) => {
+                if (e.target === list) list.classList.remove('lib-drop-target');
+            });
+            list.addEventListener('drop', (e) => {
+                if (e.target.closest('.seq-entry')) return;  // handled by entry's own drop
+                const libCond = e.dataTransfer.getData('text/x-library-cond');
+                if (!libCond) return;
+                e.preventDefault();
+                list.classList.remove('lib-drop-target');
+                onInsertSequenceRefFromLib(libCond, experiment.sequence.length);
+            });
 
             experiment.sequence.forEach((entry, idx) => {
                 const isSelected = selection && (
@@ -1608,10 +1744,12 @@
                     if (entry.randomize) meta.appendChild(el('span', { class: 'randomize-badge' }, '⚄ randomize'));
 
                     const trialsRow = el('div', { class: 'trials-row' });
-                    for (const t of entry.trials) {
+                    const blockIdxForRow = idx;
+                    entry.trials.forEach((t, trialIdx) => {
+                        const isMissing = !knownConds.has(t);
                         const chip = el('span', {
-                            class: 'trial-chip' + (!knownConds.has(t) ? ' missing' : ''),
-                            title: !knownConds.has(t) ? 'Condition "' + t + '" not in library' : 'Click to view ' + t,
+                            class: 'trial-chip' + (isMissing ? ' missing' : ''),
+                            title: isMissing ? 'Condition "' + t + '" not in library' : 'Click to view ' + t,
                             onClick: (e) => {
                                 e.stopPropagation();
                                 if (knownConds.has(t)) {
@@ -1620,8 +1758,93 @@
                                 }
                             }
                         }, t);
+                        // ✕ delete button (hidden when removing would leave 0 trials)
+                        if (entry.trials.length > 1) {
+                            chip.appendChild(el('button', {
+                                class: 'chip-x-btn',
+                                title: 'Remove this trial from the block',
+                                onClick: (e) => {
+                                    e.stopPropagation();
+                                    onRemoveTrialFromBlock(blockIdxForRow, trialIdx);
+                                }
+                            }, '✕'));
+                        }
+                        // Drag source for within-block reorder
+                        chip.setAttribute('draggable', 'true');
+                        chip.addEventListener('dragstart', (e) => {
+                            e.stopPropagation();  // don't bubble to the block card's dragstart
+                            e.dataTransfer.effectAllowed = 'move';
+                            e.dataTransfer.setData(
+                                'text/x-block-trial',
+                                blockIdxForRow + ':' + trialIdx
+                            );
+                            chip.classList.add('dragging');
+                        });
+                        chip.addEventListener('dragend', () => {
+                            chip.classList.remove('dragging');
+                            trialsRow.querySelectorAll('.trial-chip').forEach((el) =>
+                                el.classList.remove('drop-before', 'drop-after')
+                            );
+                        });
+                        chip.addEventListener('dragover', (e) => {
+                            const types = e.dataTransfer.types;
+                            const isLib = types.includes('text/x-library-cond');
+                            const isTrial = types.includes('text/x-block-trial');
+                            if (!isLib && !isTrial) return;
+                            e.stopPropagation();
+                            e.preventDefault();
+                            e.dataTransfer.dropEffect = isLib ? 'copy' : 'move';
+                            const rect = chip.getBoundingClientRect();
+                            const before = e.clientX < rect.left + rect.width / 2;
+                            trialsRow.querySelectorAll('.trial-chip').forEach((el) =>
+                                el.classList.remove('drop-before', 'drop-after')
+                            );
+                            chip.classList.add(before ? 'drop-before' : 'drop-after');
+                        });
+                        chip.addEventListener('drop', (e) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            const libCond = e.dataTransfer.getData('text/x-library-cond');
+                            const trialRaw = e.dataTransfer.getData('text/x-block-trial');
+                            const rect = chip.getBoundingClientRect();
+                            const dropBefore = e.clientX < rect.left + rect.width / 2;
+                            if (libCond) {
+                                const insertAt = dropBefore ? trialIdx : trialIdx + 1;
+                                onInsertTrialFromLib(blockIdxForRow, insertAt, libCond);
+                            } else if (trialRaw) {
+                                const [srcBlockIdxStr, srcTrialIdxStr] = trialRaw.split(':');
+                                const srcBlockIdx = Number(srcBlockIdxStr);
+                                const srcTrialIdx = Number(srcTrialIdxStr);
+                                if (srcBlockIdx !== blockIdxForRow) return;  // no cross-block move in v1
+                                if (srcTrialIdx === trialIdx) return;
+                                let toIdx = dropBefore ? trialIdx : trialIdx + 1;
+                                if (srcTrialIdx < toIdx) toIdx -= 1;
+                                onMoveTrialInBlock(blockIdxForRow, srcTrialIdx, toIdx);
+                            }
+                        });
                         trialsRow.appendChild(chip);
-                    }
+                    });
+                    // Row-level drop target for library drag onto empty area or end
+                    trialsRow.addEventListener('dragover', (e) => {
+                        if (!e.dataTransfer.types.includes('text/x-library-cond')) return;
+                        if (e.target.closest('.trial-chip')) return;
+                        e.stopPropagation();
+                        e.preventDefault();
+                        e.dataTransfer.dropEffect = 'copy';
+                        trialsRow.classList.add('drop-target');
+                    });
+                    trialsRow.addEventListener('dragleave', (e) => {
+                        if (e.target === trialsRow) trialsRow.classList.remove('drop-target');
+                    });
+                    trialsRow.addEventListener('drop', (e) => {
+                        if (e.target.closest('.trial-chip')) return;
+                        const libCond = e.dataTransfer.getData('text/x-library-cond');
+                        if (!libCond) return;
+                        e.stopPropagation();
+                        e.preventDefault();
+                        trialsRow.classList.remove('drop-target');
+                        onInsertTrialFromLib(blockIdxForRow, entry.trials.length, libCond);
+                    });
 
                     const itiRow = entry.intertrial
                         ? el('div', { class: 'iti-row' },

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -1124,6 +1124,117 @@ function docRemoveSequenceEntry(experiment, idx) {
 }
 
 /**
+ * docInsertTrialInBlock(experiment, blockIdx, atIdx, condName)
+ *
+ * Insert a trial reference (a condition name string) into the block at
+ * `blockIdx`'s `trials:` seq. atIdx is clamped to [0, trials.length] so
+ * passing trials.length appends.
+ */
+function docInsertTrialInBlock(experiment, blockIdx, atIdx, condName) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docInsertTrialInBlock: experiment has no _doc handle', 'NO_DOC');
+    }
+    const block = experiment.sequence[blockIdx];
+    if (!block || block.kind !== 'block') {
+        throw new V3ParseError(
+            'docInsertTrialInBlock: sequence[' + blockIdx + '] is not a block',
+            'INVALID_INPUT'
+        );
+    }
+    if (typeof condName !== 'string' || !condName) {
+        throw new V3ParseError(
+            'docInsertTrialInBlock: condName must be a non-empty string',
+            'INVALID_INPUT'
+        );
+    }
+    const trialsNode = experiment._doc.getIn(['experiment', blockIdx, 'trials'], true);
+    if (!trialsNode || !Array.isArray(trialsNode.items)) {
+        throw new V3ParseError(
+            'docInsertTrialInBlock: trials seq node missing at experiment[' + blockIdx + ']',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+    const clamped = Math.max(0, Math.min(atIdx, block.trials.length));
+    trialsNode.items.splice(clamped, 0, experiment._doc.createNode(condName));
+    block.trials.splice(clamped, 0, condName);
+}
+
+/**
+ * docMoveTrialInBlock(experiment, blockIdx, fromIdx, toIdx)
+ *
+ * Reorder a trial within a block's `trials:` seq. Bounds-checked; no-op on
+ * same-idx or out-of-range. Throws on doc/model divergence.
+ */
+function docMoveTrialInBlock(experiment, blockIdx, fromIdx, toIdx) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docMoveTrialInBlock: experiment has no _doc handle', 'NO_DOC');
+    }
+    const block = experiment.sequence[blockIdx];
+    if (!block || block.kind !== 'block') {
+        throw new V3ParseError(
+            'docMoveTrialInBlock: sequence[' + blockIdx + '] is not a block',
+            'INVALID_INPUT'
+        );
+    }
+    const n = block.trials.length;
+    if (fromIdx < 0 || fromIdx >= n || toIdx < 0 || toIdx >= n || fromIdx === toIdx) return;
+
+    const trialsNode = experiment._doc.getIn(['experiment', blockIdx, 'trials'], true);
+    if (!trialsNode || !Array.isArray(trialsNode.items)) {
+        throw new V3ParseError(
+            'docMoveTrialInBlock: doc/model divergence — no trials seq at experiment[' + blockIdx + ']',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+    const moved = trialsNode.items.splice(fromIdx, 1)[0];
+    trialsNode.items.splice(toIdx, 0, moved);
+    const movedJs = block.trials.splice(fromIdx, 1)[0];
+    block.trials.splice(toIdx, 0, movedJs);
+}
+
+/**
+ * docRemoveTrialFromBlock(experiment, blockIdx, trialIdx)
+ *
+ * Delete the trial at trialIdx from the block at blockIdx. Throws on
+ * out-of-bounds. v3 spec requires a non-empty trials list, so removing the
+ * last trial would produce an invalid block — guard against that here.
+ */
+function docRemoveTrialFromBlock(experiment, blockIdx, trialIdx) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docRemoveTrialFromBlock: experiment has no _doc handle', 'NO_DOC');
+    }
+    const block = experiment.sequence[blockIdx];
+    if (!block || block.kind !== 'block') {
+        throw new V3ParseError(
+            'docRemoveTrialFromBlock: sequence[' + blockIdx + '] is not a block',
+            'INVALID_INPUT'
+        );
+    }
+    const n = block.trials.length;
+    if (trialIdx < 0 || trialIdx >= n) {
+        throw new V3ParseError(
+            'docRemoveTrialFromBlock: trialIdx ' + trialIdx + ' out of bounds [0, ' + n + ')',
+            'BAD_PATH'
+        );
+    }
+    if (n === 1) {
+        throw new V3ParseError(
+            'docRemoveTrialFromBlock: cannot remove the last trial — v3 spec requires non-empty trials. Remove the whole block instead.',
+            'INVALID_INPUT'
+        );
+    }
+    const trialsNode = experiment._doc.getIn(['experiment', blockIdx, 'trials'], true);
+    if (!trialsNode || !Array.isArray(trialsNode.items)) {
+        throw new V3ParseError(
+            'docRemoveTrialFromBlock: doc/model divergence — no trials seq at experiment[' + blockIdx + ']',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+    trialsNode.items.splice(trialIdx, 1);
+    block.trials.splice(trialIdx, 1);
+}
+
+/**
  * docAppendSequenceEntry(experiment, entry)
  *
  * Append an entry to `experiment:` (the sequence). `entry` can be a ref —
@@ -1215,6 +1326,9 @@ const ProtocolV3 = {
     docInsertSequenceEntry,
     docMoveSequenceEntry,
     docRemoveSequenceEntry,
+    docInsertTrialInBlock,
+    docMoveTrialInBlock,
+    docRemoveTrialFromBlock,
     docSetPluginCommandHead,
     docAddPluginParam,
     docDeletePluginParam,
@@ -1249,6 +1363,9 @@ export {
     docInsertSequenceEntry,
     docMoveSequenceEntry,
     docRemoveSequenceEntry,
+    docInsertTrialInBlock,
+    docMoveTrialInBlock,
+    docRemoveTrialFromBlock,
     docSetPluginCommandHead,
     docAddPluginParam,
     docDeletePluginParam,

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -37,6 +37,9 @@ const {
     docInsertSequenceEntry,
     docMoveSequenceEntry,
     docRemoveSequenceEntry,
+    docInsertTrialInBlock,
+    docMoveTrialInBlock,
+    docRemoveTrialFromBlock,
     docSetPluginCommandHead,
     docAddPluginParam,
     docDeletePluginParam,
@@ -1639,6 +1642,157 @@ checkThrows(
         docRemoveSequenceEntry(exp, -1);
     },
     'BAD_PATH'
+);
+
+// ─── Test Suite 25: docInsertTrialInBlock ──────────────────────────────────
+console.log('\n--- Suite 25: docInsertTrialInBlock (drop library row on block) ---');
+
+{
+    // canonical_a has a block at sequence[2] (main block, 7 trials)
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex(e => e.kind === 'block');
+    const before = exp.sequence[blockIdx].trials.length;
+
+    docInsertTrialInBlock(exp, blockIdx, 0, 'arena check');
+    check('insert-trial: at start grows length', exp.sequence[blockIdx].trials.length, before + 1);
+    check('insert-trial: trial[0] is the new one', exp.sequence[blockIdx].trials[0], 'arena check');
+
+    docInsertTrialInBlock(exp, blockIdx, 3, 'arena check');
+    check('insert-trial: middle places trial', exp.sequence[blockIdx].trials[3], 'arena check');
+
+    docInsertTrialInBlock(exp, blockIdx, exp.sequence[blockIdx].trials.length, 'arena check');
+    check(
+        'insert-trial: at end appends',
+        exp.sequence[blockIdx].trials[exp.sequence[blockIdx].trials.length - 1],
+        'arena check'
+    );
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check(
+        'insert-trial: round-trip length',
+        reparsed.sequence[blockIdx].trials.length,
+        before + 3
+    );
+}
+
+{
+    // Index clamping
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex(e => e.kind === 'block');
+    docInsertTrialInBlock(exp, blockIdx, -5, 'arena check');
+    check('insert-trial: negative clamps to 0', exp.sequence[blockIdx].trials[0], 'arena check');
+
+    const exp2 = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx2 = exp2.sequence.findIndex(e => e.kind === 'block');
+    const len = exp2.sequence[blockIdx2].trials.length;
+    docInsertTrialInBlock(exp2, blockIdx2, 999, 'arena check');
+    check('insert-trial: too-large clamps to end', exp2.sequence[blockIdx2].trials[len], 'arena check');
+}
+
+checkThrows(
+    'insert-trial: rejects non-block target',
+    () => {
+        const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+        // sequence[0] is a ref, not a block
+        docInsertTrialInBlock(exp, 0, 0, 'arena check');
+    },
+    'INVALID_INPUT'
+);
+
+checkThrows(
+    'insert-trial: rejects empty condName',
+    () => {
+        const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+        const blockIdx = exp.sequence.findIndex(e => e.kind === 'block');
+        docInsertTrialInBlock(exp, blockIdx, 0, '');
+    },
+    'INVALID_INPUT'
+);
+
+// ─── Test Suite 26: docMoveTrialInBlock ────────────────────────────────────
+console.log('\n--- Suite 26: docMoveTrialInBlock (reorder trial within block) ---');
+
+{
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex(e => e.kind === 'block');
+    const origTrials = exp.sequence[blockIdx].trials.slice();
+
+    docMoveTrialInBlock(exp, blockIdx, 0, 2);
+    check(
+        'move-trial: first moves to position 2',
+        exp.sequence[blockIdx].trials.join('|'),
+        [origTrials[1], origTrials[2], origTrials[0], ...origTrials.slice(3)].join('|')
+    );
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check(
+        'move-trial: round-trip new order',
+        reparsed.sequence[blockIdx].trials[2],
+        origTrials[0]
+    );
+}
+
+{
+    // No-op / out-of-range
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex(e => e.kind === 'block');
+    const before = exp.sequence[blockIdx].trials.join('|');
+    docMoveTrialInBlock(exp, blockIdx, 1, 1);
+    docMoveTrialInBlock(exp, blockIdx, 99, 0);
+    docMoveTrialInBlock(exp, blockIdx, -1, 0);
+    check(
+        'move-trial: no-op / OOR preserves order',
+        exp.sequence[blockIdx].trials.join('|'),
+        before
+    );
+}
+
+// ─── Test Suite 27: docRemoveTrialFromBlock ────────────────────────────────
+console.log('\n--- Suite 27: docRemoveTrialFromBlock (✕ on trial chip) ---');
+
+{
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex(e => e.kind === 'block');
+    const before = exp.sequence[blockIdx].trials.length;
+    const removed = exp.sequence[blockIdx].trials[0];
+
+    docRemoveTrialFromBlock(exp, blockIdx, 0);
+    check('remove-trial: length shrinks', exp.sequence[blockIdx].trials.length, before - 1);
+    checkTrue('remove-trial: removed gone', !exp.sequence[blockIdx].trials.includes(removed));
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('remove-trial: round-trip length', reparsed.sequence[blockIdx].trials.length, before - 1);
+}
+
+checkThrows(
+    'remove-trial: rejects out-of-bounds',
+    () => {
+        const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+        const blockIdx = exp.sequence.findIndex(e => e.kind === 'block');
+        docRemoveTrialFromBlock(exp, blockIdx, 999);
+    },
+    'BAD_PATH'
+);
+
+checkThrows(
+    'remove-trial: rejects removing last trial (would leave block empty)',
+    () => {
+        // Build a synthetic 1-trial block
+        const yaml = [
+            'version: 3',
+            'experiment_info: {name: x}',
+            'rig: "/tmp/r.yaml"',
+            'experiment:',
+            '  - name: blk',
+            '    trials: [only_one]',
+            'conditions:',
+            '  - name: only_one',
+            '    commands: [{type: wait, duration: 1}]'
+        ].join('\n') + '\n';
+        const exp = parseV3Protocol(yaml);
+        docRemoveTrialFromBlock(exp, 0, 0);
+    },
+    'INVALID_INPUT'
 );
 
 // ─── Results ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Second slice of Phase 4. Targets the **\`phase4a-sequence-reorder\` base branch** since this builds on the new helpers in PR #70 — once that merges to main, this PR's base will auto-retarget.

- **3 new doc helpers** (\`docInsertTrialInBlock\`, \`docMoveTrialInBlock\`, \`docRemoveTrialFromBlock\`) for editing a block's \`trials:\` seq. Remove guards against deleting the last trial (v3 spec requires a non-empty trials list).
- **Library rows are now drag sources** with mime \`text/x-library-cond\`. Sequence entry drop handlers now multiplex between the existing \`text/x-seq-idx\` reorder mime and the new library-cond ref-insert.
- **Drop on sequence empty area** → appends a ref past the last entry.
- **Drop on block trial chip** → inserts a trial before/after based on cursor X position.
- **Drop on block trial strip** (empty area) → appends a trial.
- **Trial chips draggable within block** for reorder (mime \`text/x-block-trial\`). Cross-block moves blocked in v1.
- **✕ button on each trial chip** (visible on hover, matching the existing chip-x-btn pattern). Hidden when the block has exactly one trial.

## Test plan

- [x] \`npm test\` — arena 10/10, v2 137/137, v3 **358/358** (+17 in Suites 25/26/27)
  - 25: docInsertTrialInBlock — start/middle/end inserts, idx clamping, rejects non-block target / empty condName
  - 26: docMoveTrialInBlock — reorder, no-op on OOR, round-trip stable
  - 27: docRemoveTrialFromBlock — remove middle trial, rejects OOB, rejects removing last trial
- [x] Browser (v3_canonical_a): drag \"arena check\" library row onto first sequence entry → new ref inserted at top (seq 4 → 5); drag onto main block's first trial chip → trial added (trials 7 → 8); click new chip's ✕ → trial removed (trials 8 → 7)
- [x] No console errors
- [ ] Hard-refresh on GitHub Pages after merge

Footer: \`v3 Experiment Designer v0.6 | 2026-05-27 16:05 ET\`

## Next

Phase 4c — right-click context menus to convert ref ↔ single-trial block; missing trial-chip → \"Create this condition\" affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)