### PR TITLE
docs: web-tools landing page, changelog, experiment-designer quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+---
+title: Changelog
+parent: Web Tools
+grand_parent: Generation 6
+nav_order: 90
+---
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
----
-title: Web Tools
-parent: Generation 6
-has_children: true
-nav_order: 11
----
-
 # webDisplayTools - PanelDisplayTools
 
 Web-based tools for configuring and editing display patterns for modular arena systems.

--- a/docs/experiment-designer-quickstart.md
+++ b/docs/experiment-designer-quickstart.md
@@ -1,0 +1,26 @@
+---
+title: Experiment Designer Quick Start
+parent: Web Tools
+grand_parent: Generation 6
+nav_order: 2
+---
+
+# Experiment Designer Quick Start
+
+A step-by-step walkthrough for building your first experiment protocol in the Experiment Designer.
+
+The full quick start guide is a standalone styled page that preserves its original interactive layout:
+
+**[Open Experiment Designer Quick Start →](https://reiserlab.github.io/webDisplayTools/experiment_designer_quickstart.html)**
+
+The guide covers:
+
+1. Setting up experiment info and selecting an arena configuration
+2. Pointing to a rig YAML file
+3. Enabling hardware plugins (LED Backlight, BIAS Camera)
+4. Building conditions — stimulus parameters and plugin commands
+5. Using the Table view for a spreadsheet overview of all conditions
+6. Reading the lane view to understand timing
+7. Exporting a protocol v2 YAML for MATLAB execution
+
+See also: [Experiment Designer](https://reiserlab.github.io/webDisplayTools/experiment_designer.html)

--- a/docs/web-tools.md
+++ b/docs/web-tools.md
@@ -1,0 +1,80 @@
+---
+title: Web Tools
+parent: Generation 6
+has_children: true
+nav_order: 11
+---
+
+# Web Tools
+
+Browser-based tools for configuring, designing, and previewing display patterns for modular LED arena systems. All tools run as standalone HTML pages — no installation required.
+
+**Live Demo**: <https://reiserlab.github.io/webDisplayTools/>
+
+## Tools
+
+### Pattern Editor
+
+Full-arena pattern design with spherical coordinate transformations.
+
+- Generate gratings, starfields, and edges with pole rotation
+- Edit pixels directly in 2D or preview in 3D
+- Animate patterns via frame shifting or sequence building
+- Combine patterns with blend/mask/split modes
+- Export to `.pat` format for MATLAB
+
+[Launch Pattern Editor](https://reiserlab.github.io/webDisplayTools/pattern_editor.html) · [Quick Start Guide](../PATTERN_EDITOR_QUICKSTART.md)
+
+### Arena Layout Editor
+
+Configure arena geometry from standard configurations or create custom layouts.
+
+- SVG-based 2D visualization
+- 10 standard arena configurations (G3, G4, G4.1, G6)
+- Click-to-toggle panels for partial arenas
+- PDF and YAML export
+
+[Launch Arena Layout Editor](https://reiserlab.github.io/webDisplayTools/arena_editor.html)
+
+### Arena 3D Viewer
+
+Interactive 3D visualization of cylindrical arenas.
+
+- Three.js rendering with orbit controls
+- Test pattern preview (all-on, grating, sine wave)
+- Angular resolution analysis
+- Screenshot export
+
+[Launch Arena 3D Viewer](https://reiserlab.github.io/webDisplayTools/arena_3d_viewer.html)
+
+### Pattern Icon Generator
+
+Generate top-down cylindrical view icons from arena patterns.
+
+- Single-frame and multi-frame motion-blur rendering
+- Configurable perspective (inner radius 0.1–0.75)
+- Multiple background options (dark, white, transparent)
+- Supports full and partial arena configurations
+- PNG export for documentation and UI thumbnails
+
+[Launch Pattern Icon Generator](https://reiserlab.github.io/webDisplayTools/icon_generator.html)
+
+### G6 Panel Patterns
+
+Create and preview 20×20 pixel patterns for individual G6 panels.
+
+- Real-time preview with draw/erase modes
+- Multiple modes: GS2, GS16, 4-Char, LED Map Reference
+- Pattern export capabilities
+
+[Launch G6 Panel Patterns](https://reiserlab.github.io/webDisplayTools/g6_panel_editor.html)
+
+### Experiment Designer
+
+Design experiment protocols with stimulus sequences and trial parameters. YAML export for MATLAB execution.
+
+[Launch Experiment Designer](https://reiserlab.github.io/webDisplayTools/experiment_designer.html) · [Quick Start Guide](experiment-designer-quickstart.md)
+
+## Source
+
+Source code and issue tracker: [reiserlab/webDisplayTools](https://github.com/reiserlab/webDisplayTools)


### PR DESCRIPTION
Follow-up to PR #61 (and commit 6cf7ddb). Addresses the three deferred unified-site publishing items.

## What changed

### 1. Replace `README.md` as the "Web Tools" section parent → new `docs/web-tools.md`

Per @floesche's guidance in [maDisplayTools/pull/24](https://github.com/reiserlab/maDisplayTools/pull/24#issuecomment-4344659369), READMEs should be the GitHub-repo landing page only, not the unified-site section parent. We applied this to maDisplayTools already (commit a51fe18); doing the same here.

- **New** `docs/web-tools.md` — carries the Just-the-Docs front matter (`title: Web Tools`, `parent: Generation 6`, `has_children: true`, `nav_order: 11`) and a concise tool-listing body. Omits the dev/CI/repo-structure sections from the README, which belong on the GitHub README only.
- **Stripped** the front matter block from `README.md` so it is no longer picked up as a unified-site page.

### 2. `docs/experiment-designer-quickstart.md` stub (nav_order: 2)

The source file `experiment_designer_quickstart.html` is 432 lines of custom CSS + numbered step-card layout. Converting to Markdown (option a) would lose all the visual structure. Injecting Jekyll front matter into the HTML (option b) risks CSS conflicts with the site theme. 

**Chose option (c):** a small stub MD page that describes the guide and links directly to the standalone HTML at its GitHub Pages URL (`https://reiserlab.github.io/webDisplayTools/experiment_designer_quickstart.html`). This preserves the styled version without content duplication.

### 3. Just-the-Docs front matter added to `CHANGELOG.md`

Frank's "READMEs stay repo-only" guidance doesn't apply to release notes. The changelog is user-facing content appropriate for the unified site. Added:

```yaml
---
title: Changelog
parent: Web Tools
grand_parent: Generation 6
nav_order: 90
---
```

## Changeset

```
docs/web-tools.md                      (new)
docs/experiment-designer-quickstart.md (new)
CHANGELOG.md                           front matter added
README.md                              front matter stripped
```

## Verification

- `git diff main...HEAD --stat` shows exactly these 4 files, no stray changes.
- `PATTERN_EDITOR_QUICKSTART.md` already has `parent: Web Tools, grand_parent: Generation 6` — it will continue to resolve correctly once `docs/web-tools.md` is the "Web Tools" parent.
- The new `docs/experiment-designer-quickstart.md` uses `nav_order: 2` (after the Pattern Editor quickstart at `nav_order: 1`).

/cc @mbreiser for review

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kc27MCyuCGVxbKpQSP8yoH)_