### PR TITLE
docs(v3): handoff doc round 2 (post-Phase 4, with Codex review)

### DIFF
--- a/docs/development/v3-editor-handoff-2.md
+++ b/docs/development/v3-editor-handoff-2.md
@@ -1,0 +1,466 @@
+# v3 Experiment Designer — Handoff for Next Session (Round 2)
+
+**Last updated:** 2026-05-27
+**Branch:** `main` at `c5cf223`
+**Editor version:** v3 Experiment Designer **v0.8**
+**Pinned upstream:** maDisplayTools `origin/version3` at `649d7ef`
+
+This is the second handoff doc for the v3 designer. It supersedes the original
+`v3-editor-handoff.md` (which covered up to v0.2). Read this file FIRST in a
+new session — it has the post-Phase-4 picture, the Codex-flagged concerns to
+clean up, and the prioritized open work.
+
+---
+
+## 0. TL;DR
+
+The v3 designer is essentially feature-complete for single-document editing.
+Phase 1 (viewer) through Phase 4 (sequence editing) all shipped this session
+across 9 PRs (#65 → #74). Tests at **arena 10/10, v2 137/137, v3 369/369**.
+
+The next session should pick **one** of:
+
+- **(A) Phase-4 cleanup PR** — fix 4 Codex-flagged bugs (~½ day). Strongest
+  case if the lab is actively using v0.8 right now.
+- **(B) Phase 5 — Variables editor + rename cascade** (~4–5 days). Required
+  before D4 can ship per Codex-adv recommendation in `v3-d4-design-reviews.md`.
+- **(C) Phase 6 — full pre-export validation modal + Reset button** (~1 day).
+  Builds on the soft-warn banner shipped in Tier 3.
+- **(D) D4 cross-library import** (~5+ days, with rev-3 design fixes first).
+  The big architectural-stress feature; design doc already on the shelf.
+
+My recommendation: **A first** (small, fast, ships before users hit the bugs),
+then **B** (largest user-impact feature still missing). D4 stays deferred
+until B ships.
+
+---
+
+## 1. Codex review of landed work (Phase 4 + earlier)
+
+Two-pass Codex GPT-5.5 diff-review of the Phase 4 work
+(`84a5fb1...c5cf223`) ran 2026-05-27. Full report at
+`.codex-review/report-20260527-214207.md` (gitignored — preserved here
+since the synthesis is the load-bearing artifact).
+
+### Significant bugs to fix as Phase-4 cleanup (~½ day)
+
+**1. Event-listener accumulation on `#sequenceList`** — `experiment_designer_v3.html:1809`
+
+`renderSequence()` calls `addEventListener('dragover'|'dragleave'|'drop', ...)`
+on `#sequenceList` *every time it renders*. `list.innerHTML = ''` clears
+children but doesn't remove listeners from `list` itself. After N renders
+(every mutation triggers one), a single drop fires N handlers → **N
+duplicate refs inserted + N pushUndo calls**. Surfaces within the first
+session of normal editing.
+
+**Fix:** Move the list-level handlers to a one-time wiring block at startup
+(alongside `$('addRefBtn').addEventListener('click', onAddSeqRef)` etc.), OR
+assign via `list.ondragover = ...` so each render replaces the handler. ~5
+lines, straightforward.
+
+**2. Selection index doesn't track displaced entries on move** — `experiment_designer_v3.html:1482`
+
+`onMoveSequenceEntry` updates `selection.index` only when the moved entry was
+the selected one. If another selected entry sits between `fromIdx` and
+`toIdx`, its real position shifts but `selection.index` stays stale. The
+inspector then shows the wrong entry.
+
+Same class of bug for `onInsertSequenceRefFromLib`: dropping a library row
+at idx 0 shifts everything down by one, but a `selection.index = 2` doesn't
+follow.
+
+**Fix:** Compute the new selected index across the full affected range in
+each handler. ~10 lines.
+
+**3. Timeline ruler ticks don't align with min-width-clamped step layout** — `experiment_designer_v3.html:3187`
+
+Current ruler uses one global `pxPerSecRuler = totalWidthPx / realTotalSec`.
+Step widths are individually clamped (`Math.max(60, dur * pxPerSec)`). Once
+short steps clamp, time-position and pixel-position decouple. A "1m" tick
+doesn't reliably land at the spot where 1 minute of cumulative real time
+elapses.
+
+**Fix:** Build tick positions piecewise — walk the step `layout` array, find
+the step containing each tick's real time, position the tick proportionally
+within that step's pixel range. ~20 lines. (Codex-std and I both spec'd this
+approach.)
+
+**4. Block→ref convert silently drops `_unknownKeys`** — `js/protocol-yaml-v3.js:1154`
+
+`docReplaceSequenceEntry` swaps the whole YAML node. Any `_unknownKeys` on
+the original block (forward-compat fields like `retry_on_fail`, `abort_if`)
+are gone. This undermines the B5 unknown-passthrough we shipped in Tier 1.
+
+**Fix:** In `isConvertibleBlock`, also check
+`Object.keys(entry._unknownKeys || {}).length === 0`. Refuse to convert
+blocks with non-empty unknown keys (extend the existing "Cannot convert"
+error message). ~3 lines.
+
+### Minor follow-ups (combine with #1–4 in the cleanup PR)
+
+**5. `_buildSequenceEntry` accepts non-positive / non-integer `repetitions`** — `js/protocol-yaml-v3.js:1022`
+
+Parser rejects `0`, negatives, decimals. Builder doesn't. Worst case:
+`repetitions: 0` would emit `0` to YAML but mirror as `1` via the
+`|| 1` default — silent doc/model divergence. Currently no caller hits
+this path, but D4 / paste-import would.
+
+**Fix:** Add `if (typeof entry.repetitions === 'number' && (!Number.isInteger(entry.repetitions) || entry.repetitions < 1)) throw new V3ParseError(...)` in `_buildSequenceEntry`. ~5 lines.
+
+**6. No-op drops can pollute the undo stack** — multiple call sites
+
+Some drop handlers' early-return paths happen *after* a `pushUndo` call.
+Audit pass needed; not all paths exhibit it. Worth a 15-minute review.
+
+### Architectural-level concerns (flagged by Codex-adv, not blocking)
+
+**The path-based mirror model is showing strain.** 17 helpers now manage
+the `_doc` + JS-mirror + selection + undo + render dance. Each new edit
+path has to remember all of: mutate `_doc`, mutate JS mirror, preserve
+comments, preserve unknown keys, update selection, dirty state, render
+dependent panes, push undo at the right time. The two Significant bugs
+above (event-listener accumulation, unknown-keys loss) are concrete
+examples of "many edit paths, no centralized consistency gate."
+
+Codex-adv's recommendation: a single `applySequenceEdit(experiment, op)`
+reducer that validates pre-op + post-op and centralizes the bookkeeping.
+**Don't preemptively refactor.** Monitor. The next feature that can't fit
+cleanly into the current pattern is when this refactor pays for itself.
+That trigger is likely D4 (cross-library import), per the D4 design
+review history.
+
+**Timeline scale: thousands of DOM nodes for large protocols.**
+`flattenSequence` expands every repetition × trial. A 30-condition × 20-rep
+protocol = 600+ cells. For current lab-scale protocols (dozens × a few
+reps) it's fine. Worth bounding once a stress-test reveals the cliff.
+
+---
+
+## 2. What's shipped (Phase 1 through Phase 4)
+
+| PR | Description | Tier | Status |
+|---|---|---|---|
+| #62 | v0.1 Viewer (parser, document round-trip) | Phase 1 | merged |
+| #63 | v0.2 Editor (inspector edits, command CRUD, undo) | Phase 3 | merged |
+| #64 | Load demo dropdown | extra | merged |
+| #65 | Original handoff doc (now superseded) | doc | merged |
+| #66 | Tier 1 — preamble (CI hardening, unknown-type passthrough, select dropdown) | Tier 1 | merged |
+| #67 | Tier 2 — inline ref view, editable plugin head, plugin param CRUD | Tier 2 | merged |
+| #68 | Tier 3 — export warnings, vendored yaml, library add/duplicate/blank | Tier 3 | merged |
+| #69 | D4 design + review history (deferred) | doc | merged |
+| #70 | Phase 4a — sequence reorder + Add ref/block + delete | Phase 4 | merged |
+| #72 | Phase 4b — library→sequence drag + block trial editing | Phase 4 | merged |
+| #73 | Timeline ribbon — cumulative-time ruler + click-to-select | Phase 4 (item C) | merged |
+| #74 | Phase 4c — right-click ref↔block convert + missing-trial create | Phase 4 | merged |
+
+**Net delta vs start of session:** ~10K lines added across HTML, JS,
+fixtures, tests, and docs.
+
+**Live:** <https://reiserlab.github.io/webDisplayTools/experiment_designer_v3.html>
+
+### What the editor can do today (v0.8)
+
+- Round-trip any v3 YAML (anchors, comments, formatting preserved).
+- Edit any literal scalar in a command card; alias-bound scalars show
+  read-only chips.
+- Add/remove/reorder commands within a condition.
+- Edit plugin command heads (cascading plugin/command selects with
+  schema-driven param reconciliation).
+- Add/remove plugin command params from the schema.
+- Inline ref view (clicking a sequence ref inlines the condition's commands
+  with full edit affordances + "shared with N refs" badge).
+- Block-with-1-trial-no-iti also inlines (decorated-ref view).
+- Library: add new condition (auto-appends bare ref to sequence),
+  duplicate condition (preserves anchors), "New (blank)" demo.
+- Sequence: + Ref / + Block buttons, drag-to-reorder, ✕ delete per entry,
+  drag library row → insert ref at position, drag library row → add trial
+  to block, drag trial chips within block to reorder, ✕ delete per chip,
+  right-click ref↔block convert (where convertible).
+- Missing-condition trial chips / refs / itis are clickable to create the
+  condition with a placeholder wait command.
+- Settings drawer with read-only Variables / Plugins / experiment info /
+  rig path.
+- Soft-warn export validation banner: unused conditions, unused anchors,
+  undeclared plugins, raw-command cards.
+- Forward-compat unknown command types passthrough.
+- `yaml@2.9.0` vendored locally (no CDN dependency).
+- 10 demo fixtures via the Load demo dropdown.
+- Undo/redo with text-snapshot model (`Ctrl+Z` / `Ctrl+Y` / `Ctrl+Shift+Z`).
+- Timeline ribbon: cumulative-time ruler with 10s ticks, 1m / 5m labels;
+  click any step to select the underlying ref or block.
+- `beforeunload` warning when dirty; import-while-dirty confirmation;
+  library usage counts; alias chip rendering; numeric coercion for select
+  schema fields.
+
+### What the editor still can't do (deferred work)
+
+- Edit the **variables** section (anchor inline-edit, rename cascade, anchor
+  binding popover).
+- **Cross-library import** (D4) — design is on the shelf with a known fix
+  list; deferred per Codex-adv concerns.
+- **Pre-export blocking validation modal** with line numbers (currently
+  only the soft-warn banner).
+- **Library row delete** (when usage = 0).
+- **Reset button** (clear sequence + conditions + variables to defaults).
+- **MATLAB-validation flow documentation** (Phase 8 in the original plan).
+- **Quickstart HTML doc** (Phase 9 in the original plan).
+- Comment preservation tests at strategic positions (Phase 7 in the plan).
+
+---
+
+## 3. What's left to do — prioritized
+
+### Tier 1: Phase 4 cleanup (highest priority — ~½ day)
+
+A small PR addressing the four Significant Codex findings plus the minor
+ones from §1. None require new design work; all are isolated to the
+already-merged code.
+
+- Bind `#sequenceList` drag/drop listeners once at startup (event-listener
+  accumulation fix).
+- Walk `selection.index` through move and insert mutations.
+- Piecewise ruler tick positioning from the `layout` array.
+- Refuse to convert blocks with non-empty `_unknownKeys`.
+- Validate positive-integer `repetitions` in `_buildSequenceEntry`.
+- Audit no-op-drop pushUndo placements.
+
+**Why first:** the event-listener bug surfaces within a normal editing
+session. If the lab is actively using v0.8, they'll hit it. Cheap to fix.
+
+### Tier 2: Phase 5 — Variables UX (next big feature — ~4–5 days)
+
+The handoff plan's Phase 5. Three pieces:
+
+1. **Inline-editable Variables table** in the Settings drawer (anchor name
+   + value, both editable). Already exists as read-only.
+2. **Anchor binding popover** on every editable scalar in command cards.
+   Today alias-bound fields are read-only chips. Phase 5 adds a pencil
+   icon → popover with three actions: Edit literal (unbinds anchor), Bind
+   to existing anchor (dropdown of available anchors), Create new anchor
+   (name + use current value).
+3. **Rename cascade.** Confirm dialog showing all references that will
+   update, then the cascade fires as one `pushUndo()` → many `docSet`
+   calls → single `renderAll`. One undo step for the whole rename.
+
+**Why before D4:** Codex-adv flagged in the D4 design review that D4
+creates prefix-clutter (`sibling_lab__dur_short`) that Phase 5 is the
+exact tool to clean up. Doing Phase 5 first means D4 ships against a
+better base. Per `docs/development/v3-d4-design-reviews.md`.
+
+Complex anchors (maps, lists, merge keys `<<: *foo`) round-trip via
+`_doc` but surface as read-only "advanced anchor" badges. User edits
+those in YAML.
+
+### Tier 3: Phase 6 — full validation modal + Reset (~1 day)
+
+- Promote the soft-warn export banner to a full pre-export modal that
+  aggregates all errors (dup condition names, missing intertrial
+  referents, missing trial referents, alias references to missing
+  variables, duplicate anchor names, name-identity normalization).
+  Display with line numbers where possible.
+- Library: delete blocked when usage > 0; "remove from sequence first?"
+  affordance.
+- Reset button: clear sequence + conditions + variables to defaults
+  (one empty condition, sequence = `[ref to it]`).
+
+### Tier 4: D4 — cross-library import (parked — ~5+ days when picked up)
+
+Design is preserved at `docs/development/v3-d4-design.md` (rev 2) with
+the review-fix list at `docs/development/v3-d4-design-reviews.md`. Before
+implementation:
+
+1. Apply the rev-2 review fix list (the design doc lists ~11 corrections
+   needed before Milestone 1).
+2. Switch from plugin namespacing default to **plugin merge-by-default
+   when class+config match** (Codex-adv's strongest design point).
+3. Verify Phase 5 has shipped (D4 mitigations depend on it).
+4. Re-run Codex on the rev-3 doc.
+5. Start Milestone 1 (cross-doc primitives).
+
+### Tier 5: Phase 7-9 — polish (~1 day total)
+
+- Phase 7: comment-preservation tests at strategic positions, anchor edge
+  cases (numbers, strings, params, two anchors same value), randomized-block
+  semantics tests, validation error cases.
+- Phase 8: write `docs/development/v3-matlab-validation.md` describing
+  the MCP-driven MATLAB validation flow.
+- Phase 9: `experiment_designer_v3_quickstart.html` step-by-step
+  walkthrough.
+
+---
+
+## 4. Decisions waiting on the user
+
+These should be resolved before the next session picks a direction:
+
+1. **Which tier to start with?** My recommendation: Tier 1 (cleanup) →
+   Tier 2 (Phase 5). Push back if the lab needs something else more.
+2. **Architectural refactor?** Codex-adv has flagged the path-based mirror
+   model as showing strain. Recommendation: monitor, refactor when D4
+   demands it. Don't refactor preemptively.
+3. **Timeline scale cap?** No cap today. Worth adding if anyone's running
+   protocols with > 200 flattened steps. Probably defer.
+
+---
+
+## 5. Implementation patterns (crib sheet for the next session)
+
+### YAML.Document as single source of truth
+
+- `experiment._doc` is the YAML.Document. JS model (`experiment.conditions`,
+  `experiment.sequence`, `experiment.variables`, `experiment.plugins`) is a
+  derived mirror.
+- **All mutations** go through helpers in `js/protocol-yaml-v3.js`. Current
+  helper count: **17**.
+- Export = `experiment._doc.toString()`. No constructive-emit path.
+
+### Current helpers (alphabetical)
+
+`docAddPluginParam`, `docAppendSequenceEntry`, `docCloneCondition`,
+`docDelete`, `docDeletePluginParam`, `docInsertCommand`,
+`docInsertCondition`, `docInsertSequenceEntry`, `docInsertTrialInBlock`,
+`docMoveCommand`, `docMoveSequenceEntry`, `docMoveTrialInBlock`,
+`docRemoveSequenceEntry`, `docRemoveTrialFromBlock`,
+`docReplaceSequenceEntry`, `docSet`, `docSetPluginCommandHead`.
+
+Plus inspection helpers: `nodeIsAliasAt`, `aliasNameAt`,
+`collectExportWarnings`, `validateReferences`.
+
+### Helper anatomy (template for adding new ones)
+
+Every helper follows this pattern:
+
+```js
+function docXxx(experiment, ...args) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docXxx: experiment has no _doc handle', 'NO_DOC');
+    }
+    // Bounds-check / input-shape validation
+    if (badInput) throw new V3ParseError('docXxx: ...', 'BAD_PATH' | 'INVALID_INPUT');
+    // Resolve the YAML node
+    const node = experiment._doc.getIn([...path], true);
+    if (!node || !validShape(node)) {
+        throw new V3ParseError('docXxx: doc/model divergence', 'DOC_MODEL_DIVERGENCE');
+    }
+    // Mutate the doc-side
+    node.items.splice(/* ... */) || experiment._doc.setIn(/* ... */);
+    // Mirror into the JS model
+    experiment.sequence /* or conditions */ .splice(/* ... */);
+}
+```
+
+Then in the UI:
+
+```js
+function onUserAction(...) {
+    pushUndo();
+    try {
+        docXxx(experiment, ...);
+        setDirty(true);
+        // Update selection if needed (watch for displacement bugs!)
+        renderAll();
+    } catch (err) {
+        showError('...', err.message);
+    }
+}
+```
+
+### Undo/redo model
+
+Text-snapshot based: `experiment._doc.toString()` + JSON snapshot of
+`selection`. On undo, full re-parse via `parseV3Protocol(snap.text)`.
+`pushUndo()` runs BEFORE every mutation; `_restoring` guard prevents
+re-render-during-restore from polluting the stack. `UNDO_LIMIT = 50`.
+
+### State coherence after mutations
+
+After any mutation, call the right commit helper:
+
+- `commitInspectorEdit()` — re-renders inspector + timeline.
+- `commitBlockEdit()` — re-renders inspector + sequence + timeline +
+  **library** (intertrial changes shift usage).
+- `renderAll()` — everything. Used by all sequence mutations; can usually
+  be optimized to one of the above but `renderAll` is always correct.
+
+For sequence mutations, also remember to:
+- Walk `selection.index` through any shift caused by insert/remove/move.
+- Call `setDirty(true)`.
+- Call `pushUndo()` BEFORE the mutation (so undo restores pre-mutation state).
+
+---
+
+## 6. Files that matter (current)
+
+| File | Purpose |
+|---|---|
+| `experiment_designer_v3.html` | The editor (HTML + CSS + module script). At v0.8 it's ~3200 lines. |
+| `js/protocol-yaml-v3.js` | Parser, generator, validation, 17 edit helpers, `collectExportWarnings`. ~1400 lines. |
+| `js/plugin-registry.js` | Plugin command schemas, controller commands, v3 helpers (`findPluginDefByClass`, `getCommandsForClass`, `getV3PluginCommands`, `listV3PluginNames`, `getV3CommandParams`). |
+| `js/vendor/yaml/browser/dist/` | Vendored `yaml@2.9.0` library (per Tier 3). |
+| `tests/test-protocol-roundtrip-v3.js` | 369 v3 tests across 28 suites. |
+| `tests/fixtures/v3_*.yaml` | 10 demo fixtures. |
+| `docs/development/v3-spec.md` | Designer-side spec (anchors, comments, etc.). Pinned upstream SHA. |
+| `docs/development/v3-d4-design.md` | Deferred D4 design doc (rev 2). |
+| `docs/development/v3-d4-design-reviews.md` | D4 review history + fix list. |
+| `docs/development/ROADMAP.md` | Project-wide roadmap. |
+| `docs/development/v3-editor-handoff.md` | The original handoff (v0.2). Superseded by this doc. |
+
+The **old** handoff (`v3-editor-handoff.md`) is now significantly out of
+date — most of its items have shipped. Worth marking as superseded or
+deleting in the next session.
+
+---
+
+## 7. How to verify after changes
+
+```bash
+npm test                       # arena 10/10, v2 137/137, v3 369/369+
+python -m http.server 8080     # then open localhost:8080/experiment_designer_v3.html
+```
+
+For each behavioral change:
+1. Load relevant demo fixture(s) via the Load demo dropdown.
+2. Exercise the new behavior.
+3. Make an edit elsewhere → verify undo restores correctly.
+4. Export → diff against original → only the intended change should
+   appear; anchors and comments preserved.
+
+Pages auto-deploys from `main` — give it ~30s after merge to rebuild;
+hard-refresh on first load.
+
+---
+
+## 8. External state to be aware of
+
+- **maDisplayTools `origin/version3`** pinned at **`649d7ef`**. The
+  authoritative spec lives at `docs/development/yaml_protocol_documentation_v3.md`
+  on that branch.
+- **Lisa was notified** (earlier session) about 3 syntactic typos in her
+  `examples/yamls/full_experiment_test_v3.yaml`. Our local fixture has
+  the fixes applied; upstream may still have them.
+- **Codex review artifacts** for this session live in `.codex-review/`
+  (gitignored). The reconciliation reports are inlined into
+  `docs/development/v3-d4-design-reviews.md` for the D4 work, and this
+  handoff captures the Phase 4 diff review. The raw outputs are
+  ephemeral — re-run Codex if you need them.
+
+---
+
+## 9. Open questions for the next session
+
+1. **Confirm Tier 1 (cleanup PR) is the right first move.** My
+   recommendation is yes — the event-listener bug surfaces in normal use
+   and the rest are cheap rides along with it.
+2. **Phase 5 design pass needed?** The original plan covers Phase 5 in
+   broad strokes but a Codex plan-review pass on a written-out design
+   would be worth ~30 min before starting. Anchor binding popover and
+   rename cascade have non-obvious failure modes (especially rename
+   cascade — needs an "impacted aliases" enumeration similar to what
+   D4's design has).
+3. **Should the v3 designer status badge change?** Footer says "v0.8 |
+   2026-05-27 17:28 ET" and the page header says "BETA / EDITOR". With
+   sequence editing complete + working in production-like state, the
+   lab might consider it ready for daily use. User judgment.
+4. **What to do with the old `v3-editor-handoff.md`?** Replace with this
+   doc, or keep both? My instinct: replace, with a short "superseded
+   2026-05-27" stub pointing here.


### PR DESCRIPTION
## Summary

Picks up where \`docs/development/v3-editor-handoff.md\` left off — that one ended at v0.2; this one captures the post-Phase-4 state (v0.8) and the prioritized open work.

Per request, structured as: **Codex review of landed work** at the top, then **clearly discuss what's left** in priority order.

## What's in it

1. **TL;DR + recommended next direction** — Tier 1 cleanup PR (~½ day) then Phase 5 Variables UX (~4–5 days).
2. **Codex review of Phase 4 work** (PRs #70/72/73/74):
   - 4 Significant bugs to fix as a follow-up PR:
     - **Event-listener accumulation on \`#sequenceList\`** — \`renderSequence()\` calls \`addEventListener\` every render; one drop fires N handlers after N renders. Surfaces within the first session of editing.
     - **Selection index doesn't track displaced entries on move/insert** — inspector shows wrong entry after reorder.
     - **Timeline ruler ticks don't align with min-width-clamped step layout** — \"1m\" label can land at the wrong spot.
     - **Block→ref convert silently drops \`_unknownKeys\`** — undermines the B5 unknown-passthrough we shipped in Tier 1.
   - 2 minor: \`_buildSequenceEntry\` doesn't reject \`repetitions: 0\`; no-op drops may pollute undo stack.
   - 1 architectural concern: 17 helpers + no centralized consistency gate. Don't preemptively refactor.
3. **What's shipped** — 9 PRs this session (#65 → #74) across Phase 1 → Phase 4.
4. **What's left, prioritized** — Tier 1 cleanup → Phase 5 (variables editor + rename cascade) → Phase 6 (full validation modal + Reset) → D4 (deferred) → Phase 7-9 (polish).
5. **Implementation pattern crib sheet** — helper template, undo model, state-coherence rules.
6. **Files that matter** + verification commands + external state + open questions.

## Why a new file vs editing the old one

The old \`v3-editor-handoff.md\` is now significantly out of date — most of its items (A through D3, all of Tier 1/2/3, all of Phase 4) have shipped. Easier to read a fresh doc than to track diffs against a stale one. The next session can decide whether to delete the old one or leave it for historical context (\§9 open question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)