### PR TITLE
feat(v3): right-click ref↔block convert + missing-trial create (Phase 4c)

### DIFF
--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -978,7 +978,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.7 | <span id="footerTimestamp">2026-05-27 16:57 ET</span>
+        v3 Experiment Designer v0.8 | <span id="footerTimestamp">2026-05-27 17:28 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -1009,6 +1009,7 @@
             docInsertSequenceEntry,
             docMoveSequenceEntry,
             docRemoveSequenceEntry,
+            docReplaceSequenceEntry,
             docInsertTrialInBlock,
             docMoveTrialInBlock,
             docRemoveTrialFromBlock,
@@ -1535,6 +1536,87 @@
             }
         }
 
+        // Right-click handler — convert a sequence entry between ref and
+        // single-trial block. A block is "convertible" to a ref only when it
+        // has exactly 1 trial, 1 rep, no randomize, and no intertrial (i.e.,
+        // it's semantically equivalent to a bare ref). Non-convertible blocks
+        // show a soft error instead.
+        function isConvertibleBlock(entry) {
+            return entry &&
+                entry.kind === 'block' &&
+                entry.trials.length === 1 &&
+                (entry.repetitions || 1) === 1 &&
+                !entry.randomize &&
+                !entry.intertrial;
+        }
+
+        function onConvertSequenceEntry(idx) {
+            const entry = experiment.sequence[idx];
+            if (!entry) return;
+            if (entry.kind === 'ref') {
+                if (!confirm('Convert ref "' + entry.condition_name + '" to a single-trial block?')) return;
+                pushUndo();
+                try {
+                    docReplaceSequenceEntry(experiment, idx, {
+                        kind: 'block',
+                        name: entry.condition_name,
+                        trials: [entry.condition_name],
+                        repetitions: 1
+                    });
+                    setDirty(true);
+                    selection = { kind: 'block', index: idx };
+                    renderAll();
+                } catch (err) {
+                    showError('Convert failed', err.message);
+                }
+            } else if (entry.kind === 'block') {
+                if (!isConvertibleBlock(entry)) {
+                    showError(
+                        'Cannot convert block to ref',
+                        'Only blocks with exactly 1 trial, 1 repetition, no randomize, and no intertrial can convert to a bare ref. ' +
+                        'This block has ' + entry.trials.length + ' trial(s), ' +
+                        (entry.repetitions || 1) + ' rep(s), randomize=' + (entry.randomize ? 'on' : 'off') + ', ' +
+                        (entry.intertrial ? 'intertrial=' + entry.intertrial : 'no intertrial') + '.'
+                    );
+                    return;
+                }
+                const trial = entry.trials[0];
+                if (!confirm('Convert block "' + (entry.name || 'block_' + (idx + 1)) + '" to a bare ref to "' + trial + '"?')) return;
+                pushUndo();
+                try {
+                    docReplaceSequenceEntry(experiment, idx, { kind: 'ref', condition_name: trial });
+                    setDirty(true);
+                    selection = { kind: 'ref', index: idx };
+                    renderAll();
+                } catch (err) {
+                    showError('Convert failed', err.message);
+                }
+            }
+        }
+
+        // Create a missing condition referenced from the sequence (either a
+        // bare ref to a missing condition, or a trial chip / intertrial that
+        // points at a name not in conditions:). Creates a minimal valid
+        // condition with [{type:'wait', duration:1}] as the placeholder; the
+        // user edits commands after.
+        function onCreateMissingCondition(name) {
+            if (!experiment) return;
+            if (experiment.conditions.find((c) => c.name === name)) {
+                showError('Create failed', 'A condition named "' + name + '" already exists.');
+                return;
+            }
+            if (!confirm('Create a new condition "' + name + '" with a placeholder wait command?')) return;
+            pushUndo();
+            try {
+                docInsertCondition(experiment, name, [{ type: 'wait', duration: 1 }]);
+                setDirty(true);
+                selection = { kind: 'condition', name };
+                renderAll();
+            } catch (err) {
+                showError('Create failed', err.message);
+            }
+        }
+
         function onRemoveSequenceEntry(idx) {
             pushUndo();
             try {
@@ -1751,13 +1833,28 @@
                 );
 
                 if (entry.kind === 'ref') {
+                    const isMissingRef = !knownConds.has(entry.condition_name);
+                    const missingBadge = isMissingRef
+                        ? el('span', {
+                            class: 'trial-chip missing',
+                            title: 'Right-click for options',
+                            onClick: (e) => {
+                                e.stopPropagation();
+                                onCreateMissingCondition(entry.condition_name);
+                            }
+                          }, 'missing — click to create')
+                        : null;
                     const card = el('div', {
                         class: 'seq-entry ref' + (isSelected ? ' selected' : ''),
-                        onClick: () => { selection = { kind: 'ref', index: idx }; renderSequence(); renderInspector(); renderLibrary(); }
+                        onClick: () => { selection = { kind: 'ref', index: idx }; renderSequence(); renderInspector(); renderLibrary(); },
+                        onContextMenu: (e) => {
+                            e.preventDefault();
+                            onConvertSequenceEntry(idx);
+                        }
                     },
                         el('span', { class: 'marker' }, '▸'),
                         el('span', { class: 'name' }, entry.condition_name),
-                        !knownConds.has(entry.condition_name) ? el('span', { class: 'trial-chip missing' }, 'missing') : null,
+                        missingBadge,
                         makeActions(idx)
                     );
                     attachDrag(card, idx);
@@ -1774,10 +1871,12 @@
                         const isMissing = !knownConds.has(t);
                         const chip = el('span', {
                             class: 'trial-chip' + (isMissing ? ' missing' : ''),
-                            title: isMissing ? 'Condition "' + t + '" not in library' : 'Click to view ' + t,
+                            title: isMissing ? 'Condition "' + t + '" not in library — click to create' : 'Click to view ' + t,
                             onClick: (e) => {
                                 e.stopPropagation();
-                                if (knownConds.has(t)) {
+                                if (isMissing) {
+                                    onCreateMissingCondition(t);
+                                } else {
                                     selection = { kind: 'condition', name: t };
                                     renderLibrary(); renderInspector(); renderSequence();
                                 }
@@ -1872,9 +1971,26 @@
                     });
 
                     const itiRow = entry.intertrial
-                        ? el('div', { class: 'iti-row' },
-                            'intertrial: ',
-                            el('span', { class: 'iti-ref' + (!knownConds.has(entry.intertrial) ? ' missing' : '') }, entry.intertrial))
+                        ? (() => {
+                            const itiName = entry.intertrial;
+                            const itiMissing = !knownConds.has(itiName);
+                            return el('div', { class: 'iti-row' },
+                                'intertrial: ',
+                                el('span', {
+                                    class: 'iti-ref' + (itiMissing ? ' missing' : ''),
+                                    title: itiMissing ? 'Condition "' + itiName + '" not in library — click to create' : 'Click to view ' + itiName,
+                                    style: 'cursor: pointer;',
+                                    onClick: (e) => {
+                                        e.stopPropagation();
+                                        if (itiMissing) {
+                                            onCreateMissingCondition(itiName);
+                                        } else {
+                                            selection = { kind: 'condition', name: itiName };
+                                            renderLibrary(); renderInspector(); renderSequence();
+                                        }
+                                    }
+                                }, itiName));
+                        })()
                         : null;
 
                     const unknownPill = entry._unknownKeys && Object.keys(entry._unknownKeys).length > 0
@@ -1888,7 +2004,11 @@
                     );
                     const card = el('div', {
                         class: 'seq-entry block' + (isSelected ? ' selected' : ''),
-                        onClick: () => { selection = { kind: 'block', index: idx }; renderSequence(); renderInspector(); renderLibrary(); }
+                        onClick: () => { selection = { kind: 'block', index: idx }; renderSequence(); renderInspector(); renderLibrary(); },
+                        onContextMenu: (e) => {
+                            e.preventDefault();
+                            onConvertSequenceEntry(idx);
+                        }
                     },
                         blockHead,
                         meta,

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -1124,6 +1124,38 @@ function docRemoveSequenceEntry(experiment, idx) {
 }
 
 /**
+ * docReplaceSequenceEntry(experiment, idx, newEntry)
+ *
+ * Replace the sequence entry at `idx` with a fresh ref or block built from
+ * `newEntry`. Used by the ref↔block convert affordance. Validates the new
+ * entry via _buildSequenceEntry (same kinds/shape as insert/append).
+ *
+ * Throws on out-of-bounds and on doc/model divergence.
+ */
+function docReplaceSequenceEntry(experiment, idx, newEntry) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docReplaceSequenceEntry: experiment has no _doc handle', 'NO_DOC');
+    }
+    const n = experiment.sequence.length;
+    if (idx < 0 || idx >= n) {
+        throw new V3ParseError(
+            'docReplaceSequenceEntry: idx ' + idx + ' out of bounds [0, ' + n + ')',
+            'BAD_PATH'
+        );
+    }
+    const seqNode = experiment._doc.getIn(['experiment'], true);
+    if (!seqNode || !Array.isArray(seqNode.items)) {
+        throw new V3ParseError(
+            'docReplaceSequenceEntry: doc/model divergence — no experiment seq node',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+    const built = _buildSequenceEntry(experiment._doc, newEntry);
+    seqNode.items[idx] = built.node;
+    experiment.sequence[idx] = built.jsEntry;
+}
+
+/**
  * docInsertTrialInBlock(experiment, blockIdx, atIdx, condName)
  *
  * Insert a trial reference (a condition name string) into the block at
@@ -1326,6 +1358,7 @@ const ProtocolV3 = {
     docInsertSequenceEntry,
     docMoveSequenceEntry,
     docRemoveSequenceEntry,
+    docReplaceSequenceEntry,
     docInsertTrialInBlock,
     docMoveTrialInBlock,
     docRemoveTrialFromBlock,
@@ -1363,6 +1396,7 @@ export {
     docInsertSequenceEntry,
     docMoveSequenceEntry,
     docRemoveSequenceEntry,
+    docReplaceSequenceEntry,
     docInsertTrialInBlock,
     docMoveTrialInBlock,
     docRemoveTrialFromBlock,

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -37,6 +37,7 @@ const {
     docInsertSequenceEntry,
     docMoveSequenceEntry,
     docRemoveSequenceEntry,
+    docReplaceSequenceEntry,
     docInsertTrialInBlock,
     docMoveTrialInBlock,
     docRemoveTrialFromBlock,
@@ -1791,6 +1792,61 @@ checkThrows(
         ].join('\n') + '\n';
         const exp = parseV3Protocol(yaml);
         docRemoveTrialFromBlock(exp, 0, 0);
+    },
+    'INVALID_INPUT'
+);
+
+// ─── Test Suite 28: docReplaceSequenceEntry ─────────────────────────────────
+console.log('\n--- Suite 28: docReplaceSequenceEntry (ref↔block convert) ---');
+
+{
+    // Convert a bare ref to a single-trial block
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const refIdx = 0;
+    const condName = exp.sequence[refIdx].condition_name;
+    docReplaceSequenceEntry(exp, refIdx, {
+        kind: 'block',
+        name: condName + ' block',
+        trials: [condName],
+        repetitions: 1
+    });
+    check('replace: ref → block kind', exp.sequence[refIdx].kind, 'block');
+    check('replace: block has 1 trial', exp.sequence[refIdx].trials.length, 1);
+    check('replace: trial is original cond', exp.sequence[refIdx].trials[0], condName);
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('replace: round-trip kind', reparsed.sequence[refIdx].kind, 'block');
+    check('replace: round-trip trial', reparsed.sequence[refIdx].trials[0], condName);
+}
+
+{
+    // Convert a block back to a ref
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const blockIdx = exp.sequence.findIndex(e => e.kind === 'block');
+    const firstTrial = exp.sequence[blockIdx].trials[0];
+    docReplaceSequenceEntry(exp, blockIdx, { kind: 'ref', condition_name: firstTrial });
+    check('replace: block → ref kind', exp.sequence[blockIdx].kind, 'ref');
+    check('replace: ref condition_name', exp.sequence[blockIdx].condition_name, firstTrial);
+
+    const reparsed = parseV3Protocol(generateV3Protocol(exp));
+    check('replace: round-trip kind', reparsed.sequence[blockIdx].kind, 'ref');
+    check('replace: round-trip name', reparsed.sequence[blockIdx].condition_name, firstTrial);
+}
+
+checkThrows(
+    'replace: rejects out-of-bounds',
+    () => {
+        const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+        docReplaceSequenceEntry(exp, 999, { kind: 'ref', condition_name: 'x' });
+    },
+    'BAD_PATH'
+);
+
+checkThrows(
+    'replace: rejects bad entry kind',
+    () => {
+        const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+        docReplaceSequenceEntry(exp, 0, { kind: 'bogus' });
     },
     'INVALID_INPUT'
 );


### PR DESCRIPTION
## Summary

Final slice of Phase 4. Sequence entries expose a right-click convert action between ref and single-trial block; missing trial chips (and missing bare refs / missing intertrials) become clickable to create the referenced condition with a placeholder wait command.

- **New helper** \`docReplaceSequenceEntry(experiment, idx, newEntry)\` builds a fresh ref or block via the existing \`_buildSequenceEntry\` factory and swaps the YAMLSeq item + JS mirror at \`idx\`. Same validation as the insert / append helpers; throws on out-of-bounds and doc/model divergence.
- **Right-click → convert**. Refs prompt \"Convert to single-trial block?\" → builds a block with that condition as its only trial (reps=1, no randomize, no iti). Blocks are converted to refs only when convertible (exactly 1 trial, 1 rep, no randomize, no iti); non-convertible blocks show a soft error explaining why.
- **Missing-condition create affordance**. Trial chips inside a block, the missing badge on top-level refs, and the intertrial label all become clickable when their condition isn't in the library. The handler confirms, then calls \`docInsertCondition\` with \`[{type:'wait', duration:1}]\` as a placeholder; selection lands on the new condition so the user can edit it immediately.

## Test plan

- [x] \`npm test\` — arena 10/10, v2 137/137, v3 **369/369** (+11 in Suite 28)
  - 28: \`docReplaceSequenceEntry\` — ref→block round-trip; block→ref round-trip; rejects out-of-bounds; rejects bad entry kind
- [x] Browser (v3_canonical_a): right-click first ref → ref converts to block (className flips \`seq-entry ref\` → \`seq-entry block selected\`); right-click that block → converts back to ref
- [x] Non-convertible block right-click → shows the \"Cannot convert\" error explaining trial count / reps / randomize / iti
- [x] Missing-trial \`onCreateMissingCondition\` path code-verified — synthetic missing-ref YAML can't be imported (validateReferences blocks dangling refs at parse), so the chip onClick branch is the only way to surface the affordance; it reuses already-tested \`docInsertCondition\`
- [x] No console errors
- [ ] Hard-refresh on GitHub Pages after merge

Footer: \`v3 Experiment Designer v0.8 | 2026-05-27 17:28 ET\`

## Phase 4 complete

All four pieces of Phase 4 (sequence editing) shipped across PRs #70, #72, #73, and this one:
- **4a** (#70): sequence reorder + Add ref/block + delete
- **4b** (#72): drag library row to sequence + block trial editing
- **Timeline ribbon** (#73): cumulative-time ruler + click-to-select
- **4c** (this PR): right-click ref↔block convert + missing-trial create

🤖 Generated with [Claude Code](https://claude.com/claude-code)