### PR TITLE
feat(v3): D4 Milestones 1+2 — cross-library import substrate (v0.15)

### DIFF
--- a/docs/development/v3-d4-design.md
+++ b/docs/development/v3-d4-design.md
@@ -1,20 +1,21 @@
-# D4 — Cross-Library Import Design Doc (revision 2)
+# D4 — Cross-Library Import Design Doc (revision 3)
 
-**Status:** **DEFERRED** (2026-05-27). Phase 4 (sequence drag/drop) takes
-priority; D4 will be reassessed after Phase 4 + Phase 5 (Variables editor +
-rename cascade) ship. See `v3-d4-design-reviews.md` for the round-2 review
-that drove the deferral.
+**Status:** **ACTIVE** (2026-05-30). Prerequisites met: Phase 4 (sequence
+drag/drop) and Phase 5 (Variables editor + rename cascade) both shipped, so
+D4's "prefix clutter is fixable in-tool" mitigation now holds. This revision
+applies the full rev-2 → rev-3 fix list from `v3-d4-design-reviews.md`. The
+executable milestone breakdown lives in `v3-d4-implementation-handoff.md`.
 
-**When D4 is picked up again, this doc still needs corrections.** The fix list
-is in `v3-d4-design-reviews.md` — read that *before* using this doc as the
-implementation spec. The biggest one: plugin namespacing should NOT be the
-default; plugins should merge-when-class+config-match.
+**This doc is now the implementation spec.** It folds in every correction the
+round-2 Codex review caught — the biggest being **plugins merge by default
+when `matlab.class` + `config` match** (anchors still namespace by default).
 
-**Owner:** Next session that touches D4.
+**Owner:** Session implementing D4.
 **History:**
 - rev 1 (2026-05-27): merge-by-default, monolithic helpers, optimistic milestones.
-- **rev 2 (2026-05-27, current):** namespaced-default, module-first helpers, alias-node API, transitive closure, revised milestones.
-- Round 2 review (2026-05-27): caught further bugs (see `v3-d4-design-reviews.md`); D4 deferred.
+- rev 2 (2026-05-27): namespaced-default, module-first helpers, alias-node API, transitive closure, revised milestones.
+- Round 2 review (2026-05-27): caught further bugs (see `v3-d4-design-reviews.md`); D4 deferred behind Phase 4/5.
+- **rev 3 (2026-05-30, current):** applied the 11-item fix list — one shared `aliasRewriteMap`, visited-set cycle detection, per-batch dependency registry, topological anchor insert, commit rewrites `name:`, plugin-merge-by-default, alias-bound `plugin_name` block, cross-buffer collision check, fixed `sortedJson`, broken-alias hard-block, lock-via-UI-handlers.
 **Supersedes:** the D4 sketch in `docs/development/v3-editor-handoff.md` (lines 209–260).
 
 ---
@@ -45,40 +46,53 @@ This doc is the substrate reassessment Codex flagged in the PR #63 review. The g
 
 ---
 
-## 3. Substrate: staging buffer with namespaced-default imports
+## 3. Substrate: staging buffer; anchors namespace, plugins merge
 
 ### The substrate decision (Option B, staging buffer)
 
 Settled in rev 1; no revision needed. The user enters import mode, browses "theirs," adds candidate conditions to a *staging buffer*, optionally adjusts what their imported names look like, then **Commit** in one batch (one undo step) or **Cancel** to discard. The buffer never mutates `yours._doc` until commit. Cross-doc primitives + commit pipeline live in a new `js/v3-import.js` module so Node tests can exercise them directly.
 
-### The product-shape decision (namespaced-default)
+### The product-shape decision (anchors namespace, plugins merge)
 
 When the user adds a "theirs" condition to the buffer, the defaults are:
 
 - **Imported condition name** keeps its original name unless that name already exists in "yours." Conditions are user-facing and renaming the condition is more disruptive than namespacing — so for conditions we accept the risk of a name suggestion-with-suffix (e.g., `arena check_2`) on collision and don't prefix by default.
 - **Imported anchor names** get a **source prefix** by default (e.g., `&sibling__dur_short`). The user must *opt in* to merging with an existing anchor.
-- **Imported plugin names** get a **source prefix** by default (e.g., `sibling__camera`). The user must *opt in* to merging with an existing plugin entry.
+- **Imported plugins MERGE by default** when an existing "yours" plugin is the
+  *same runtime resource*. On a *mismatch* (or no same-named plugin exists), the
+  imported plugin is added under a **source-prefixed** name (e.g., `sibling__camera`).
+  See the plugin/anchor asymmetry rationale below — this is the rev-3 change.
+  - **Identity projection (rev-3 review, Codex-std/adv):** structural equality is
+    computed over **every plugin field except `name`** — `type`, `matlab`,
+    `python`, `config`, `port`, `baudrate`, `script_path`, and unknown keys (all
+    preserved by `extractPlugin`) — NOT `matlab.class` + `config` alone. Empty
+    `config` is common, so class-only matching would merge unrelated hardware.
+    When both candidates omit hardware-specific fields, also require the same
+    top-level `rig` path before merging (hardware defaults can live in the rig
+    file). The built-in `log` plugin is exempt (see §5).
 
 The source prefix derives from the imported filename, sanitized to anchor-safe characters and stripped of extension: `sibling_lab.yaml` → `sibling_lab__`. User can override the prefix when entering import mode (default value pre-filled from the filename, editable).
 
-**Why this defaults to namespacing for anchors/plugins but not conditions:**
+**Why anchors namespace by default but plugins merge by default (the asymmetry):**
 - Conditions are *named tasks* the user picks from a list. A user importing "arena check" from a sibling lab wants to see "arena check" or "arena check_2" — not "sibling__arena check," which would just be confusing.
-- Anchors are *internal references* the user mostly doesn't see except when something breaks. A user importing condition X doesn't care if X's internal `*dur_short` reference is to `&dur_short` or to `&sibling__dur_short` — they just want X to work. The cost of `sibling__` prefix is "slightly noisier YAML"; the benefit is no silent semantic merge.
-- Plugins are *infrastructure* the user declares in `plugins:` but rarely thinks about command-by-command. Similar tradeoff as anchors.
+- Anchors are *internal data references* the user mostly doesn't see except when something breaks. A user importing condition X doesn't care if X's internal `*dur_short` reference is to `&dur_short` or to `&sibling__dur_short` — they just want X to work. The cost of `sibling__` prefix is "slightly noisier YAML"; the benefit is no silent semantic merge. Two labs may use `&dur_short` for semantically different values, so namespacing is the safe default.
+- Plugins are **runtime resources representing physical hardware** (cameras, controllers, serial ports) — not data. Duplicating `camera` → `sibling__camera` does **not** isolate the hardware: both YAML entries may point at the *same* physical device, and two declarations for one device is a real runtime bug (double-open of a serial port, conflicting camera handles). So plugins merge when `matlab.class` + `config` match (same hardware, same wiring → one declaration), and only namespace when they genuinely differ. This asymmetry is honest: anchors and plugins have different operational semantics.
 
-**What namespaced-default eliminates:**
+**What this design eliminates:**
 - "Anchor value mismatch" as a conflict kind — the import gets its own anchor namespace, no comparison needed.
-- "Plugin class mismatch" as a conflict kind — the import gets its own plugin entry, no compatibility check needed.
-- Structural-equality checks via `toJS(doc)` + `JSON.stringify` — no longer needed for the default path. (Still optional if the user *explicitly* asks to merge.)
-- Duplicate anchor names in "theirs" — each anchor gets a unique prefixed name on the user's side, so source-side duplicates don't matter.
+- "Plugin class mismatch" as a blocking conflict — a mismatch just namespaces (adds a prefixed entry), it never blocks.
+- Structural-equality checks on anchors — not needed; anchors always namespace. (The `yamlNodeStructuralEquals` path survives **scoped to plugins only**, for the merge-vs-namespace decision.)
+- Duplicate anchor names in "theirs" — each anchor gets a unique prefixed name on the user's side, so source-side duplicates don't matter. (Source duplicate *anchors* are still preflight-rejected; see §5/§7 — `parseV3Protocol` throws on them anyway.)
 
-**What namespaced-default keeps as conflicts:**
-- **Condition name collision** (still real — conditions aren't prefixed). Resolution: suggest `<name>_2`, user accepts or edits.
+**What this design keeps as conflicts:**
+- **Condition name collision** (still real — conditions aren't prefixed). Resolution: suggest `<name>_2`, user accepts or edits. Mandatory before commit.
+- **Plugin namespace collision** (rare) — a plugin that *doesn't* match an existing one structurally, but whose prefixed name already exists in `yours.plugins[]`. Resolution: bump the prefix (`sibling__camera_2`). Mandatory before commit.
 - **Unknown command type** (informational only — preserved as raw card).
 
-**What namespaced-default trades away:**
-- Slightly noisier YAML on import (`&sibling_lab__dur_short` vs `&dur_short`).
-- The "merge equivalent anchors" optimization that rev 1 had as default is now an opt-in. Users who really do want to share anchors between source and target click a "merge with existing &dur_short" toggle per-anchor.
+**What this design trades away:**
+- Slightly noisier YAML on import for anchors (`&sibling_lab__dur_short` vs `&dur_short`).
+- The "merge equivalent anchors" optimization that rev 1 had as default is now an opt-in (deferred to v1.1 per the implementation handoff). Users who really do want to share anchors between source and target would click a "merge with existing &dur_short" toggle per-anchor.
+- Plugin merge introduces a small structural-equality path (`yamlNodeStructuralEquals` + `sortedJson`) — but only on the plugin path, and only to *decide* merge-vs-namespace. It never silently merges anchors.
 
 ---
 
@@ -117,9 +131,22 @@ function cloneNodeAcrossDocs(srcNode, targetDoc, aliasRewriteMap) {
     // aliasRewriteMap: { oldAnchorName: newAnchorName, ... }
     const cloned = srcNode.clone(targetDoc.schema);  // intra-doc clone; aliases still dangle
     YAML.visit(cloned, {
+        // Rewrite alias REFERENCES…
         Alias(_, node) {
-            if (aliasRewriteMap[node.source]) {
+            if (Object.prototype.hasOwnProperty.call(aliasRewriteMap, node.source)) {
                 node.source = aliasRewriteMap[node.source];
+            }
+        },
+        // …AND anchor DEFINITIONS carried inside the cloned subtree (Codex-std).
+        // A source condition may define an inline anchor (`duration: &dur 5`) and
+        // reference it (`*dur`). Cloning carries the inline `&dur` along; if we
+        // only rewrote the alias we'd strand a stale `&dur` and risk a document-
+        // wide duplicate-anchor blocker (anchorExists / collectBlockingErrors are
+        // doc-wide). Rewrite any anchor whose name is in the map too.
+        Node(_, node) {
+            if (node && node.anchor &&
+                Object.prototype.hasOwnProperty.call(aliasRewriteMap, node.anchor)) {
+                node.anchor = aliasRewriteMap[node.anchor];
             }
         }
     });
@@ -129,37 +156,77 @@ function cloneNodeAcrossDocs(srcNode, targetDoc, aliasRewriteMap) {
 
 `clone()` is intra-document; `cloned` lives logically in the target doc but its `Alias.source` strings still point at the *source* doc's anchor names. We rewrite them per the map provided. After rewriting, the cloned node's aliases will resolve against the target doc's anchors (which we'll insert separately).
 
+**Fix #2 — one shared `aliasRewriteMap`.** The *same* map must be passed to the
+clone of the condition AND to every value-node clone. Building an empty `{}` per
+value-node clone (as rev 2 did) leaves nested aliases inside an imported anchor's
+value dangling. The map is built **once**, after the closure walk has discovered
+every anchor and assigned its planned name (§5). `hasOwnProperty` (not truthiness)
+guards the rewrite so a legitimately-empty-but-present mapping is honored and a
+source name that is *not* being rewritten is left untouched.
+
+**Rev-3 review add (Codex-std) — rewrite anchor definitions too.** The `Node`
+visitor above closes the inline-anchor hole. The defining value node we import
+into `variables:` gets its `.anchor` set to the planned name by the commit step
+anyway; this visitor handles the case where an anchor is defined *inside* a
+cloned condition/plugin subtree (not in `variables:`).
+
 ### Primitive: insert a top-level section if it doesn't exist
 
 ```js
-function ensureTopLevelSection(doc, key, defaultShape) {
-    // defaultShape: 'map' or 'seq'
+function ensureTopLevelSection(experiment, key, defaultShape) {
+    // defaultShape: 'map' or 'seq'. Operates on experiment._doc (signature
+    // matches the ~23 other doc* helpers).
+    const doc = experiment._doc;
     const existing = doc.getIn([key], true);
     if (existing) return existing;
     const node = doc.createNode(defaultShape === 'seq' ? [] : {});
-    doc.setIn([key], node);
+
+    // CRITICAL (Claude finding): do NOT doc.set(key, node) — that APPENDS the new
+    // pair to the END of the root map, i.e. AFTER conditions:. yaml@2 stringifies
+    // with verifyAliasOrder:true (default), and an imported condition's *alias
+    // would then precede its &anchor in document order → toString() THROWS
+    // ("the anchor must be set before the alias"). Splice the new section at its
+    // canonical position (before experiment:/conditions:) instead.
+    const root = doc.contents;                         // YAMLMap
+    const ORDER = KNOWN_TOP_LEVEL_KEYS;                // version, experiment_info, rig, variables, plugins, experiment, conditions
+    const keyRank = ORDER.indexOf(key);
+    let insertAt = root.items.length;
+    for (let i = 0; i < root.items.length; i++) {
+        const k = root.items[i].key && root.items[i].key.value !== undefined
+            ? root.items[i].key.value : String(root.items[i].key);
+        const rank = ORDER.indexOf(k);
+        if (rank !== -1 && rank > keyRank) { insertAt = i; break; }
+    }
+    root.items.splice(insertAt, 0, new YAML.Pair(doc.createNode(key), node));
     return doc.getIn([key], true);
 }
 ```
 
-Needed because some target YAMLs don't have a `variables:` section (e.g., `v3_no_variables.yaml`). Import must create it before splicing.
+Needed because some target YAMLs don't have a `variables:` section (e.g., `v3_no_variables.yaml`). Import must create it before splicing — *and place it before the alias-bearing sections* so round-trip holds.
 
 ### Primitive: splice an already-cloned condition node into the target
 
 ```js
-function docInsertConditionNode(experiment, clonedCondNode, derivedJsCond) {
+function docInsertConditionNode(experiment, clonedCondNode) {
     const condsNode = experiment._doc.getIn(['conditions'], true);
     if (!condsNode || !Array.isArray(condsNode.items)) {
         throw new V3ParseError('docInsertConditionNode: conditions seq missing', 'DOC_MODEL_DIVERGENCE');
     }
     condsNode.items.push(clonedCondNode);
-    experiment.conditions.push(derivedJsCond);
+    // Derive the JS mirror INTERNALLY (Codex-std) — these helpers live in the
+    // same module as extractCondition, so reuse it instead of trusting a caller-
+    // built object that can drift from the YAML after plugin-name rewrites.
+    experiment.conditions.push(extractCondition(clonedCondNode.toJSON()));
 }
 ```
 
-Distinct from existing `docInsertCondition`, which builds a fresh YAML node from JS objects (losing imported comments/style). The new helper takes the already-cloned-and-rewired node and just splices.
+Distinct from existing `docInsertCondition`, which builds a fresh YAML node from JS objects (losing imported comments/style). The new helper takes the already-cloned-and-rewired node, splices it, and re-derives the mirror with the same extractor `parseV3Protocol` uses.
 
-Similar parallel helpers: `docInsertVariableNode`, `docInsertPluginNode`.
+Similar parallel helpers `docInsertVariableNode(experiment, name, clonedValueNode)`
+and `docInsertPluginNode(experiment, clonedPluginNode)` likewise derive their
+mirror entries internally (via `extractVariables`-equivalent logic / `extractPlugin`)
+and `docInsertVariableNode` sets `clonedValueNode.anchor = name` itself so the map
+key and the anchor can never diverge.
 
 ### Primitive: structural equality (only used on explicit merge path)
 
@@ -175,90 +242,231 @@ function yamlNodeStructuralEquals(aNode, aDoc, bNode, bDoc) {
 }
 
 function sortedJson(value) {
-    // JSON.stringify with deterministic key order — sort each object's keys
-    return JSON.stringify(value, Object.keys(value).sort?.bind(Object.keys(value)) || null);
-    // (Implementation note: use a custom replacer that sorts object keys recursively.
-    //  Many libraries provide this; we'll handroll a small one.)
+    // Deterministic, RECURSIVE key sort so {a:1,b:2} and {b:2,a:1} compare equal.
+    // A JSON.stringify replacer cannot do this reliably (the replacer sees parent
+    // objects, not a stable per-object key order), so we rebuild the value with
+    // sorted keys at every depth, then stringify normally.
+    function canon(v) {
+        if (Array.isArray(v)) return v.map(canon);
+        if (v && typeof v === 'object') {
+            const out = {};
+            for (const k of Object.keys(v).sort()) out[k] = canon(v[k]);
+            return out;
+        }
+        return v;
+    }
+    return JSON.stringify(canon(value));
 }
 ```
 
-Only used when the user *explicitly* asks to merge an imported anchor with an existing one. Catches `toJS()` errors from unresolved aliases. Sorts keys to avoid key-order false-negatives.
+**Fix #9.** Rev 2's `sortedJson` was broken pseudo-code (it passed an array as
+the stringify *replacer*, which is a key-allow-list, not a sorter). The recursive
+`canon()` above sorts keys at every depth so plugin `config` maps compare equal
+regardless of key order. Used **only on the plugin merge path** (deciding
+merge-vs-namespace, §5) — `yamlNodeStructuralEquals` catches `toJS()` errors from
+unresolved aliases and returns `false`.
 
 ---
 
-## 5. Anchor handling — concrete algorithm
+## 5. Anchor + plugin handling — concrete algorithm
 
-When the user adds a condition `srcCond` (a YAMLMap from `theirs._doc`) to the staging buffer:
+Two phases: **plan** (when items are added/adjusted in the buffer — pure, no
+mutation) and **commit** (one batch, mutates `yours._doc`). The plan walk runs
+against a **per-batch dependency registry** shared across every staged item
+(fix #4), so two staged conditions that both reference `&dur_short` import it
+*once*.
 
-1. **Find all aliases the condition uses.** `aliases = collectAliasReferences(srcCond)`.
+### 5a. Preflight (enter import mode)
 
-2. **For each `aliasNode` in `aliases`:**
-   - **Resolve to source value node.** `srcValueNode = resolveAlias(aliasNode, theirsDoc)`.
-   - If `srcValueNode` is null: mark as `{kind: 'broken-alias', sourceName: aliasNode.source}` — informational; the imported alias will dangle in `yours._doc` and trigger an existing `unused-anchor` warning on export.
-   - **Record the planned anchor name.** Default: `<prefix> + aliasNode.source` (e.g., `sibling_lab__dur_short`). User can override per-anchor in the staging UI.
-   - **Record dependencies.** Each `srcValueNode` may itself contain Aliases. Recursively collect them.
+- `parseV3Protocol(srcText)` — this calls `doc.toJS()` which **throws on any
+  unresolved alias**, so a broken-alias source can never enter import mode (fix
+  #6 — broken alias is a hard block, not "informational"). A clear error is
+  surfaced to the user.
+- Reject sources with **duplicate anchor names** (two `&dur_short` definitions).
+  yaml@2 round-trips them but last-wins resolution makes the plan ambiguous; we
+  reject up front. (In practice `parseV3Protocol`'s `toJS()` already rejects the
+  pathological cases; this is belt-and-suspenders — see §13.)
 
-3. **Transitive closure.** For each new source value node discovered in step 2, run steps 1–2 on it. Iterate until no new anchors discovered. Cap depth at 10 to detect cycles.
+### 5b. Plan — per condition `srcCond` (a YAMLMap from `theirs._doc`)
 
-4. **Build the import plan for this condition:**
+The batch carries a shared registry:
+
+```js
+batch = {
+    anchorRegistry: Map<srcAnchorName, { srcValueNode, plannedName }>,  // dedup across items
+    pluginRegistry: Map<srcPluginName, { srcEntryNode, plannedName, action, mergeWith }>,
+    visitedAnchors: Set<srcAnchorName>  // cycle guard, fix #5
+}
+```
+
+1. **Collect direct aliases.** `aliases = collectAliasReferences(srcCond)`.
+
+2. **Transitive closure with a visited-set (fix #5 — NOT a depth cap).** Process a
+   worklist of alias source-names. For each `srcName` not in `visitedAnchors`:
+   - Add to `visitedAnchors`.
+   - Resolve once: `srcValueNode = resolveAlias(<one alias with this source>, theirsDoc)`.
+     `resolveAlias` returns `null` only for a broken alias — impossible past
+     preflight, but guarded defensively.
+   - Register in `anchorRegistry` (if absent) with `plannedName = prefix + srcName`
+     (user-overridable).
+   - Enqueue every alias *inside* `srcValueNode` (`collectAliasReferences(srcValueNode)`).
+   A visited-set terminates the *walk* on cycles and never rejects a long
+   legitimate chain (the depth-10 cap of rev 2 did both wrong). **It does NOT
+   prove the dependency graph is acyclic (rev-3 review, Codex-std):** yaml@2
+   permits self-referential anchors (`a: &A {self: *A}`), so the topo-sort in §5c
+   must handle self-edges and genuine cycles explicitly rather than assuming the
+   visited-set removed them.
+
+3. **Plugins the condition references.** For each `plugin` command in `srcCond`,
+   read its `plugin_name`:
+   - **Built-in `log` (rev-3 review, Codex-std):** if `plugin_name === 'log'`,
+     leave it unchanged — `log` is the always-declared built-in plugin
+     (`collectExportWarnings` treats it as declared, [protocol-yaml-v3.js:626]).
+     Do NOT require a source `plugins:` entry, do NOT namespace it, do NOT register
+     it. Continue to the next command.
+   - **If `plugin_name` is alias-bound** (`plugin_name: *camera_plugin`): **block
+     at staging time** (fix #7). Namespacing the *declaration* to `sibling__camera`
+     while the alias still resolves to the literal `"camera"` would strand the
+     reference. v1 surfaces this as a blocking item ("alias-bound plugin_name not
+     supported for import — edit the source YAML to use a literal name").
+   - Otherwise look up the source plugin entry by that literal name and register
+     it in `pluginRegistry` (if absent). Compute its `action`:
+     - **`merge`** if a `yours.plugins[]` entry matches on the identity projection
+       (§3 — all fields except `name`, + same `rig` when config-less), via
+       `yamlNodeStructuralEquals` on the compared sub-shape (§4). `mergeWith` = the
+       existing plugin name; `plannedName` = that same existing name (the condition
+       will reference the name already in `yours`).
+     - **`add`** otherwise; `plannedName = prefix + srcName`, namespaced.
+   - **Plugin `config` aliases (rev-3 review, Codex-adv):** when an entry is
+     registered with `action: add`, run the §5b-step-2 closure on its *value node*
+     too — a `config: { port: *camera_port }` references an anchor the condition
+     itself may not. Missing this clones a dangling alias into `yours`. The shared
+     `anchorRegistry` absorbs it.
+
+4. **Per-item plan** (references shared registry entries; names recomputed when
+   the prefix changes, persisting explicit overrides — fix #4-defaults):
    ```js
    {
        sourceCondNode: srcCond,
        originalName: 'arena check',
-       targetName: 'arena check',  // user-editable if collision
-       conditionNameCollision: false | 'arena check_2',
-       anchorsToImport: [
-           { srcAnchor: 'dur_short', srcValueNode: <Node>, plannedName: 'sibling_lab__dur_short', action: 'add', mergeWith: null },
-           ...
-       ],
-       pluginsToImport: [
-           { srcName: 'camera', srcEntry: <plugin object>, plannedName: 'sibling_lab__camera', action: 'add', mergeWith: null },
-           ...
-       ],
-       unknownCommandTypes: ['branch'],  // informational
-       brokenAliases: []  // informational
+       targetName: 'arena check',         // user-editable; rewritten into the clone (fix #1)
+       conditionNameCollision: false | 'arena check_2',  // blocking
+       anchorRefs:  ['dur_short', ...],   // keys into batch.anchorRegistry
+       pluginRefs:  ['camera', ...],      // keys into batch.pluginRegistry
+       unknownCommandTypes: ['branch'],   // informational
+       aliasBoundPluginNames: [],         // blocking if non-empty (fix #7)
    }
    ```
 
-5. **Commit translates the plan into mutations:**
-   - For each `anchorsToImport[i]`:
-     - `cloneNodeAcrossDocs(srcValueNode, yoursDoc, {})` — recursive aliases inside the value node also need their `source` strings rewritten per the user's chosen names.
-     - Tag the cloned value node with `clonedValueNode.anchor = plannedName`.
-     - Insert into `yours._doc`'s `variables:` map with key `plannedName` (via `ensureTopLevelSection` then `docInsertVariableNode`).
-   - For each `pluginsToImport[i]`:
-     - Clone the plugin entry node, rewrite any internal aliases, tag with `plannedName`.
-     - Insert into `yours._doc`'s `plugins:` seq via `docInsertPluginNode`.
-   - For the condition itself:
-     - Build the `aliasRewriteMap` from `anchorsToImport` (`{srcAnchor → plannedName}`).
-     - `cloneNodeAcrossDocs(srcCond, yoursDoc, aliasRewriteMap)`.
-     - Rewrite any `plugin_name` strings inside the cloned condition's commands per `pluginsToImport`.
-     - Splice via `docInsertConditionNode`.
+### 5c. Commit — translate the batch into mutations (one `pushUndo`)
 
-6. **Optional: append bare refs to sequence.** A checkbox in the staging UI (default ON) appends a bare ref to `yours.sequence` for each committed condition, via the existing `docAppendSequenceEntry`. See §7 for rationale.
+**Pre-commit validation pass (rev-3 review, Codex-std) — runs BEFORE any
+mutation.** Reject (block) if: any planned anchor name fails `isValidAnchorName`;
+any planned anchor name collides with an existing doc anchor (`anchorExists`) or
+another planned anchor (incl. when the user set an empty prefix); any planned
+plugin name collides with an existing/other-staged plugin (and isn't a merge);
+any `targetName` collides with `yours.conditions[]` or another staged item.
+Validating up front (rather than mid-mutation) is what makes commit safe to treat
+as atomic — see §7.
+
+Built once, used everywhere — **one shared `aliasRewriteMap`** (fix #2):
+
+```js
+aliasRewriteMap = {};
+for (const [srcName, {plannedName}] of batch.anchorRegistry) aliasRewriteMap[srcName] = plannedName;
+```
+
+1. **Topologically sort `anchorRegistry` (fix #3).** yaml@2 enforces *anchor before
+   alias* at stringify time. Order anchors so any anchor whose value references
+   another imported anchor is inserted *after* its dependency. Build a dependency
+   edge `A → B` when `A`'s value node contains `*B`; emit in dependency-first order.
+   **Handle self-edges and real cycles explicitly (rev-3 review):** a self-edge
+   (`a: &A {self: *A}`) is fine — the anchor resolves to itself once emitted, so
+   ignore self-edges in the sort; a genuine multi-node cycle among imported anchors
+   is rejected at validation (it cannot be stringified in any order). Do not assume
+   §5b's visited-set made the graph acyclic.
+
+2. **Insert anchors (variables).** For each anchor in topo order, where `action`
+   is `add`:
+   - `clonedValueNode = cloneNodeAcrossDocs(srcValueNode, yoursDoc, aliasRewriteMap)`
+     — the **same** map, so nested aliases inside the value rewrite too.
+   - `clonedValueNode.anchor = plannedName`.
+   - `ensureTopLevelSection(yours, 'variables', 'map')` then
+     `docInsertVariableNode(yours, plannedName, clonedValueNode)`.
+
+3. **Insert / merge plugins.** For each plugin in `pluginRegistry`:
+   - `action === 'merge'` → no insert; the condition's `plugin_name` already
+     points at the existing `yours` plugin (`plannedName === mergeWith`).
+   - `action === 'add'` → `cloneNodeAcrossDocs(srcEntryNode, yoursDoc, aliasRewriteMap)`,
+     rewrite its `name:` to `plannedName`, `ensureTopLevelSection(yours, 'plugins', 'seq')`
+     then `docInsertPluginNode(yours, clonedPluginNode)`.
+
+4. **Insert the condition.** Per item, in buffer order:
+   - `clonedCond = cloneNodeAcrossDocs(srcCond, yoursDoc, aliasRewriteMap)` — same map.
+   - **Rewrite the cloned node's `name:` field to `targetName`** (fix #1 — rev 2
+     forgot this; the JS mirror would say `arena check_2` while the YAML still
+     said `arena check`). Mirror `docCloneCondition`.
+   - Rewrite literal `plugin_name` scalars inside the cloned commands per
+     `pluginRegistry` (`srcName → plannedName`) — leaving `log` untouched.
+   - `docInsertConditionNode(yours, clonedCond)` — the helper derives the JS
+     mirror internally via `extractCondition` (rev-3 review, Codex-std), so the
+     mirror can't drift from the YAML after the name/plugin rewrites above.
+
+5. **Optional: append bare refs to sequence.** A checkbox (default ON) appends a
+   bare ref to `yours.sequence` for each committed condition via the existing
+   `docAppendSequenceEntry`. See §7. Label notes the lossy nature (source
+   block/repetition context is not preserved).
 
 ---
 
-## 6. Conflict kinds (much reduced post-namespacing)
+## 6. Conflict kinds (much reduced; plugins merge by default)
 
-The aggressive conflict catalog of rev 1 collapses to two real conflicts:
+Two real (blocking) conflicts:
 
-- **Condition name collision.** Imported condition name already exists in `yours.conditions[]`. Resolution: suggest `<name>_2`, `_3`, etc. User can edit. Mandatory before commit.
-- **Plugin namespace collision** (rare). Imported plugin's prefixed name (`sibling__camera`) somehow already exists in `yours.plugins[]` — would only happen if the user had previously imported from the same source and renamed. Resolution: bump prefix to `sibling__camera_2`. Mandatory before commit.
+- **Condition name collision.** Imported condition name already exists in
+  `yours.conditions[]`. Resolution: suggest `<name>_2`, `_3`, … User can edit.
+  Mandatory before commit. The accepted name is rewritten into the cloned node's
+  `name:` field (fix #1).
+- **Plugin namespace collision (cross-buffer, fix #10).** A plugin that does *not*
+  structurally match an existing one (so it must be added namespaced), but whose
+  prefixed name `sibling__camera` already exists in `yours.plugins[]` — e.g. the
+  user previously imported from the same source. Resolution: bump the prefix
+  (`sibling__camera_2`). Mandatory before commit. (Distinct from the *merge* case,
+  where a same-identity plugin merges silently.)
+- **Planned anchor-name collision (rev-3 review, Codex-std).** Namespacing
+  *usually* avoids this, but it is **not** eliminated: the user can set an empty/
+  short prefix, or `sibling__dur_short` may already exist from a prior import. A
+  planned anchor name that fails `isValidAnchorName`, collides with an existing
+  doc anchor (`anchorExists`), or duplicates another planned anchor is **blocking**
+  and checked in the pre-commit validation pass (§5c). Resolution: edit the
+  anchor's planned name or the prefix.
 
-Plus three informational annotations (not blocking conflicts):
+Plus blocking-but-rare:
 
-- **Unknown command type** in an imported condition — preserved as raw card, shows up in `collectExportWarnings` after commit. No resolution required.
-- **Broken alias in source YAML** (alias points at a non-existent anchor in `theirs`) — informational. The cloned node will have a dangling alias; `collectExportWarnings` will flag it post-commit. User can decide whether to import anyway.
-- **Pattern file reference** like `pattern: "lisa_specific.pat"` — soft warning ("verify this pattern exists on your machine"). No blocking behavior.
+- **Alias-bound `plugin_name`** (fix #7) — `plugin_name: *camera_plugin` in the
+  source. Blocked at staging time for v1. User must edit the source to use a
+  literal name.
+
+Plus informational annotations (not blocking):
+
+- **Unknown command type** in an imported condition — preserved as a raw card;
+  surfaces in `collectExportWarnings` after commit. Soft warning at commit.
+- **Pattern file reference** like `pattern: "lisa_specific.pat"` — soft warning
+  ("verify this pattern exists on your machine"). No blocking behavior.
 
 Removed conflict kinds (vs rev 1):
 
-- ❌ "Anchor value mismatch" — eliminated by namespacing.
-- ❌ "Anchor name collision" — eliminated by namespacing.
-- ❌ "Plugin class mismatch" — eliminated by namespacing.
-- ❌ "Undeclared plugin" — irrelevant once we import plugin declarations alongside.
-- ❌ "Override existing anchor" — removed entirely (was dangerous + underspecified per Codex-std).
-- ❌ "Cross-condition trial reference" — wrong scope (blocks/intertrials live in `experiment:`, not `conditions:`).
+- ❌ "Anchor value mismatch" — eliminated by namespacing anchors.
+- ⚠️ "Anchor name collision" — *mostly* eliminated by namespacing, but retained as
+  a pre-commit blocking check for the empty-prefix / prior-import cases (above).
+- ❌ "Plugin class mismatch (blocking)" — a mismatch now just namespaces (adds a
+  prefixed entry); never blocks.
+- ❌ "Undeclared plugin" — irrelevant once we import/merge plugin declarations.
+- ❌ "Override existing anchor" — removed entirely (was dangerous + underspecified).
+- ❌ "Cross-condition trial reference" — wrong scope (blocks/intertrials live in
+  `experiment:`, not `conditions:`).
+- ❌ "Broken alias = informational" — now a **hard block** at preflight (fix #6);
+  `parseV3Protocol` throws on it anyway.
 
 ---
 
@@ -270,17 +478,23 @@ Removed conflict kinds (vs rev 1):
 const staging = {
     src: { doc, conditions, variables, plugins, filename },  // parsed "theirs"
     prefix: 'sibling_lab__',  // user-editable, derived from filename
+    batch: {
+        // per-batch dependency registry — shared across ALL items (fix #4)
+        anchorRegistry: Map<srcAnchorName, { srcValueNode, plannedName }>,
+        pluginRegistry: Map<srcPluginName, { srcEntryNode, plannedName, action, mergeWith }>,
+        visitedAnchors: Set<srcAnchorName>   // closure-walk cycle guard (fix #5)
+    },
     items: [
         // one entry per condition the user has chosen to import
         {
             sourceCondIdx: 4,
             originalName: 'arena check',
-            targetName: 'arena check',  // editable for collision
+            targetName: 'arena check',  // editable for collision; rewritten into clone (fix #1)
             conditionNameCollision: false | <suggestion>,
-            anchorsToImport: [...],  // see §5 step 4
-            pluginsToImport: [...],
-            unknownCommandTypes: [...],
-            brokenAliases: [...]
+            anchorRefs: ['dur_short', ...],  // keys into batch.anchorRegistry (§5b step 4)
+            pluginRefs: ['camera', ...],     // keys into batch.pluginRegistry
+            unknownCommandTypes: [...],      // informational
+            aliasBoundPluginNames: [...]     // blocking if non-empty (fix #7)
         },
         ...
     ],
@@ -289,13 +503,35 @@ const staging = {
 };
 ```
 
+The registry lives on `staging.batch`, not per-item, so an anchor or plugin
+referenced by two staged conditions is imported exactly once (fix #4).
+
 ### Lifecycle
 
-- **Enter import mode** → file picker → parse + reject if duplicate anchors in source (preflight) → `staging.src` populated, three-pane layout swaps in, `staging.locked = true` disables `+ Add`, `dup`, inspector edits in "yours."
-- **Add to buffer** → on ← click, compute the import plan for that source condition (§5 steps 1–4). Push into `staging.items`.
-- **Adjust per-item** → user can edit the planned target name, individual anchor names, individual plugin names from the inspector. Each adjustment re-validates collision in `staging`. Bulk options (toolbar): "Reset all to default prefixes," "Use shorter prefix" (prompt for new prefix string, recompute all planned names).
-- **Commit** → `pushUndo()` once → walk `staging.items[]` and apply §5 step 5 for each → if `addBareRefs`, append refs via existing helper → exit import mode → `selection` points to the first committed condition.
+- **Enter import mode** → file picker → `parseV3Protocol` (throws on broken aliases → hard block, fix #6) + reject if duplicate anchors in source (preflight) → `staging.src` populated, three-pane layout swaps in, `staging.locked = true` disables `+ Add`, `dup`, inspector edits in "yours."
+- **Add to buffer** → on ← click, run the plan walk for that source condition (§5b) against the shared `batch` registry. Push the per-item plan into `staging.items`.
+- **Adjust per-item** → user can edit the planned target name, individual anchor names, individual plugin names from the inspector. Each adjustment re-validates collision in `staging`. Bulk options (toolbar): "Reset all to default prefixes," "Use shorter prefix" (prompt for new prefix string, recompute all planned names — explicitly-typed per-item names persist, fix #4-defaults).
+- **Commit** → run the pre-commit validation pass (§5c) — if it reports any
+  blocking item, abort with no mutation → else `pushUndo()` once → snapshot
+  `yours._doc.toString()` for rollback → build the shared `aliasRewriteMap`,
+  topo-sort anchors (fix #3), apply §5c → if `addBareRefs`, append refs via
+  existing helper → exit import mode → `selection` points to the first committed
+  condition.
+  - **Atomicity (rev-3 review, Codex-std).** `commitStaging` performs many
+    mutations after one `pushUndo`. If a later step throws (e.g. plugin insert
+    fails after anchors landed), the doc is half-mutated. Mitigation: validate
+    everything up front (above) so the happy path can't fail on policy; and wrap
+    the mutation block so any unexpected throw restores the pre-commit
+    `toString()` snapshot (re-parse) before surfacing the error. Net effect: commit
+    is all-or-nothing.
 - **Cancel** → discard `staging`, exit import mode, restore the two-pane layout. No mutations.
+
+**Do NOT `setDirty(true)` on *entering* import mode (rev-3 review, Codex-std).**
+The dirty flag means "the YAML has unsaved edits." Entering import mode and then
+cancelling mutates nothing, so it must not mark the document dirty. Set dirty only
+on a successful **commit** (or on a real target-document edit, which locking
+otherwise blocks). The `beforeunload` guard during import mode is handled
+separately (Milestone 4) and does not depend on the dirty flag.
 
 ### Re-using existing renderers (with caveats from Codex-std)
 
@@ -307,14 +543,27 @@ Without auto-add, imported conditions land in `yours.conditions[]` but aren't re
 
 ### Locking "yours" during import
 
-While `staging.locked === true`:
-- `+ Add condition` button is disabled.
-- Library row dup buttons are disabled.
-- Inspector edits return early (no commit, show a tooltip "import mode — finish or cancel first").
-- Export button is disabled.
-- `addCondBtn`, `exportBtn`, command-card actions, `pushUndo` triggers all respect the flag.
+While `staging.locked === true`, the lock is enforced **in the UI event
+handlers** (fix #8), NOT by globally suppressing `pushUndo()`. The lock must cover
+**every target-document mutation path** (rev-3 review, Codex-std — the rev-2 list
+was incomplete). On the v3 page that means:
+- `+ Add condition`.
+- Library row **delete (✕)** and **context-menu duplicate** ([experiment_designer_v3.html] renderLibrary).
+- **Library → sequence drag/drop** sources.
+- **Sequence edits** (reorder, +Ref/+Block, ref↔block convert) and **block trial edits**.
+- **Variables / Settings edits** (anchor rename, value, +Add; experiment_info / rig fields).
+- Inspector / command-card edits return early (tooltip "import mode — finish or cancel first").
+- **Export** button.
+- **Undo/Redo** keyboard + buttons (the target-doc undo stack is frozen during import; commit pushes exactly one entry).
 
-This avoids the stale-resolution problem Codex-adv flagged: staged target-name suggestions become invalid if "yours" mutates underneath.
+**Why not lock `pushUndo` globally?** Commit *itself* calls `pushUndo()` (one
+snapshot for the whole batch). A global `pushUndo` suppression would swallow
+commit's own undo snapshot, making the import un-undoable. So the guard sits on
+the user-facing handlers (`addCondBtn`, `dupBtn`, inspector inputs, `exportBtn`),
+and commit's `pushUndo` runs unimpeded.
+
+This also avoids the stale-resolution problem Codex-adv flagged: staged
+target-name suggestions become invalid if "yours" mutates underneath.
 
 ---
 
@@ -356,13 +605,19 @@ In a new module `js/v3-import.js`:
 
 Add to `js/protocol-yaml-v3.js`:
 - `ensureTopLevelSection(experiment, key, defaultShape)`
-- `docInsertConditionNode(experiment, clonedCondNode, derivedJsCond)`
+- `docInsertConditionNode(experiment, clonedCondNode)`
 - `docInsertVariableNode(experiment, name, clonedValueNode)`
 - `docInsertPluginNode(experiment, clonedPluginNode)`
 
 Tests:
-- Suite for the primitive functions: cross-doc clone with rewrite, alias resolution against last-wins ordering, transitive walks find nested anchors.
-- Suite for the new doc helpers: insert into existing `variables:`, insert when `variables:` is absent (creates section), round-trip stable.
+- Suite for the primitive functions: cross-doc clone with rewrite, alias
+  resolution against last-wins ordering, transitive walks find nested anchors,
+  **anchor-definition rewrite** for an inline `&anchor` inside the cloned subtree
+  (rev-3 review).
+- Suite for the new doc helpers: insert into existing `variables:`, insert when
+  `variables:` is absent (**created section lands BEFORE `conditions:` so an
+  imported alias still re-parses** — rev-3 review), mirror derived internally,
+  round-trip stable.
 
 ### Milestone 2 — Staging buffer + commit pipeline (no UI yet) (~1.5 days)
 
@@ -414,14 +669,14 @@ Browser smoke tests:
 
 - **Suite N1 — `collectAliasReferences`:** finds direct + transitive aliases, deterministic order.
 - **Suite N2 — `resolveAlias`:** correctly resolves against last-matching semantics; returns null on broken aliases.
-- **Suite N3 — `cloneNodeAcrossDocs`:** clones structure; rewrites Alias `source` per map; leaves non-rewritten sources alone.
+- **Suite N3 — `cloneNodeAcrossDocs`:** clones structure; rewrites Alias `source` per map; leaves non-rewritten sources alone; **rewrites an inline `&anchor` definition carried inside the cloned subtree when it's in the map** (rev-3 review).
 - **Suite N4 — `yamlNodeStructuralEquals`:** detects key-order-irrelevant equality; returns false on broken aliases; returns false on different types.
-- **Suite N5 — `ensureTopLevelSection`:** idempotent on existing section; creates missing section.
-- **Suite N6 — `docInsertConditionNode` + variable + plugin:** all three add to doc + mirror; round-trip stable.
+- **Suite N5 — `ensureTopLevelSection`:** idempotent on existing section; creates missing section; **created section is spliced BEFORE `conditions:` (not appended)** so it round-trips (rev-3 review).
+- **Suite N6 — `docInsertConditionNode` + variable + plugin:** all three add to doc + **mirror derived internally**; insert into existing & absent `variables:` (alias in a condition still re-parses after creating the section); round-trip stable.
 - **Suite N7 — Staging buffer dry-run:** synthetic add + adjust prefix + commit → assert `yours._doc.toString()`.
-- **Suite N8 — Each conflict kind triggered:** condition name collision, plugin namespace collision, broken alias, unknown command, transitive alias closure.
-- **Suite N9 — Edge cases:** no `variables:` section, no `plugins:` section, condition with zero aliases, anchor → anchor → anchor chain (depth 3).
-- **Suite N10 — Preflight rejection:** source YAML with duplicate anchor names is rejected at `enterImportMode`.
+- **Suite N8 — Each conflict / built-in kind:** condition name collision; plugin namespace collision (cross-buffer, fix #10); plugin **merge** on identity-projection match (fix #11); **merge false-positive guard** (same class + empty config + different `rig` ⇒ namespace, not merge); alias-bound `plugin_name` block (fix #7); **built-in `plugin_name: log` left unchanged, not namespaced**; planned anchor-name collision (empty prefix) blocks; unknown command; transitive alias closure (incl. **plugin `config` alias**).
+- **Suite N9 — Edge cases:** no `variables:` section, no `plugins:` section, condition with zero aliases, anchor → anchor → anchor chain (depth 3), `A→B→A` cycle terminates the walk (fix #5), **self-referential anchor `&A {self: *A}` handled**, topological insert order so anchors precede their aliases (fix #3), **failed-commit rollback restores the pre-commit `toString()`**.
+- **Suite N10 — Preflight rejection:** source YAML with duplicate anchor names is rejected at `enterImportMode`; broken-alias source is rejected at parse (fix #6).
 
 ### Browser-side (manual checklist in PR):
 
@@ -437,13 +692,22 @@ Browser smoke tests:
 
 ## 11. Open questions for the user
 
-These can still be settled in-flight without blocking Milestone 1.
+**These are now pre-answered** in `v3-d4-implementation-handoff.md` §4 (defaults
+for autonomous execution; change only if the user objects). Recorded here for
+the record:
 
-1. **Default prefix derivation.** Filename `sibling_lab.yaml` → `sibling_lab__`. Acceptable, or do you want shorter / different default?
-2. **"Merge with existing" opt-in path.** Should v1 ship the per-anchor "merge with `&dur_short` from yours" toggle, or defer to v1.1? It's a small surface (one button per anchor row) but requires the `yamlNodeStructuralEquals` path. Defer if simpler.
-3. **Bulk prefix override scope.** Editing the prefix mid-session recomputes ALL planned anchor/plugin names. Should per-item overrides persist across a prefix change, or get reset? Recommend: persist (user explicitly typed those names; respect their intent).
-4. **Sequence ref auto-add default.** Defaults ON in this design. OK?
-5. **What happens to imported plugin commands referencing controllers not in the registry?** E.g., source uses `command_name: foo` on a plugin and `foo` isn't in `getV3PluginCommands(yours, plugin)`. Currently: it imports as-is, `collectExportWarnings` doesn't flag (existing gap). Soft warning at commit?
+1. **Default prefix derivation.** Filename `sibling_lab.yaml` → `sibling_lab__`
+   (sanitized stem + `__`). Editable at enter-import.
+2. **"Merge with existing" anchor opt-in.** **Defer to v1.1.** Ship
+   namespaced-default for anchors; the per-anchor merge toggle is extra surface.
+   (Plugin merge-by-default from §3 still ships — it's not optional.)
+3. **Bulk prefix override scope.** **Persist** per-item name overrides across a
+   prefix change (respect explicitly-typed names).
+4. **Sequence ref auto-add default.** **ON**, with the lossy-context label
+   ("Append bare refs to sequence (source block/repetition context is not
+   preserved)").
+5. **Imported plugin command not in the registry.** Import as-is + **soft warning
+   at commit** (informational, non-blocking).
 
 ---
 
@@ -455,6 +719,19 @@ These can still be settled in-flight without blocking Milestone 1.
 - **Multi-doc YAML streams.** One doc per file assumed.
 - **Pattern file path resolution.** Soft warning only; no validation.
 - **Plugin command schema drift.** If "theirs" uses a plugin command the registry doesn't know about, it imports as-is. The export-warnings system catches some of this but not all.
+- **Product contract: snippet import, not behavior import (rev-3 review, Codex-adv).**
+  D4 copies *conditions* + their direct YAML dependencies (anchors, plugin
+  declarations) and appends bare sequence refs. It does **not** reproduce the
+  source's block membership, repetitions, randomize, or intertrial placement —
+  those live in `experiment:`, not `conditions:`. This is an accepted scope call
+  (the auto-bare-ref label says so), but it means an imported condition is
+  *runnable*, not *behaviorally identical to how the sibling ran it*. Sequence/
+  block import is explicitly out of scope for D4 v1. Surfaced to the user as an
+  open question.
+- **Import provenance (rev-3 review, Codex-adv).** After export there is no durable
+  record distinguishing a D4-imported `sibling__dur_short` from a user-typed one
+  (only the naming convention hints at it). v1 accepts this as destructive
+  copy/paste; a comment-stamp on imported nodes is a possible v1.1 add.
 
 ---
 
@@ -464,17 +741,21 @@ These can still be settled in-flight without blocking Milestone 1.
 - **Staging buffer becoming a parallel architecture.** Mitigation: explicit rule (in §7 and §13) — staging touches only its own state + commits via the documented primitives. No new undo/selection/validation paths.
 - **Renderer reuse underestimated.** Codex-std flagged `renderLibrary` is tightly bound; my rev 2 explicitly budgets the `renderConditionList` extraction. Mitigation: extract early in Milestone 3, before per-pane rendering.
 - **User confusion about prefix-by-default.** Some users will dislike noisy anchor names. Mitigation: the prefix-edit UI is prominent at the top of the buffer; users can shorten or use empty prefix if they want. Documentation in CLAUDE.md after Milestone 4.
-- **Locking "yours" is restrictive.** A user mid-edit who wants to import will lose their place. Mitigation: enter import mode also calls `setDirty(true)` and the `beforeunload` is already set. Optionally: a "discard staging" Cancel that doesn't lose pre-import edits (already the default).
+- **Locking "yours" is restrictive.** A user mid-edit who wants to import will lose their place. Mitigation: the `beforeunload` guard (Milestone 4) covers accidental navigation; Cancel discards staging without touching pre-import edits (the default). Note: entering import mode does **not** set dirty (rev-3 review — only commit does).
+- **Partial commit (rev-3 review, Codex-std).** `commitStaging` makes many
+  mutations after one `pushUndo`; a mid-commit throw could half-mutate the doc.
+  Mitigation: full pre-commit validation (§5c) so the happy path can't fail on
+  policy, plus a `toString()` snapshot/restore around the mutation block — commit
+  is all-or-nothing. Covered by the N9 rollback test.
 - **`alias.resolve` vs duplicate-anchor preflight.** We reject duplicate-anchor sources at enter, then use `alias.resolve` (which respects last-wins) for everything else. If a corner-case duplicate slips past (e.g., due to mid-stream additions to the source), `alias.resolve` will still give a defined answer. Belt-and-suspenders.
 
 ---
 
-## 14. Decision needed before any code lands
+## 14. Decision status
 
-Read this doc + (re-running Codex on this revision is included in the same PR). Then either:
-
-- **Approve** — Milestone 1 starts.
-- **Push back on the substrate or product shape** — revisit (return to merge-by-default, try Option C refactor, etc.).
-- **Defer D4** — pivot to Phase 4 (sequence drag/drop) or Phase 5 (Variables editor) on the current architecture.
-
-No code until we've explicitly picked one.
+**Decided (2026-05-30): APPROVED, building.** Prerequisites (Phase 4 + Phase 5)
+shipped; the rev-2 → rev-3 fix list is applied in this revision; a fresh
+`codex-plan-review` pass on rev 3 ran before Milestone 1 (findings reconciled).
+Milestone 1 (cross-doc primitives + node-based helpers + suites N1–N6) is the
+first committable unit — see `v3-d4-implementation-handoff.md` §5 for the
+milestone gates.

--- a/docs/development/v3-d4-design.md
+++ b/docs/development/v3-d4-design.md
@@ -719,6 +719,14 @@ the record:
 - **Multi-doc YAML streams.** One doc per file assumed.
 - **Pattern file path resolution.** Soft warning only; no validation.
 - **Plugin command schema drift.** If "theirs" uses a plugin command the registry doesn't know about, it imports as-is. The export-warnings system catches some of this but not all.
+- **Truly circular anchor values (M2 finding).** A genuinely circular anchor
+  (`&A {self: *A}`) used as a command's `params` cannot be represented in the JS
+  mirror — `extractCommand` deep-clones params via `JSON.parse(JSON.stringify(...))`,
+  which throws on cycles. This is a pre-existing codebase limitation (not D4's),
+  and `parseV3Protocol` itself can't mirror such a source. D4 fails *safe*: the
+  topo sort handles anchor self-edges (no false cycle) and rejects genuine
+  multi-node cycles; if a circular-params condition somehow reaches commit, the
+  atomic rollback restores the pre-commit document. Not supported; not corrupting.
 - **Product contract: snippet import, not behavior import (rev-3 review, Codex-adv).**
   D4 copies *conditions* + their direct YAML dependencies (anchors, plugin
   declarations) and appends bare sequence refs. It does **not** reproduce the

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -1201,7 +1201,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.14 | <span id="footerTimestamp">2026-05-30 00:37 ET</span>
+        v3 Experiment Designer v0.15 | <span id="footerTimestamp">2026-05-30 01:01 ET</span>
     </div>
 
     <!-- Error modal -->

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -1201,7 +1201,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.13 | <span id="footerTimestamp">2026-05-29 07:41 ET</span>
+        v3 Experiment Designer v0.14 | <span id="footerTimestamp">2026-05-30 00:37 ET</span>
     </div>
 
     <!-- Error modal -->

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -1876,6 +1876,181 @@ function docUnbindAnchor(experiment, path) {
 }
 
 // ════════════════════════════════════════════════════
+// D4 (cross-library import) — node-based section + splice helpers
+//
+// These exist alongside the JS-object-building docInsertCondition etc. The
+// difference: the import pipeline (js/v3-import.js) clones already-parsed YAML
+// nodes from a *second* document so it can preserve their comments, anchors,
+// and formatting. These helpers splice those cloned nodes in and re-derive the
+// JS mirror with the SAME extractors parseV3Protocol uses, so the mirror can't
+// drift from the YAML. See docs/development/v3-d4-design.md §4/§5.
+// ════════════════════════════════════════════════════
+
+/**
+ * ensureTopLevelSection(experiment, key, defaultShape)
+ *
+ * Return the top-level `key` node, creating it (empty map or seq) if absent.
+ *
+ * CRITICAL placement rule: a created section must land BEFORE the alias-bearing
+ * sections (`experiment:` / `conditions:`) in document order. `doc.set(key, …)`
+ * APPENDS to the end of the root map — i.e. after `conditions:` — and yaml@2
+ * stringifies with `verifyAliasOrder: true` (the default), so an imported
+ * condition's `*alias` would then precede its `&anchor` and `toString()` would
+ * throw. We splice at the canonical position derived from KNOWN_TOP_LEVEL_KEYS.
+ *
+ * @param {object} experiment - model with a `_doc` handle
+ * @param {string} key - 'variables' | 'plugins' | …
+ * @param {'map'|'seq'} defaultShape
+ * @returns {YAMLMap|YAMLSeq} the (existing or newly-created) section node
+ */
+function ensureTopLevelSection(experiment, key, defaultShape) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('ensureTopLevelSection: experiment has no _doc handle', 'NO_DOC');
+    }
+    const doc = experiment._doc;
+    const existing = doc.getIn([key], true);
+    if (existing) return existing;
+
+    const node = doc.createNode(defaultShape === 'seq' ? [] : {});
+    const root = doc.contents;
+    if (!root || !Array.isArray(root.items)) {
+        throw new V3ParseError(
+            'ensureTopLevelSection: document root is not a map',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+
+    // Insert before the first existing key that ranks AFTER `key` in the
+    // canonical top-level order; otherwise append.
+    const keyRank = KNOWN_TOP_LEVEL_KEYS.indexOf(key);
+    let insertAt = root.items.length;
+    if (keyRank !== -1) {
+        for (let i = 0; i < root.items.length; i++) {
+            const pair = root.items[i];
+            const k =
+                pair.key && pair.key.value !== undefined ? pair.key.value : String(pair.key);
+            const rank = KNOWN_TOP_LEVEL_KEYS.indexOf(k);
+            if (rank !== -1 && rank > keyRank) {
+                insertAt = i;
+                break;
+            }
+        }
+    }
+    root.items.splice(insertAt, 0, new YAML.Pair(doc.createNode(key), node));
+    return doc.getIn([key], true);
+}
+
+/**
+ * docInsertConditionNode(experiment, clonedCondNode)
+ *
+ * Splice an already-cloned-and-rewired condition node into `conditions:` and
+ * mirror it into experiment.conditions. The JS mirror is derived INTERNALLY via
+ * extractCondition(clonedCondNode.toJS(_doc)) — the node is pushed first so its
+ * aliases resolve against the target doc's (already-inserted) anchors, exactly
+ * like parseV3Protocol would have produced. If resolution fails (a dangling
+ * alias — which the import preflight blocks), falls back to the unresolved
+ * shape so the helper never throws on mirror derivation alone.
+ */
+function docInsertConditionNode(experiment, clonedCondNode) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docInsertConditionNode: experiment has no _doc handle', 'NO_DOC');
+    }
+    if (!clonedCondNode || !Array.isArray(clonedCondNode.items)) {
+        throw new V3ParseError('docInsertConditionNode: cloned node is not a map', 'INVALID_INPUT');
+    }
+    const condsNode = experiment._doc.getIn(['conditions'], true);
+    if (!condsNode || !Array.isArray(condsNode.items)) {
+        throw new V3ParseError(
+            'docInsertConditionNode: conditions seq missing',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+    condsNode.items.push(clonedCondNode);
+
+    let jsObj;
+    try {
+        jsObj = clonedCondNode.toJS(experiment._doc);
+    } catch (e) {
+        jsObj = clonedCondNode.toJSON();
+    }
+    if (!Array.isArray(experiment.conditions)) experiment.conditions = [];
+    experiment.conditions.push(extractCondition(jsObj));
+}
+
+/**
+ * docInsertVariableNode(experiment, name, clonedValueNode)
+ *
+ * Add `name: <clonedValueNode>` to `variables:` (creating the section in the
+ * canonical position if absent) and mirror into experiment.variables. Sets
+ * `clonedValueNode.anchor = name` itself so the map key and the anchor can never
+ * diverge. Mirror value derivation matches extractVariables.
+ */
+function docInsertVariableNode(experiment, name, clonedValueNode) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docInsertVariableNode: experiment has no _doc handle', 'NO_DOC');
+    }
+    if (!isValidAnchorName(name)) {
+        throw new V3ParseError(
+            'docInsertVariableNode: invalid anchor name ' + JSON.stringify(name),
+            'INVALID_INPUT'
+        );
+    }
+    if (!clonedValueNode || typeof clonedValueNode !== 'object') {
+        throw new V3ParseError('docInsertVariableNode: clonedValueNode missing', 'INVALID_INPUT');
+    }
+    const varsNode = ensureTopLevelSection(experiment, 'variables', 'map');
+    if (!varsNode || !Array.isArray(varsNode.items)) {
+        throw new V3ParseError(
+            'docInsertVariableNode: variables map missing',
+            'DOC_MODEL_DIVERGENCE'
+        );
+    }
+
+    clonedValueNode.anchor = name;
+    const keyNode = experiment._doc.createNode(name);
+    varsNode.items.push(new YAML.Pair(keyNode, clonedValueNode));
+
+    // Mirror — same identity/value rules as extractVariables.
+    let value;
+    if (clonedValueNode.value !== undefined) value = clonedValueNode.value;
+    else if (typeof clonedValueNode.toJSON === 'function') value = clonedValueNode.toJSON();
+    else value = clonedValueNode;
+    if (!Array.isArray(experiment.variables)) experiment.variables = [];
+    experiment.variables.push({ name: String(name), value: value });
+}
+
+/**
+ * docInsertPluginNode(experiment, clonedPluginNode)
+ *
+ * Splice an already-cloned plugin entry node into `plugins:` (creating the
+ * section in the canonical position if absent) and mirror into
+ * experiment.plugins via extractPlugin. The node is pushed first so any aliases
+ * in its config resolve against the target doc.
+ */
+function docInsertPluginNode(experiment, clonedPluginNode) {
+    if (!experiment || !experiment._doc) {
+        throw new V3ParseError('docInsertPluginNode: experiment has no _doc handle', 'NO_DOC');
+    }
+    if (!clonedPluginNode || !Array.isArray(clonedPluginNode.items)) {
+        throw new V3ParseError('docInsertPluginNode: cloned node is not a map', 'INVALID_INPUT');
+    }
+    const pluginsNode = ensureTopLevelSection(experiment, 'plugins', 'seq');
+    if (!pluginsNode || !Array.isArray(pluginsNode.items)) {
+        throw new V3ParseError('docInsertPluginNode: plugins seq missing', 'DOC_MODEL_DIVERGENCE');
+    }
+    pluginsNode.items.push(clonedPluginNode);
+
+    let jsObj;
+    try {
+        jsObj = clonedPluginNode.toJS(experiment._doc);
+    } catch (e) {
+        jsObj = clonedPluginNode.toJSON();
+    }
+    if (!Array.isArray(experiment.plugins)) experiment.plugins = [];
+    experiment.plugins.push(extractPlugin(jsObj));
+}
+
+// ════════════════════════════════════════════════════
 // Exports
 // ════════════════════════════════════════════════════
 
@@ -1915,7 +2090,12 @@ const ProtocolV3 = {
     findAliasesTo,
     variableIsComplex,
     isValidAnchorName,
-    anchorExists
+    anchorExists,
+    // D4 — node-based section + splice helpers
+    ensureTopLevelSection,
+    docInsertConditionNode,
+    docInsertVariableNode,
+    docInsertPluginNode
 };
 
 // Browser global
@@ -1965,6 +2145,11 @@ export {
     findAliasesTo,
     variableIsComplex,
     isValidAnchorName,
-    anchorExists
+    anchorExists,
+    // D4 — node-based section + splice helpers
+    ensureTopLevelSection,
+    docInsertConditionNode,
+    docInsertVariableNode,
+    docInsertPluginNode
 };
 export default ProtocolV3;

--- a/js/v3-import.js
+++ b/js/v3-import.js
@@ -28,6 +28,39 @@
 'use strict';
 
 import * as YAML from 'yaml';
+import {
+    parseV3Protocol,
+    ensureTopLevelSection,
+    docInsertConditionNode,
+    docInsertVariableNode,
+    docInsertPluginNode,
+    docAppendSequenceEntry,
+    isValidAnchorName,
+    anchorExists
+} from './protocol-yaml-v3.js';
+
+// Command types the v3 schema knows (mirrors KNOWN_COMMAND_KEYS_BY_TYPE in
+// protocol-yaml-v3.js). Anything else in a condition is an "unknown command
+// type" — preserved as a raw card, surfaced as an informational note on import.
+const KNOWN_COMMAND_TYPES = ['controller', 'wait', 'plugin'];
+
+// The built-in always-declared plugin: a `plugin_name: log` command needs no
+// source declaration and is never namespaced (collectExportWarnings treats it
+// as declared). See docs/development/v3-d4-design.md §5.
+const BUILTIN_PLUGIN_NAMES = ['log'];
+
+/**
+ * V3ImportError — import-pipeline failures (preflight rejection, blocked commit).
+ * Carries a `code` and, for COMMIT_BLOCKED, a `blocking` array of conflict items.
+ */
+class V3ImportError extends Error {
+    constructor(message, code, extra) {
+        super(message);
+        this.name = 'V3ImportError';
+        this.code = code || 'IMPORT_ERROR';
+        if (extra && typeof extra === 'object') Object.assign(this, extra);
+    }
+}
 
 /**
  * collectAliasReferences(rootNode) → Alias node[]
@@ -150,15 +183,718 @@ function yamlNodeStructuralEquals(aNode, aDoc, bNode, bDoc) {
 }
 
 // ════════════════════════════════════════════════════
+// Milestone 2 — staging buffer + commit pipeline (no UI)
+//
+// The user enters import mode, browses "theirs", adds candidate conditions to a
+// staging buffer, optionally adjusts planned names, then commits in one batch
+// (one undo step) or cancels. The buffer never mutates yours._doc until commit.
+// Plan (add) is pure; commit applies the §5c mutations. A per-batch dependency
+// registry shared across all items dedups anchors/plugins. See design §5/§7.
+// ════════════════════════════════════════════════════
+
+// ── small pure utilities ────────────────────────────────────────────────────
+
+/**
+ * derivePrefix(filename) → 'stem__' (anchor-safe) | ''
+ * `sibling_lab.yaml` → `sibling_lab__`. Strips any directory + extension and
+ * replaces non-[A-Za-z0-9_-] characters with `_`.
+ */
+function derivePrefix(filename) {
+    const base = String(filename || '')
+        .replace(/^.*[\\/]/, '')
+        .replace(/\.[^.]+$/, '');
+    const safe = base.replace(/[^A-Za-z0-9_-]/g, '_');
+    return safe ? safe + '__' : '';
+}
+
+/** Find the unique value node defining `anchorName` in `doc` (null if none). */
+function _findAnchorNode(doc, anchorName) {
+    let found = null;
+    if (!doc || typeof YAML.visit !== 'function') return null;
+    YAML.visit(doc, {
+        Node(_key, node) {
+            if (node && node.anchor === anchorName) {
+                found = node;
+                return YAML.visit.BREAK;
+            }
+        }
+    });
+    return found;
+}
+
+/** Names of anchors defined more than once anywhere in `doc` (duplicate-anchor preflight). */
+function detectDuplicateAnchors(doc) {
+    const seen = Object.create(null);
+    const dupes = [];
+    if (!doc || typeof YAML.visit !== 'function') return dupes;
+    YAML.visit(doc, {
+        Node(_key, node) {
+            if (node && node.anchor) {
+                if (seen[node.anchor]) {
+                    if (!dupes.includes(node.anchor)) dupes.push(node.anchor);
+                } else {
+                    seen[node.anchor] = true;
+                }
+            }
+        }
+    });
+    return dupes;
+}
+
+/** A plugin mirror's identity projection = every field except `name`. */
+function _pluginProjection(pluginMirror) {
+    const out = {};
+    for (const k of Object.keys(pluginMirror)) {
+        if (k === 'name') continue;
+        out[k] = pluginMirror[k];
+    }
+    return out;
+}
+
+/** True when a plugin declares no hardware-specific fields (config/port/baudrate/script_path). */
+function _pluginIsConfigLess(p) {
+    const hasConfig = p.config && typeof p.config === 'object' && Object.keys(p.config).length > 0;
+    return (
+        !hasConfig &&
+        p.port === undefined &&
+        p.baudrate === undefined &&
+        p.script_path === undefined
+    );
+}
+
+/** suggestUniqueName('arena check', set) → 'arena check' | 'arena check_2' | … */
+function suggestUniqueName(base, takenSet) {
+    if (!takenSet.has(base)) return base;
+    let n = 2;
+    while (takenSet.has(base + '_' + n)) n++;
+    return base + '_' + n;
+}
+
+/** Prepend a provenance comment line to a node's commentBefore (idempotent-ish). */
+function _stampProvenance(node, filename) {
+    if (!node) return;
+    const stamp = ' imported from ' + (filename || 'another protocol');
+    if (node.commentBefore && node.commentBefore.indexOf(stamp) !== -1) return;
+    node.commentBefore = node.commentBefore ? stamp + '\n' + node.commentBefore : stamp;
+}
+
+/**
+ * Topologically order anchor source-names so any anchor whose value references
+ * another imported anchor comes AFTER it (yaml@2 needs anchor-before-alias).
+ * Self-edges (a: &A {self: *A}) are ignored. A genuine multi-node cycle throws
+ * (it cannot be stringified in any order). registry: Map<srcName, {srcValueNode}>.
+ */
+function _topoSortAnchors(registry) {
+    const names = Array.from(registry.keys());
+    const inReg = new Set(names);
+    // deps[name] = set of registry anchors that `name`'s value references
+    const deps = new Map();
+    for (const name of names) {
+        const entry = registry.get(name);
+        const refs = collectAliasReferences(entry.srcValueNode).map((a) => a.source);
+        const d = new Set();
+        for (const r of refs) {
+            if (r !== name && inReg.has(r)) d.add(r); // ignore self-edge + external refs
+        }
+        deps.set(name, d);
+    }
+    const ordered = [];
+    const state = new Map(); // name → 'visiting' | 'done'
+    function visit(name, stack) {
+        const s = state.get(name);
+        if (s === 'done') return;
+        if (s === 'visiting') {
+            throw new V3ImportError(
+                'topological sort: anchor dependency cycle among imported anchors (' +
+                    stack.concat(name).join(' → ') +
+                    ')',
+                'ANCHOR_CYCLE'
+            );
+        }
+        state.set(name, 'visiting');
+        for (const dep of deps.get(name)) visit(dep, stack.concat(name));
+        state.set(name, 'done');
+        ordered.push(name);
+    }
+    for (const name of names) visit(name, []);
+    return ordered; // dependency-first
+}
+
+/** Rewrite literal `plugin_name:` scalar values inside a cloned condition node. */
+function _rewritePluginNamesInClone(clonedCondNode, pluginNameRewrite) {
+    if (typeof YAML.visit !== 'function') return;
+    YAML.visit(clonedCondNode, {
+        Pair(_key, pair) {
+            const k = pair.key && pair.key.value !== undefined ? pair.key.value : null;
+            if (k !== 'plugin_name') return;
+            const v = pair.value;
+            if (v && !YAML.isAlias(v) && v.value !== undefined) {
+                if (Object.prototype.hasOwnProperty.call(pluginNameRewrite, v.value)) {
+                    v.value = pluginNameRewrite[v.value];
+                }
+            }
+        }
+    });
+}
+
+// ── staging buffer ───────────────────────────────────────────────────────────
+
+/**
+ * createStagingBuffer(srcExperiment, srcFilename, opts) → staging
+ *
+ * Build an empty staging buffer over a parsed "theirs" experiment. Runs the
+ * duplicate-anchor preflight (#6) — broken-alias sources are already rejected by
+ * parseV3Protocol's toJS(). opts.prefix overrides the filename-derived default.
+ */
+function createStagingBuffer(srcExperiment, srcFilename, opts) {
+    if (!srcExperiment || !srcExperiment._doc) {
+        throw new V3ImportError('createStagingBuffer: source has no _doc handle', 'NO_DOC');
+    }
+    const dupes = detectDuplicateAnchors(srcExperiment._doc);
+    if (dupes.length > 0) {
+        throw new V3ImportError(
+            'createStagingBuffer: source YAML defines duplicate anchor name(s): ' +
+                dupes.join(', ') +
+                '. Resolve them in the source before importing.',
+            'DUPLICATE_ANCHOR_SOURCE',
+            { duplicates: dupes }
+        );
+    }
+    const options = opts || {};
+    const prefix = options.prefix !== undefined ? options.prefix : derivePrefix(srcFilename);
+    return {
+        src: { doc: srcExperiment._doc, experiment: srcExperiment, filename: srcFilename || '' },
+        prefix: prefix,
+        batch: {
+            anchorRegistry: new Map(), // srcName → { srcValueNode, plannedName, override }
+            pluginRegistry: new Map(), // srcName → { srcEntryNode, plannedName, override, action, mergeWith }
+            visitedAnchors: new Set()
+        },
+        items: [],
+        addBareRefs: options.addBareRefs !== undefined ? !!options.addBareRefs : true,
+        _yours: null // set on first addToStaging; used by validation refresh
+    };
+}
+
+// Walk a source value/condition node, registering every transitively-referenced
+// anchor into the shared registry (visited-set closure, #5).
+function _closeAnchors(staging, seedNode) {
+    const reg = staging.batch.anchorRegistry;
+    const visited = staging.batch.visitedAnchors;
+    const work = collectAliasReferences(seedNode).map((a) => a.source);
+    while (work.length) {
+        const name = work.shift();
+        if (visited.has(name)) continue;
+        visited.add(name);
+        const valNode = _findAnchorNode(staging.src.doc, name);
+        if (!valNode) continue; // broken alias — preflight blocks; defensive skip
+        if (!reg.has(name)) {
+            reg.set(name, {
+                srcValueNode: valNode,
+                plannedName: staging.prefix + name,
+                override: false
+            });
+        }
+        for (const a of collectAliasReferences(valNode)) {
+            if (!visited.has(a.source)) work.push(a.source);
+        }
+    }
+}
+
+// Decide merge-vs-namespace for a source plugin against yours (broadened identity).
+function _computePluginAction(staging, srcPluginMirror, yoursExperiment) {
+    const srcProj = sortedJson(_pluginProjection(srcPluginMirror));
+    const srcRig = staging.src.experiment.rig_path;
+    const yoursRig = yoursExperiment.rig_path;
+    for (const yp of yoursExperiment.plugins || []) {
+        if (sortedJson(_pluginProjection(yp)) === srcProj) {
+            // structurally identical (minus name); guard config-less cross-rig merges
+            if (
+                _pluginIsConfigLess(srcPluginMirror) &&
+                _pluginIsConfigLess(yp) &&
+                srcRig !== yoursRig
+            ) {
+                continue;
+            }
+            return { action: 'merge', mergeWith: yp.name, plannedName: yp.name };
+        }
+    }
+    return { action: 'add', mergeWith: null, plannedName: staging.prefix + srcPluginMirror.name };
+}
+
+/**
+ * addToStaging(staging, sourceCondIdx, yoursExperiment) → staging
+ *
+ * Compute the import plan for one source condition and push it as an item,
+ * folding its anchor + plugin dependencies into the shared per-batch registry.
+ * Idempotent on a sourceCondIdx already staged.
+ */
+function addToStaging(staging, sourceCondIdx, yoursExperiment) {
+    staging._yours = yoursExperiment;
+    if (staging.items.some((it) => it.sourceCondIdx === sourceCondIdx)) return staging;
+
+    const srcCondNode = staging.src.doc.getIn(['conditions', sourceCondIdx], true);
+    if (!srcCondNode || !Array.isArray(srcCondNode.items)) {
+        throw new V3ImportError('addToStaging: bad sourceCondIdx ' + sourceCondIdx, 'BAD_INDEX');
+    }
+    const srcCondMirror = staging.src.experiment.conditions[sourceCondIdx];
+    const originalName = srcCondMirror ? srcCondMirror.name : String(srcCondNode.get('name'));
+
+    // 1. anchors referenced by the condition (transitive closure)
+    _closeAnchors(staging, srcCondNode);
+
+    // 2. plugins referenced by the condition's commands
+    const anchorRefs = collectAliasReferences(srcCondNode).map((a) => a.source);
+    const pluginRefs = [];
+    const aliasBoundPluginNames = [];
+    const unknownCommandTypes = [];
+    const undeclaredPlugins = [];
+    const cmdsSeq = srcCondNode.get('commands', true);
+    if (cmdsSeq && Array.isArray(cmdsSeq.items)) {
+        for (const cmdNode of cmdsSeq.items) {
+            if (!cmdNode || typeof cmdNode.get !== 'function') continue;
+            const typeNode = cmdNode.get('type', true);
+            const type = typeNode && typeNode.value !== undefined ? typeNode.value : typeNode;
+            if (type === 'plugin') {
+                const pnNode = cmdNode.get('plugin_name', true);
+                if (pnNode && YAML.isAlias(pnNode)) {
+                    if (!aliasBoundPluginNames.includes(pnNode.source)) {
+                        aliasBoundPluginNames.push(pnNode.source);
+                    }
+                    continue;
+                }
+                const pn = pnNode && pnNode.value !== undefined ? pnNode.value : pnNode;
+                if (typeof pn !== 'string') continue;
+                if (BUILTIN_PLUGIN_NAMES.includes(pn)) continue; // built-in: leave as-is
+                if (!staging.batch.pluginRegistry.has(pn)) {
+                    const srcPluginMirror = (staging.src.experiment.plugins || []).find(
+                        (p) => p.name === pn
+                    );
+                    const srcEntryNode = _findPluginEntryNode(staging.src.doc, pn);
+                    if (!srcPluginMirror || !srcEntryNode) {
+                        if (!undeclaredPlugins.includes(pn)) undeclaredPlugins.push(pn);
+                    } else {
+                        const act = _computePluginAction(staging, srcPluginMirror, yoursExperiment);
+                        staging.batch.pluginRegistry.set(pn, {
+                            srcEntryNode: srcEntryNode,
+                            plannedName: act.plannedName,
+                            override: false,
+                            action: act.action,
+                            mergeWith: act.mergeWith
+                        });
+                        // plugin config may reference anchors the condition doesn't
+                        if (act.action === 'add') _closeAnchors(staging, srcEntryNode);
+                    }
+                }
+                if (!pluginRefs.includes(pn)) pluginRefs.push(pn);
+            } else if (type && !KNOWN_COMMAND_TYPES.includes(type)) {
+                if (!unknownCommandTypes.includes(type)) unknownCommandTypes.push(type);
+            }
+        }
+    }
+
+    staging.items.push({
+        sourceCondIdx: sourceCondIdx,
+        originalName: originalName,
+        targetName: originalName,
+        targetNameOverride: false,
+        conditionNameCollision: false,
+        anchorRefs: anchorRefs,
+        pluginRefs: pluginRefs,
+        unknownCommandTypes: unknownCommandTypes,
+        aliasBoundPluginNames: aliasBoundPluginNames,
+        undeclaredPlugins: undeclaredPlugins
+    });
+
+    refreshStagingValidation(staging, yoursExperiment);
+    return staging;
+}
+
+/** Find the plugins[] entry node whose name === pluginName (null if none). */
+function _findPluginEntryNode(doc, pluginName) {
+    const plugins = doc.getIn(['plugins'], true);
+    if (!plugins || !Array.isArray(plugins.items)) return null;
+    for (const entry of plugins.items) {
+        if (!entry || typeof entry.get !== 'function') continue;
+        const nameNode = entry.get('name', true);
+        const n = nameNode && nameNode.value !== undefined ? nameNode.value : nameNode;
+        if (n === pluginName) return entry;
+    }
+    return null;
+}
+
+/** removeFromStaging(staging, itemIdx) → staging. Rebuilds the registry from scratch. */
+function removeFromStaging(staging, itemIdx) {
+    if (itemIdx < 0 || itemIdx >= staging.items.length) return staging;
+    staging.items.splice(itemIdx, 1);
+    _rebuildRegistry(staging);
+    if (staging._yours) refreshStagingValidation(staging, staging._yours);
+    return staging;
+}
+
+// Recompute the shared registry from the remaining items (preserving overrides).
+function _rebuildRegistry(staging) {
+    const oldAnchors = staging.batch.anchorRegistry;
+    const oldPlugins = staging.batch.pluginRegistry;
+    staging.batch.anchorRegistry = new Map();
+    staging.batch.pluginRegistry = new Map();
+    staging.batch.visitedAnchors = new Set();
+    const yours = staging._yours;
+    const items = staging.items.slice();
+    // re-derive from each item's source condition
+    for (const it of items) {
+        const srcCondNode = staging.src.doc.getIn(['conditions', it.sourceCondIdx], true);
+        if (srcCondNode) _closeAnchors(staging, srcCondNode);
+        for (const pn of it.pluginRefs) {
+            if (staging.batch.pluginRegistry.has(pn)) continue;
+            const srcPluginMirror = (staging.src.experiment.plugins || []).find(
+                (p) => p.name === pn
+            );
+            const srcEntryNode = _findPluginEntryNode(staging.src.doc, pn);
+            if (srcPluginMirror && srcEntryNode && yours) {
+                const act = _computePluginAction(staging, srcPluginMirror, yours);
+                staging.batch.pluginRegistry.set(pn, {
+                    srcEntryNode: srcEntryNode,
+                    plannedName: act.plannedName,
+                    override: false,
+                    action: act.action,
+                    mergeWith: act.mergeWith
+                });
+                if (act.action === 'add') _closeAnchors(staging, srcEntryNode);
+            }
+        }
+    }
+    // restore explicit name overrides
+    for (const [name, entry] of staging.batch.anchorRegistry) {
+        const old = oldAnchors.get(name);
+        if (old && old.override) {
+            entry.plannedName = old.plannedName;
+            entry.override = true;
+        }
+    }
+    for (const [name, entry] of staging.batch.pluginRegistry) {
+        const old = oldPlugins.get(name);
+        if (old && old.override && entry.action === 'add') {
+            entry.plannedName = old.plannedName;
+            entry.override = true;
+        }
+    }
+}
+
+/**
+ * setStagingPrefix(staging, newPrefix) → staging
+ * Recompute every non-overridden planned anchor/plugin name from the new prefix.
+ * Explicitly-typed names (override) persist (#4-defaults).
+ */
+function setStagingPrefix(staging, newPrefix) {
+    staging.prefix = String(newPrefix || '');
+    for (const [name, entry] of staging.batch.anchorRegistry) {
+        if (!entry.override) entry.plannedName = staging.prefix + name;
+    }
+    for (const [name, entry] of staging.batch.pluginRegistry) {
+        if (entry.action === 'add' && !entry.override) entry.plannedName = staging.prefix + name;
+    }
+    if (staging._yours) refreshStagingValidation(staging, staging._yours);
+    return staging;
+}
+
+/** setItemTargetName(staging, itemIdx, newName) → staging. Marks an explicit override. */
+function setItemTargetName(staging, itemIdx, newName) {
+    const item = staging.items[itemIdx];
+    if (!item) return staging;
+    item.targetName = String(newName);
+    item.targetNameOverride = true;
+    if (staging._yours) refreshStagingValidation(staging, staging._yours);
+    return staging;
+}
+
+/** setAnchorPlannedName(staging, srcAnchorName, newName) → staging (explicit override). */
+function setAnchorPlannedName(staging, srcAnchorName, newName) {
+    const entry = staging.batch.anchorRegistry.get(srcAnchorName);
+    if (!entry) return staging;
+    entry.plannedName = String(newName);
+    entry.override = true;
+    if (staging._yours) refreshStagingValidation(staging, staging._yours);
+    return staging;
+}
+
+/** setPluginPlannedName(staging, srcPluginName, newName) → staging (explicit override). */
+function setPluginPlannedName(staging, srcPluginName, newName) {
+    const entry = staging.batch.pluginRegistry.get(srcPluginName);
+    if (!entry || entry.action !== 'add') return staging;
+    entry.plannedName = String(newName);
+    entry.override = true;
+    if (staging._yours) refreshStagingValidation(staging, staging._yours);
+    return staging;
+}
+
+/**
+ * validateStaging(staging, yoursExperiment) → { ok, blocking: [...], warnings: [...] }
+ *
+ * Pure pre-commit validation (#2/#6/#7/#10): condition-name collisions, planned
+ * anchor-name validity + collisions, plugin namespace collisions, alias-bound
+ * plugin_name, real anchor cycles. Informational notes (unknown command,
+ * undeclared plugin) go to warnings.
+ */
+function validateStaging(staging, yoursExperiment) {
+    const blocking = [];
+    const warnings = [];
+
+    // condition target names: unique across yours + all staged items
+    const existingCondNames = new Set((yoursExperiment.conditions || []).map((c) => c.name));
+    const stagedNames = new Set();
+    for (const item of staging.items) {
+        if (existingCondNames.has(item.targetName) || stagedNames.has(item.targetName)) {
+            blocking.push({
+                kind: 'condition-name-collision',
+                name: item.targetName,
+                detail: 'condition "' + item.targetName + '" already exists'
+            });
+        }
+        stagedNames.add(item.targetName);
+        if (item.aliasBoundPluginNames && item.aliasBoundPluginNames.length) {
+            for (const an of item.aliasBoundPluginNames) {
+                blocking.push({
+                    kind: 'alias-bound-plugin-name',
+                    name: an,
+                    detail:
+                        'plugin_name is alias-bound (*' + an + '); use a literal name in the source'
+                });
+            }
+        }
+        if (item.unknownCommandTypes && item.unknownCommandTypes.length) {
+            warnings.push({
+                kind: 'unknown-command-type',
+                name: item.targetName,
+                detail: 'unknown command type(s): ' + item.unknownCommandTypes.join(', ')
+            });
+        }
+        if (item.undeclaredPlugins && item.undeclaredPlugins.length) {
+            warnings.push({
+                kind: 'undeclared-plugin',
+                name: item.targetName,
+                detail: 'plugin(s) not declared in source: ' + item.undeclaredPlugins.join(', ')
+            });
+        }
+    }
+
+    // planned anchor names: valid + no collision with yours or each other
+    const plannedAnchorNames = new Set();
+    for (const [, entry] of staging.batch.anchorRegistry) {
+        const pn = entry.plannedName;
+        if (!isValidAnchorName(pn)) {
+            blocking.push({
+                kind: 'invalid-anchor-name',
+                name: pn,
+                detail: 'invalid anchor name "' + pn + '"'
+            });
+            continue;
+        }
+        if (anchorExists(yoursExperiment, pn) || plannedAnchorNames.has(pn)) {
+            blocking.push({
+                kind: 'anchor-name-collision',
+                name: pn,
+                detail: 'anchor "' + pn + '" already exists (edit the name or prefix)'
+            });
+        }
+        plannedAnchorNames.add(pn);
+    }
+
+    // planned plugin names (action add): no collision with yours or each other
+    const existingPluginNames = new Set((yoursExperiment.plugins || []).map((p) => p.name));
+    const plannedPluginNames = new Set();
+    for (const [, entry] of staging.batch.pluginRegistry) {
+        if (entry.action !== 'add') continue;
+        const pn = entry.plannedName;
+        if (existingPluginNames.has(pn) || plannedPluginNames.has(pn)) {
+            blocking.push({
+                kind: 'plugin-name-collision',
+                name: pn,
+                detail: 'plugin "' + pn + '" already exists (bump the prefix)'
+            });
+        }
+        plannedPluginNames.add(pn);
+    }
+
+    // real anchor cycle among imported anchors (self-edges are fine)
+    try {
+        _topoSortAnchors(staging.batch.anchorRegistry);
+    } catch (e) {
+        blocking.push({ kind: 'anchor-cycle', name: '', detail: e.message });
+    }
+
+    return { ok: blocking.length === 0, blocking: blocking, warnings: warnings };
+}
+
+// Refresh per-item collision flags + cache the validation result on staging.
+function refreshStagingValidation(staging, yoursExperiment) {
+    const existing = new Set((yoursExperiment.conditions || []).map((c) => c.name));
+    const seen = new Set();
+    for (const item of staging.items) {
+        const taken = new Set([...existing, ...seen]);
+        if (taken.has(item.targetName)) {
+            item.conditionNameCollision = suggestUniqueName(item.targetName, taken);
+        } else {
+            item.conditionNameCollision = false;
+        }
+        seen.add(item.targetName);
+    }
+    staging._validation = validateStaging(staging, yoursExperiment);
+    return staging._validation;
+}
+
+/**
+ * commitStaging(staging, yoursExperiment) → summary
+ *
+ * Apply the whole batch to yours._doc + the JS mirror in one shot. Validates
+ * first (throws V3ImportError COMMIT_BLOCKED with .blocking on any conflict),
+ * then snapshots yours._doc.toString() and restores it on any mid-commit throw
+ * (atomic — all-or-nothing). Does NOT call pushUndo (the UI wrapper does that
+ * once, before calling this). Returns a summary of what changed.
+ */
+function commitStaging(staging, yoursExperiment) {
+    const validation = validateStaging(staging, yoursExperiment);
+    if (!validation.ok) {
+        throw new V3ImportError(
+            'commitStaging: ' +
+                validation.blocking.length +
+                ' blocking conflict(s) must be resolved first',
+            'COMMIT_BLOCKED',
+            { blocking: validation.blocking }
+        );
+    }
+
+    const snapshot = yoursExperiment._doc.toString();
+    const filename = staging.src.filename;
+    const summary = {
+        conditionsAdded: [],
+        anchorsAdded: [],
+        pluginsAdded: [],
+        pluginsMerged: [],
+        bareRefsAdded: 0,
+        warnings: validation.warnings
+    };
+
+    try {
+        // one shared alias rewrite map: srcAnchorName → plannedName
+        const aliasRewriteMap = {};
+        for (const [srcName, entry] of staging.batch.anchorRegistry) {
+            aliasRewriteMap[srcName] = entry.plannedName;
+        }
+        // plugin_name rewrite map: srcName → plannedName (add AND merge)
+        const pluginNameRewrite = {};
+        for (const [srcName, entry] of staging.batch.pluginRegistry) {
+            pluginNameRewrite[srcName] = entry.plannedName;
+        }
+
+        // 1. anchors → variables, in dependency-first (topological) order.
+        // Stamp the inserted pair's KEY (not the value) so the provenance comment
+        // renders cleanly above the `key: &anchor value` line instead of splitting it.
+        for (const srcName of _topoSortAnchors(staging.batch.anchorRegistry)) {
+            const entry = staging.batch.anchorRegistry.get(srcName);
+            const clonedVal = cloneNodeAcrossDocs(
+                entry.srcValueNode,
+                yoursExperiment._doc,
+                aliasRewriteMap
+            );
+            docInsertVariableNode(yoursExperiment, entry.plannedName, clonedVal);
+            const varsNode = yoursExperiment._doc.getIn(['variables'], true);
+            const insertedPair = varsNode.items[varsNode.items.length - 1];
+            if (insertedPair && insertedPair.key) _stampProvenance(insertedPair.key, filename);
+            summary.anchorsAdded.push(entry.plannedName);
+        }
+
+        // 2. plugins → merge (no-op) or add
+        for (const [, entry] of staging.batch.pluginRegistry) {
+            if (entry.action === 'merge') {
+                summary.pluginsMerged.push(entry.mergeWith);
+                continue;
+            }
+            const clonedPlugin = cloneNodeAcrossDocs(
+                entry.srcEntryNode,
+                yoursExperiment._doc,
+                aliasRewriteMap
+            );
+            if (typeof clonedPlugin.set === 'function') clonedPlugin.set('name', entry.plannedName);
+            _stampProvenance(clonedPlugin, filename);
+            docInsertPluginNode(yoursExperiment, clonedPlugin);
+            summary.pluginsAdded.push(entry.plannedName);
+        }
+
+        // 3. conditions
+        for (const item of staging.items) {
+            const srcCondNode = staging.src.doc.getIn(['conditions', item.sourceCondIdx], true);
+            const clonedCond = cloneNodeAcrossDocs(
+                srcCondNode,
+                yoursExperiment._doc,
+                aliasRewriteMap
+            );
+            if (typeof clonedCond.set === 'function') clonedCond.set('name', item.targetName);
+            _rewritePluginNamesInClone(clonedCond, pluginNameRewrite);
+            _stampProvenance(clonedCond, filename);
+            docInsertConditionNode(yoursExperiment, clonedCond);
+            summary.conditionsAdded.push(item.targetName);
+        }
+
+        // 4. optional bare sequence refs
+        if (staging.addBareRefs) {
+            for (const item of staging.items) {
+                docAppendSequenceEntry(yoursExperiment, {
+                    kind: 'ref',
+                    condition_name: item.targetName
+                });
+                summary.bareRefsAdded++;
+            }
+        }
+    } catch (err) {
+        // atomic rollback: re-parse the pre-commit snapshot back into yoursExperiment
+        _restoreExperimentInPlace(yoursExperiment, snapshot);
+        throw new V3ImportError(
+            'commitStaging: aborted and rolled back after error: ' + err.message,
+            'COMMIT_FAILED',
+            { cause: err }
+        );
+    }
+
+    return summary;
+}
+
+// Re-parse `yamlText` and copy its fields onto `experiment` in place, so callers
+// holding the same reference see the restored state (used by commit rollback).
+// protocol-yaml-v3.js does not import this module, so the top-level import is
+// cycle-free.
+function _restoreExperimentInPlace(experiment, yamlText) {
+    const fresh = parseV3Protocol(yamlText);
+    for (const k of Object.keys(experiment)) delete experiment[k];
+    Object.assign(experiment, fresh);
+}
+
+// ════════════════════════════════════════════════════
 // Exports (dual: ES module + CommonJS + browser global)
 // ════════════════════════════════════════════════════
 
 const V3Import = {
+    // Milestone 1 — cross-doc primitives
     collectAliasReferences,
     resolveAlias,
     cloneNodeAcrossDocs,
     yamlNodeStructuralEquals,
-    sortedJson
+    sortedJson,
+    // Milestone 2 — staging buffer + commit pipeline
+    V3ImportError,
+    derivePrefix,
+    detectDuplicateAnchors,
+    suggestUniqueName,
+    createStagingBuffer,
+    addToStaging,
+    removeFromStaging,
+    setStagingPrefix,
+    setItemTargetName,
+    setAnchorPlannedName,
+    setPluginPlannedName,
+    validateStaging,
+    refreshStagingValidation,
+    commitStaging
 };
 
 // Browser global
@@ -173,10 +909,26 @@ if (typeof module !== 'undefined' && module.exports) {
 
 // ES module export
 export {
+    // Milestone 1
     collectAliasReferences,
     resolveAlias,
     cloneNodeAcrossDocs,
     yamlNodeStructuralEquals,
-    sortedJson
+    sortedJson,
+    // Milestone 2
+    V3ImportError,
+    derivePrefix,
+    detectDuplicateAnchors,
+    suggestUniqueName,
+    createStagingBuffer,
+    addToStaging,
+    removeFromStaging,
+    setStagingPrefix,
+    setItemTargetName,
+    setAnchorPlannedName,
+    setPluginPlannedName,
+    validateStaging,
+    refreshStagingValidation,
+    commitStaging
 };
 export default V3Import;

--- a/js/v3-import.js
+++ b/js/v3-import.js
@@ -1,0 +1,182 @@
+/**
+ * js/v3-import.js — D4 cross-library import: cross-document primitives.
+ *
+ * D4 lets the user open a SECOND parsed YAML.Document ("theirs") alongside the
+ * one they're editing ("yours") and copy conditions across, bringing the anchors
+ * and plugin declarations those conditions depend on. yaml@2's anchors are
+ * document-local, so copying a condition means cloning its node tree across docs
+ * and explicitly rewiring every alias. These are the low-level primitives that
+ * make that safe; the staging buffer + commit pipeline (Milestone 2) and the
+ * three-pane UI (Milestone 3) build on top.
+ *
+ * Milestone 1 surface:
+ *   - collectAliasReferences(rootNode)             → Alias node[]
+ *   - resolveAlias(aliasNode, sourceDoc)           → value node | null
+ *   - cloneNodeAcrossDocs(srcNode, targetDoc, map) → cloned, rewired node
+ *   - yamlNodeStructuralEquals(aNode, aDoc, bNode, bDoc) → boolean
+ *   - sortedJson(value)                            → deterministic JSON string
+ *
+ * Dual-export (mirrors js/protocol-yaml-v3.js): an `import * as YAML from 'yaml'`
+ * resolves to the npm package under Node and to the vendored browser build via
+ * the HTML import map. Node tests `require()` this file (Node ≥22 require(ESM));
+ * the browser imports it as a module. The window-global + module.exports blocks
+ * are no-ops in whichever environment they don't apply to.
+ *
+ * Reference: docs/development/v3-d4-design.md §4 (rev 3).
+ */
+
+'use strict';
+
+import * as YAML from 'yaml';
+
+/**
+ * collectAliasReferences(rootNode) → Alias node[]
+ *
+ * Walk a node SUBTREE (not just a Document) collecting every Alias reference, in
+ * deterministic document order (depth-first pre-order, per YAML.visit). Works on
+ * any node — a condition map, a value node, or a whole document.
+ */
+function collectAliasReferences(rootNode) {
+    const aliases = [];
+    if (!rootNode || typeof YAML.visit !== 'function') return aliases;
+    YAML.visit(rootNode, {
+        Alias(_key, node) {
+            aliases.push(node);
+        }
+    });
+    return aliases;
+}
+
+/**
+ * resolveAlias(aliasNode, sourceDoc) → value node | null
+ *
+ * Resolve an Alias to the source-doc value node it points at, using yaml@2's
+ * own `Alias.resolve(doc)`. That implements last-wins semantics: the LAST node
+ * whose `.anchor` matches `aliasNode.source` and appears BEFORE the alias in
+ * document order. Returns null for an unresolvable (broken) alias. This is the
+ * correct API — NOT a name-based anchor-table lookup, which would bind to the
+ * wrong value when a source has duplicate anchor names.
+ */
+function resolveAlias(aliasNode, sourceDoc) {
+    if (!aliasNode || typeof aliasNode.resolve !== 'function') return null;
+    return aliasNode.resolve(sourceDoc) || null;
+}
+
+/**
+ * cloneNodeAcrossDocs(srcNode, targetDoc, aliasRewriteMap) → cloned node
+ *
+ * Deep-clone a node tree for insertion into `targetDoc`, rewriting both:
+ *   - Alias REFERENCES  (`*old` → `*new`) whose `.source` is in the map, and
+ *   - anchor DEFINITIONS (`&old` → `&new`) carried inside the cloned subtree
+ *     whose `.anchor` is in the map.
+ *
+ * Rewriting anchor definitions matters for the inline-anchor case: a source
+ * condition may both DEFINE and reference an inline anchor (`duration: &dur 5`
+ * … `*dur`). Cloning carries the inline `&dur` along; rewriting only the alias
+ * would strand a stale `&dur` and risk a document-wide duplicate-anchor blocker
+ * (anchors are doc-wide in this codebase, not variables-only).
+ *
+ * `clone()` is intra-document: the clone lives logically in `targetDoc` (via the
+ * passed schema) but its alias `.source` strings still point at the source doc's
+ * anchor names until rewritten here. The SAME `aliasRewriteMap` must be used for
+ * the condition AND every value-node clone in a batch so nested aliases rewrite
+ * consistently. `hasOwnProperty` (not truthiness) guards each rewrite so an
+ * unmapped name is left untouched and an explicit empty-string target is honored.
+ */
+function cloneNodeAcrossDocs(srcNode, targetDoc, aliasRewriteMap) {
+    if (!srcNode || typeof srcNode.clone !== 'function') {
+        throw new TypeError('cloneNodeAcrossDocs: srcNode is not a cloneable yaml node');
+    }
+    const map = aliasRewriteMap || {};
+    const schema = targetDoc && targetDoc.schema ? targetDoc.schema : undefined;
+    const cloned = srcNode.clone(schema);
+    if (typeof YAML.visit === 'function') {
+        YAML.visit(cloned, {
+            Alias(_key, node) {
+                if (node && Object.prototype.hasOwnProperty.call(map, node.source)) {
+                    node.source = map[node.source];
+                }
+            },
+            Node(_key, node) {
+                if (node && node.anchor && Object.prototype.hasOwnProperty.call(map, node.anchor)) {
+                    node.anchor = map[node.anchor];
+                }
+            }
+        });
+    }
+    return cloned;
+}
+
+/**
+ * sortedJson(value) → string
+ *
+ * Deterministic JSON with keys sorted recursively at every depth, so two maps
+ * that differ only in key order serialize identically. A JSON.stringify replacer
+ * cannot do this reliably (it sees parent objects, not a stable per-object key
+ * order), so we rebuild the value with sorted keys, then stringify. `null` is
+ * passed through (it is `typeof 'object'` but falsy); arrays keep their order.
+ */
+function sortedJson(value) {
+    function canon(v) {
+        if (Array.isArray(v)) return v.map(canon);
+        if (v && typeof v === 'object') {
+            const out = {};
+            for (const k of Object.keys(v).sort()) out[k] = canon(v[k]);
+            return out;
+        }
+        return v;
+    }
+    return JSON.stringify(canon(value));
+}
+
+/**
+ * yamlNodeStructuralEquals(aNode, aDoc, bNode, bDoc) → boolean
+ *
+ * True when two nodes convert to structurally-equal JS values, ignoring key
+ * order. `NodeBase.toJS(doc)` requires a Document argument (it throws without
+ * one), so each node is resolved against its own document. An unresolvable alias
+ * makes toJS throw → caught → not equal. Used ONLY on the plugin merge path
+ * (deciding merge-vs-namespace); anchors never use it (they always namespace).
+ */
+function yamlNodeStructuralEquals(aNode, aDoc, bNode, bDoc) {
+    if (!aNode || !bNode) return false;
+    try {
+        const a = sortedJson(aNode.toJS(aDoc));
+        const b = sortedJson(bNode.toJS(bDoc));
+        return a === b;
+    } catch (e) {
+        return false;
+    }
+}
+
+// ════════════════════════════════════════════════════
+// Exports (dual: ES module + CommonJS + browser global)
+// ════════════════════════════════════════════════════
+
+const V3Import = {
+    collectAliasReferences,
+    resolveAlias,
+    cloneNodeAcrossDocs,
+    yamlNodeStructuralEquals,
+    sortedJson
+};
+
+// Browser global
+if (typeof window !== 'undefined') {
+    window.V3Import = V3Import;
+}
+
+// Node.js / CommonJS (skipped under ESM, where `module` is undefined)
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = V3Import;
+}
+
+// ES module export
+export {
+    collectAliasReferences,
+    resolveAlias,
+    cloneNodeAcrossDocs,
+    yamlNodeStructuralEquals,
+    sortedJson
+};
+export default V3Import;

--- a/tests/fixtures/v3_sibling_source.yaml
+++ b/tests/fixtures/v3_sibling_source.yaml
@@ -1,0 +1,70 @@
+version: 3
+
+# A "sibling lab" source protocol for D4 cross-library import tests.
+# Exercises: scalar anchors, a transitive anchor (a map anchor whose value
+# references another anchor), plugin declarations, a condition that aliases the
+# anchors AND references plugins by literal name, and a comment to verify
+# comment preservation on cross-doc clone.
+
+experiment_info:
+  name: "Sibling Lab Protocol"
+  author: "Sibling Lab"
+
+rig: '/sibling/configs/rigs/sibling_rig.yaml'
+
+variables:
+  dur_short: &dur_short 3
+  dur_long: &dur_long 10
+  color_power: &color_power 5
+  # transitive: this map anchor's value references &color_power
+  led_settings: &led_settings
+    power: *color_power
+    panel_num: 0
+
+plugins:
+  - name: "camera"
+    type: "class"
+    matlab:
+      class: "BiasPlugin"
+
+  - name: "backlight"
+    type: "class"
+    matlab:
+      class: "LEDControllerPlugin"
+
+experiment:
+  - "sibling check"
+
+conditions:
+  - name: "sibling check"
+    commands:
+      # references &dur_short via alias
+      - type: "controller"
+        command_name: "allOn"
+      - type: "wait"
+        duration: *dur_short
+      # references the camera plugin by literal name
+      - type: "plugin"
+        plugin_name: "camera"
+        command_name: "getTimestamp"
+      # a controller trial that aliases &dur_long
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "sibling_pattern.pat"
+        duration: *dur_long
+        mode: 2
+        frame_index: 1
+        frame_rate: 10
+        gain: 0
+      - type: "controller"
+        command_name: "allOff"
+
+  - name: "sibling led"
+    commands:
+      # references the backlight plugin + the transitive &led_settings map anchor
+      - type: "plugin"
+        plugin_name: "backlight"
+        command_name: "setRedLEDPower"
+        params: *led_settings
+      - type: "wait"
+        duration: *dur_short

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -57,7 +57,12 @@ const {
     findAliasesTo,
     variableIsComplex,
     isValidAnchorName,
-    anchorExists
+    anchorExists,
+    // D4 (Milestone 1) — node-based section + splice helpers
+    ensureTopLevelSection,
+    docInsertConditionNode,
+    docInsertVariableNode,
+    docInsertPluginNode
 } = require('../js/protocol-yaml-v3.js');
 
 const {
@@ -68,6 +73,18 @@ const {
     getV3CommandParams,
     LOG_PLUGIN
 } = require('../js/plugin-registry.js');
+
+// D4 (Milestone 1) — cross-document primitives
+const {
+    collectAliasReferences,
+    resolveAlias,
+    cloneNodeAcrossDocs,
+    yamlNodeStructuralEquals,
+    sortedJson
+} = require('../js/v3-import.js');
+
+// yaml@2 itself (for building raw source docs in import tests)
+const YAML = require('yaml');
 
 // ─── Counters & helpers ─────────────────────────────────────────────────────
 
@@ -2493,6 +2510,328 @@ console.log('\n--- Suite 31: comment preservation + anchor edge cases + randomiz
     checkTrue('randomize: explicit false preserved in regen', /randomize:\s*false/.test(regen));
     // repetitions survive too
     checkTrue('randomize: repetitions preserved', block.repetitions === 2);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// D4 — Cross-library import, Milestone 1 (suites N1–N6)
+// Cross-doc primitives (js/v3-import.js) + node-based splice helpers
+// (js/protocol-yaml-v3.js). See docs/development/v3-d4-design.md §10.
+// ════════════════════════════════════════════════════════════════════════════
+
+// Small builder: a raw source YAML.Document (no v3 validation) for primitive tests.
+function rawDoc(text) {
+    return YAML.parseDocument(text, { keepSourceTokens: true });
+}
+
+// ─── Suite N1: collectAliasReferences ───────────────────────────────────────
+console.log('\n--- Suite N1: collectAliasReferences ---');
+{
+    const src = parseV3Protocol(readFixture('v3_sibling_source.yaml'));
+    const cond = src._doc.getIn(['conditions', 0], true); // "sibling check"
+    const aliases = collectAliasReferences(cond);
+    const sources = aliases.map((a) => a.source);
+    check('N1: direct aliases found in condition', sources.length, 2);
+    checkTrue(
+        'N1: aliases are dur_short then dur_long (document order)',
+        sources[0] === 'dur_short' && sources[1] === 'dur_long'
+    );
+    checkTrue('N1: every collected node is an Alias', aliases.every((a) => YAML.isAlias(a)));
+
+    // transitive: the &led_settings value node itself contains *color_power
+    const ledVal = src._doc.getIn(['variables', 'led_settings'], true);
+    const nested = collectAliasReferences(ledVal).map((a) => a.source);
+    check('N1: transitive aliases inside a value node', nested.join(','), 'color_power');
+
+    // zero-alias subtree
+    const noAlias = rawDoc('a:\n  b: 1\n  c: [2, 3]\n').getIn(['a'], true);
+    check('N1: zero aliases → empty array', collectAliasReferences(noAlias).length, 0);
+
+    // works on a whole document
+    checkTrue('N1: walks a whole Document', collectAliasReferences(src._doc).length >= 2);
+}
+
+// ─── Suite N2: resolveAlias (last-wins) ──────────────────────────────────────
+console.log('\n--- Suite N2: resolveAlias ---');
+{
+    const src = parseV3Protocol(readFixture('v3_sibling_source.yaml'));
+    const cond = src._doc.getIn(['conditions', 0], true);
+    const aliases = collectAliasReferences(cond);
+    const v = resolveAlias(aliases[0], src._doc); // *dur_short
+    checkTrue('N2: resolves to the source value node (scalar 3)', v && v.value === 3);
+
+    // last-wins: with two anchors of the same name, an alias binds to the LAST
+    // definition appearing before it in document order.
+    const dup = rawDoc('first: &a 1\nsecond: &a 2\nuse: *a\n');
+    let useAlias = null;
+    YAML.visit(dup, {
+        Alias(_, n) {
+            useAlias = n;
+        }
+    });
+    const resolved = resolveAlias(useAlias, dup);
+    checkTrue('N2: last-wins — *a after two &a resolves to 2', resolved && resolved.value === 2);
+
+    // broken alias → null (no matching anchor anywhere)
+    const broken = rawDoc('x: *nope\n');
+    let brokenAlias = null;
+    YAML.visit(broken, {
+        Alias(_, n) {
+            brokenAlias = n;
+        }
+    });
+    check('N2: broken alias resolves to null', resolveAlias(brokenAlias, broken), null);
+    check('N2: null aliasNode → null', resolveAlias(null, src._doc), null);
+}
+
+// ─── Suite N3: cloneNodeAcrossDocs ───────────────────────────────────────────
+console.log('\n--- Suite N3: cloneNodeAcrossDocs ---');
+{
+    const src = parseV3Protocol(readFixture('v3_sibling_source.yaml'));
+    const target = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const cond = src._doc.getIn(['conditions', 0], true);
+
+    // rewrite dur_short, leave dur_long untouched
+    const cloned = cloneNodeAcrossDocs(cond, target._doc, { dur_short: 'sib__dur_short' });
+    const clonedSources = collectAliasReferences(cloned)
+        .map((a) => a.source)
+        .sort();
+    check(
+        'N3: mapped alias rewritten, unmapped left alone',
+        clonedSources.join(','),
+        'dur_long,sib__dur_short'
+    );
+
+    // deep clone: mutating the clone does not affect the source
+    cloned.set('name', 'mutated_clone');
+    check(
+        'N3: source condition name unchanged after clone mutation',
+        src._doc.getIn(['conditions', 0, 'name']),
+        'sibling check'
+    );
+
+    // inline anchor DEFINITION rewrite (the rev-3 review fix)
+    const inline = rawDoc('cmd:\n  duration: &dur 5\n  wait: *dur\n').getIn(['cmd'], true);
+    const clonedInline = cloneNodeAcrossDocs(inline, target._doc, { dur: 'sib__dur' });
+    let foundAnchor = null;
+    YAML.visit(clonedInline, {
+        Node(_, n) {
+            if (n && n.anchor) foundAnchor = n.anchor;
+        }
+    });
+    const inlineAliasSrc = collectAliasReferences(clonedInline).map((a) => a.source);
+    check('N3: inline anchor DEFINITION rewritten', foundAnchor, 'sib__dur');
+    check('N3: inline alias rewritten to match', inlineAliasSrc.join(','), 'sib__dur');
+
+    // comment preservation on clone — the cloned node keeps its commentBefore…
+    const commented = rawDoc('m:\n  # keep me\n  a: 1\n').getIn(['m'], true);
+    const clonedCommented = cloneNodeAcrossDocs(commented, target._doc, {});
+    checkTrue(
+        'N3: commentBefore preserved on the cloned node',
+        clonedCommented.commentBefore && clonedCommented.commentBefore.includes('keep me')
+    );
+    // …and it actually serializes when spliced into a real document
+    const condComment = rawDoc(
+        'conditions:\n  - name: c\n    # inside comment\n    commands: [{type: wait, duration: 1}]\n'
+    ).getIn(['conditions', 0], true);
+    const clonedCondComment = cloneNodeAcrossDocs(condComment, target._doc, {});
+    target._doc.getIn(['conditions'], true).items.push(clonedCondComment);
+    checkTrue(
+        'N3: comment emitted in full-document toString()',
+        target._doc.toString().includes('inside comment')
+    );
+}
+
+// ─── Suite N4: yamlNodeStructuralEquals + sortedJson ─────────────────────────
+console.log('\n--- Suite N4: yamlNodeStructuralEquals ---');
+{
+    check(
+        'N4: sortedJson is key-order-independent (flat)',
+        sortedJson({ b: 1, a: 2 }),
+        sortedJson({ a: 2, b: 1 })
+    );
+    check(
+        'N4: sortedJson is key-order-independent (nested)',
+        sortedJson({ x: { d: 4, c: 3 } }),
+        sortedJson({ x: { c: 3, d: 4 } })
+    );
+    checkTrue('N4: sortedJson preserves array order', sortedJson([1, 2, 3]) !== sortedJson([3, 2, 1]));
+    check('N4: sortedJson handles null', sortedJson({ a: null }), '{"a":null}');
+
+    const docA = rawDoc('p:\n  class: BiasPlugin\n  config: {a: 1, b: 2}\n');
+    const docB = rawDoc('p:\n  config: {b: 2, a: 1}\n  class: BiasPlugin\n'); // reordered
+    const docC = rawDoc('p:\n  class: BiasPlugin\n  config: {a: 1, b: 3}\n'); // b differs
+    const nA = docA.getIn(['p'], true);
+    const nB = docB.getIn(['p'], true);
+    const nC = docC.getIn(['p'], true);
+    checkTrue(
+        'N4: structurally-equal maps (key order ignored) → true',
+        yamlNodeStructuralEquals(nA, docA, nB, docB)
+    );
+    checkTrue('N4: differing value → false', !yamlNodeStructuralEquals(nA, docA, nC, docC));
+    // different types
+    const scalarDoc = rawDoc('s: 5\n');
+    checkTrue(
+        'N4: map vs scalar → false',
+        !yamlNodeStructuralEquals(nA, docA, scalarDoc.getIn(['s'], true), scalarDoc)
+    );
+    // broken alias inside → false (toJS throws → caught)
+    const brokenDoc = rawDoc('q:\n  x: *missing\n');
+    checkTrue(
+        'N4: unresolvable alias → false',
+        !yamlNodeStructuralEquals(brokenDoc.getIn(['q'], true), brokenDoc, nA, docA)
+    );
+}
+
+// ─── Suite N5: ensureTopLevelSection ─────────────────────────────────────────
+console.log('\n--- Suite N5: ensureTopLevelSection ---');
+{
+    // idempotent on an existing section (canonical_a has variables: already)
+    const exp = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const before = exp._doc.getIn(['variables'], true);
+    const got = ensureTopLevelSection(exp, 'variables', 'map');
+    checkTrue('N5: returns the existing section node (same identity)', got === before);
+    const varCount = (exp._doc.toString().match(/^variables:/gm) || []).length;
+    check('N5: existing section not duplicated', varCount, 1);
+
+    // creates a missing section, placed BEFORE conditions:
+    const noVars = parseV3Protocol(readFixture('v3_no_variables.yaml'));
+    checkTrue('N5: precondition — no variables: in fixture', !noVars._doc.getIn(['variables'], true));
+    const created = ensureTopLevelSection(noVars, 'variables', 'map');
+    checkTrue('N5: creates a YAMLMap', YAML.isMap(created));
+    const out = noVars._doc.toString();
+    const vIdx = out.indexOf('variables:');
+    const cIdx = out.indexOf('conditions:');
+    checkTrue('N5: created variables: lands BEFORE conditions:', vIdx >= 0 && vIdx < cIdx);
+    // and before experiment: too
+    const eIdx = out.indexOf('\nexperiment:');
+    checkTrue('N5: created variables: lands before experiment:', vIdx < eIdx);
+    checkTrue(
+        'N5: doc still re-parses after section creation',
+        (() => {
+            try {
+                parseV3Protocol(out);
+                return true;
+            } catch (e) {
+                return false;
+            }
+        })()
+    );
+
+    // creates a seq section when asked
+    const noPlugins = parseV3Protocol(readFixture('v3_no_variables.yaml'));
+    const pl = ensureTopLevelSection(noPlugins, 'plugins', 'seq');
+    checkTrue('N5: creates a YAMLSeq for plugins', YAML.isSeq(pl));
+}
+
+// ─── Suite N6: docInsert{Condition,Variable,Plugin}Node ──────────────────────
+console.log('\n--- Suite N6: node-based splice helpers ---');
+{
+    const src = parseV3Protocol(readFixture('v3_sibling_source.yaml'));
+
+    // (a) insert variable into an EXISTING variables: section + mirror + round-trip
+    const target = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const durNode = cloneNodeAcrossDocs(
+        src._doc.getIn(['variables', 'dur_short'], true),
+        target._doc,
+        {}
+    );
+    docInsertVariableNode(target, 'sib__dur_short', durNode);
+    checkTrue(
+        'N6a: mirror variable added',
+        target.variables.some((v) => v.name === 'sib__dur_short' && v.value === 3)
+    );
+    const tOut = target._doc.toString();
+    checkTrue('N6a: anchor &sib__dur_short emitted', /&sib__dur_short\b/.test(tOut));
+    checkTrue(
+        'N6a: round-trips',
+        (() => {
+            try {
+                parseV3Protocol(tOut);
+                return true;
+            } catch (e) {
+                return false;
+            }
+        })()
+    );
+
+    // (b) insert variable when variables: is ABSENT → section created, condition
+    //     aliasing it still re-parses (the headline placement guarantee)
+    const noVars = parseV3Protocol(readFixture('v3_no_variables.yaml'));
+    const durNode2 = cloneNodeAcrossDocs(
+        src._doc.getIn(['variables', 'dur_short'], true),
+        noVars._doc,
+        {}
+    );
+    docInsertVariableNode(noVars, 'sib__dur_short', durNode2);
+    const condClone = cloneNodeAcrossDocs(src._doc.getIn(['conditions', 0], true), noVars._doc, {
+        dur_short: 'sib__dur_short',
+        dur_long: 'sib__dur_long'
+    });
+    // import dur_long too so the second alias in that condition resolves
+    const durLong = cloneNodeAcrossDocs(
+        src._doc.getIn(['variables', 'dur_long'], true),
+        noVars._doc,
+        {}
+    );
+    docInsertVariableNode(noVars, 'sib__dur_long', durLong);
+    condClone.set('name', 'imported check');
+    docInsertConditionNode(noVars, condClone);
+    const nvOut = noVars._doc.toString();
+    checkTrue(
+        'N6b: created variables: precedes conditions:',
+        nvOut.indexOf('variables:') < nvOut.indexOf('conditions:')
+    );
+    checkTrue(
+        'N6b: doc with imported alias re-parses cleanly',
+        (() => {
+            try {
+                parseV3Protocol(nvOut);
+                return true;
+            } catch (e) {
+                return false;
+            }
+        })()
+    );
+
+    // (c) docInsertConditionNode derives the mirror INTERNALLY with resolved values
+    const mirror = noVars.conditions.find((c) => c.name === 'imported check');
+    checkTrue('N6c: condition mirror added', !!mirror);
+    const waitCmd = mirror && mirror.commands.find((c) => c.type === 'wait');
+    check('N6c: aliased duration resolved in mirror', waitCmd && waitCmd.duration, 3);
+
+    // (d) docInsertPluginNode → doc + extractPlugin mirror + round-trip
+    const target2 = parseV3Protocol(readFixture('v3_no_variables.yaml'));
+    const camNode = cloneNodeAcrossDocs(src._doc.getIn(['plugins', 0], true), target2._doc, {});
+    const beforeCount = target2.plugins.length;
+    docInsertPluginNode(target2, camNode);
+    check('N6d: plugin mirror count +1', target2.plugins.length, beforeCount + 1);
+    const added = target2.plugins[target2.plugins.length - 1];
+    checkTrue(
+        'N6d: plugin mirror shaped by extractPlugin',
+        added.name === 'camera' && added.matlab && added.matlab.class === 'BiasPlugin'
+    );
+    checkTrue(
+        'N6d: plugins: section round-trips',
+        (() => {
+            try {
+                parseV3Protocol(target2._doc.toString());
+                return true;
+            } catch (e) {
+                return false;
+            }
+        })()
+    );
+
+    // (e) full round-trip stability after a node insert (parse→gen→parse model equal)
+    const stable = parseV3Protocol(readFixture('v3_canonical_a.yaml'));
+    const cp = cloneNodeAcrossDocs(src._doc.getIn(['variables', 'color_power'], true), stable._doc, {});
+    docInsertVariableNode(stable, 'sib__color_power', cp);
+    const regen = generateV3Protocol(stable);
+    const re = parseV3Protocol(regen);
+    checkTrue(
+        'N6e: model stable across regen after insert',
+        JSON.stringify(dropDoc(re).variables) === JSON.stringify(dropDoc(stable).variables)
+    );
 }
 
 // ─── Results ────────────────────────────────────────────────────────────────

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -74,13 +74,26 @@ const {
     LOG_PLUGIN
 } = require('../js/plugin-registry.js');
 
-// D4 (Milestone 1) — cross-document primitives
+// D4 — cross-document primitives (M1) + staging/commit pipeline (M2)
 const {
     collectAliasReferences,
     resolveAlias,
     cloneNodeAcrossDocs,
     yamlNodeStructuralEquals,
-    sortedJson
+    sortedJson,
+    V3ImportError,
+    derivePrefix,
+    detectDuplicateAnchors,
+    suggestUniqueName,
+    createStagingBuffer,
+    addToStaging,
+    removeFromStaging,
+    setStagingPrefix,
+    setItemTargetName,
+    setAnchorPlannedName,
+    setPluginPlannedName,
+    validateStaging,
+    commitStaging
 } = require('../js/v3-import.js');
 
 // yaml@2 itself (for building raw source docs in import tests)
@@ -2832,6 +2845,424 @@ console.log('\n--- Suite N6: node-based splice helpers ---');
         'N6e: model stable across regen after insert',
         JSON.stringify(dropDoc(re).variables) === JSON.stringify(dropDoc(stable).variables)
     );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// D4 — Cross-library import, Milestone 2 (suites N7–N10)
+// Staging buffer + commit pipeline (js/v3-import.js). See design §5/§7/§10.
+// ════════════════════════════════════════════════════════════════════════════
+
+// Builders for inline source/target protocols used by the import tests.
+function mkProtocol(parts) {
+    return (
+        [
+            'version: 3',
+            'experiment_info: {name: ' + (parts.name || 'p') + '}',
+            'rig: ' + JSON.stringify(parts.rig || '/tmp/r.yaml'),
+            parts.variables || null,
+            parts.plugins || null,
+            'experiment: [' + (parts.experiment || 'c0') + ']',
+            'conditions:',
+            parts.conditions
+        ]
+            .filter((x) => x !== null)
+            .join('\n') + '\n'
+    );
+}
+
+// ─── Suite N7: staging dry-run (build / add / adjust prefix / commit) ─────────
+console.log('\n--- Suite N7: staging buffer dry-run ---');
+{
+    const src = parseV3Protocol(readFixture('v3_sibling_source.yaml'));
+    const yours = parseV3Protocol(readFixture('v3_no_variables.yaml'));
+
+    const staging = createStagingBuffer(src, 'sibling_source.yaml');
+    check('N7: prefix derived from filename', staging.prefix, 'sibling_source__');
+
+    addToStaging(staging, 0, yours); // "sibling check" → dur_short, dur_long, camera
+    check('N7: one item staged', staging.items.length, 1);
+    check('N7: target name defaults to original', staging.items[0].targetName, 'sibling check');
+    const planned = [...staging.batch.anchorRegistry.values()].map((e) => e.plannedName).sort();
+    checkTrue(
+        'N7: anchors planned with prefix',
+        planned.includes('sibling_source__dur_short') && planned.includes('sibling_source__dur_long')
+    );
+
+    // adjust prefix → non-overridden planned names recompute
+    setStagingPrefix(staging, 'sib__');
+    const planned2 = [...staging.batch.anchorRegistry.values()].map((e) => e.plannedName);
+    checkTrue('N7: prefix change recomputes anchor names', planned2.includes('sib__dur_short'));
+
+    // explicit anchor override persists across a later prefix change (#4-defaults)
+    setAnchorPlannedName(staging, 'dur_short', 'my_short');
+    setStagingPrefix(staging, 'other__');
+    check(
+        'N7: explicit anchor override persists across prefix change',
+        staging.batch.anchorRegistry.get('dur_short').plannedName,
+        'my_short'
+    );
+    checkTrue(
+        'N7: non-overridden anchor still follows new prefix',
+        staging.batch.anchorRegistry.get('dur_long').plannedName === 'other__dur_long'
+    );
+
+    // commit and assert the doc
+    const summary = commitStaging(staging, yours);
+    check('N7: summary conditionsAdded', summary.conditionsAdded.join(','), 'sibling check');
+    check('N7: bare ref appended by default', summary.bareRefsAdded, 1);
+    const out = yours._doc.toString();
+    checkTrue('N7: committed condition present', /name:\s*"?sibling check"?/.test(out));
+    checkTrue('N7: overridden anchor &my_short emitted', /&my_short\b/.test(out));
+    checkTrue('N7: bare ref present in experiment:', /-\s*"?sibling check"?/.test(out));
+    checkTrue(
+        'N7: provenance stamp present',
+        out.includes('# imported from sibling_source.yaml')
+    );
+    checkTrue(
+        'N7: committed doc re-parses',
+        (() => {
+            try {
+                parseV3Protocol(out);
+                return true;
+            } catch (e) {
+                return false;
+            }
+        })()
+    );
+
+    // addBareRefs=false → no new refs
+    const yours2 = parseV3Protocol(readFixture('v3_no_variables.yaml'));
+    const seqLenBefore = yours2.sequence.length;
+    const st2 = createStagingBuffer(src, 'sibling_source.yaml', { addBareRefs: false });
+    addToStaging(st2, 0, yours2);
+    const sum2 = commitStaging(st2, yours2);
+    check('N7: addBareRefs=false adds no refs', sum2.bareRefsAdded, 0);
+    check('N7: sequence length unchanged', yours2.sequence.length, seqLenBefore);
+}
+
+// ─── Suite N8: conflicts + built-ins ─────────────────────────────────────────
+console.log('\n--- Suite N8: conflicts + built-ins ---');
+{
+    const src = parseV3Protocol(readFixture('v3_sibling_source.yaml'));
+
+    // (a) condition name collision → blocking + suggestion → resolve → commit ok
+    const yoursA = parseV3Protocol(
+        mkProtocol({
+            name: 'yoursA',
+            conditions: '  - name: "sibling check"\n    commands: [{type: wait, duration: 1}]'
+        })
+    );
+    const stA = createStagingBuffer(src, 'sib.yaml');
+    addToStaging(stA, 0, yoursA);
+    checkTrue('N8a: condition-name collision detected (blocking)', !stA._validation.ok);
+    checkTrue(
+        'N8a: collision suggestion offered',
+        stA.items[0].conditionNameCollision === 'sibling check_2'
+    );
+    checkThrows('N8a: commit blocked by collision', () => commitStaging(stA, yoursA), 'COMMIT_BLOCKED');
+    setItemTargetName(stA, 0, 'sibling check 2');
+    checkTrue('N8a: resolved → validation ok', stA._validation.ok);
+    const sumA = commitStaging(stA, yoursA);
+    check('N8a: commit after resolve', sumA.conditionsAdded.join(','), 'sibling check 2');
+
+    // (b) plugin MERGE when class+config match (same rig)
+    const srcMerge = parseV3Protocol(
+        mkProtocol({
+            name: 'theirs',
+            rig: '/shared/rig.yaml',
+            plugins:
+                'plugins:\n  - {name: cam, type: class, matlab: {class: BiasPlugin}, config: {ip: "1.2.3.4"}}',
+            conditions:
+                '  - name: trial\n    commands:\n      - {type: plugin, plugin_name: cam, command_name: getTimestamp}'
+        })
+    );
+    const yoursMerge = parseV3Protocol(
+        mkProtocol({
+            name: 'yours',
+            rig: '/shared/rig.yaml',
+            plugins:
+                'plugins:\n  - {name: camera, type: class, matlab: {class: BiasPlugin}, config: {ip: "1.2.3.4"}}',
+            experiment: 'existing',
+            conditions: '  - name: existing\n    commands: [{type: wait, duration: 1}]'
+        })
+    );
+    const stM = createStagingBuffer(srcMerge, 'theirs.yaml');
+    addToStaging(stM, 0, yoursMerge);
+    const camEntry = stM.batch.pluginRegistry.get('cam');
+    check('N8b: matching plugin merges (action)', camEntry.action, 'merge');
+    check('N8b: merge targets existing plugin', camEntry.mergeWith, 'camera');
+    const pcountBefore = yoursMerge.plugins.length;
+    const sumM = commitStaging(stM, yoursMerge);
+    check('N8b: no plugin added on merge', yoursMerge.plugins.length, pcountBefore);
+    check('N8b: merge recorded in summary', sumM.pluginsMerged.join(','), 'camera');
+    checkTrue(
+        'N8b: imported condition plugin_name rewritten to existing name',
+        /plugin_name:\s*"?camera"?/.test(yoursMerge._doc.toString())
+    );
+
+    // (c) plugin merge FALSE-POSITIVE guard: same class, empty config, different rig → namespace
+    const srcCl = parseV3Protocol(
+        mkProtocol({
+            name: 'theirs',
+            rig: '/their/rig.yaml',
+            plugins: 'plugins:\n  - {name: cam, type: class, matlab: {class: BiasPlugin}}',
+            conditions:
+                '  - name: trial\n    commands:\n      - {type: plugin, plugin_name: cam, command_name: getTimestamp}'
+        })
+    );
+    const yoursCl = parseV3Protocol(
+        mkProtocol({
+            name: 'yours',
+            rig: '/your/rig.yaml',
+            plugins: 'plugins:\n  - {name: camera, type: class, matlab: {class: BiasPlugin}}',
+            experiment: 'existing',
+            conditions: '  - name: existing\n    commands: [{type: wait, duration: 1}]'
+        })
+    );
+    const stCl = createStagingBuffer(srcCl, 'their.yaml');
+    addToStaging(stCl, 0, yoursCl);
+    check('N8c: config-less + different rig → namespace (not merge)', stCl.batch.pluginRegistry.get('cam').action, 'add');
+
+    // (d) plugin namespace collision (cross-buffer): planned name already in yours
+    const yoursColl = parseV3Protocol(
+        mkProtocol({
+            name: 'yours',
+            plugins:
+                'plugins:\n' +
+                '  - {name: camera, type: class, matlab: {class: BiasPlugin}, config: {ip: "9"}}\n' +
+                '  - {name: their__cam, type: class, matlab: {class: Foo}}',
+            experiment: 'existing',
+            conditions: '  - name: existing\n    commands: [{type: wait, duration: 1}]'
+        })
+    );
+    const stColl = createStagingBuffer(srcCl, 'their.yaml', { prefix: 'their__' });
+    addToStaging(stColl, 0, yoursColl); // cam projection != camera (config differs) → add → their__cam, which EXISTS
+    checkTrue('N8d: plugin namespace collision blocks', !stColl._validation.ok);
+    checkTrue(
+        'N8d: collision kind is plugin-name-collision',
+        stColl._validation.blocking.some((b) => b.kind === 'plugin-name-collision')
+    );
+    setPluginPlannedName(stColl, 'cam', 'their__cam_2');
+    checkTrue('N8d: bumping the planned name resolves it', stColl._validation.ok);
+
+    // (e) alias-bound plugin_name → blocking
+    const srcAB = parseV3Protocol(
+        mkProtocol({
+            name: 'theirs',
+            variables: 'variables:\n  camref: &camref camera',
+            plugins: 'plugins:\n  - {name: camera, type: class, matlab: {class: BiasPlugin}}',
+            conditions:
+                '  - name: trial\n    commands:\n      - {type: plugin, plugin_name: *camref, command_name: getTimestamp}'
+        })
+    );
+    const yoursAB = parseV3Protocol(
+        mkProtocol({ name: 'yours', conditions: '  - name: x\n    commands: [{type: wait, duration: 1}]' })
+    );
+    const stAB = createStagingBuffer(srcAB, 'ab.yaml');
+    addToStaging(stAB, 0, yoursAB);
+    checkTrue(
+        'N8e: alias-bound plugin_name recorded',
+        stAB.items[0].aliasBoundPluginNames.includes('camref')
+    );
+    checkTrue('N8e: alias-bound plugin_name blocks commit', !stAB._validation.ok);
+    checkThrows('N8e: commit blocked', () => commitStaging(stAB, yoursAB), 'COMMIT_BLOCKED');
+
+    // (f) built-in plugin_name: log → not namespaced, not registered, left as-is
+    const srcLog = parseV3Protocol(
+        mkProtocol({
+            name: 'theirs',
+            conditions:
+                '  - name: logtrial\n    commands:\n      - {type: plugin, plugin_name: log, command_name: info}'
+        })
+    );
+    const yoursLog = parseV3Protocol(
+        mkProtocol({ name: 'yours', conditions: '  - name: x\n    commands: [{type: wait, duration: 1}]' })
+    );
+    const stLog = createStagingBuffer(srcLog, 'log.yaml');
+    addToStaging(stLog, 0, yoursLog);
+    checkTrue('N8f: log not registered as a plugin', !stLog.batch.pluginRegistry.has('log'));
+    const sumLog = commitStaging(stLog, yoursLog);
+    check('N8f: no plugin added for log', sumLog.pluginsAdded.length, 0);
+    checkTrue('N8f: plugin_name: log preserved verbatim', /plugin_name:\s*"?log"?/.test(yoursLog._doc.toString()));
+
+    // (g) planned anchor-name collision with empty prefix → blocking
+    const yoursAnch = parseV3Protocol(readFixture('v3_canonical_a.yaml')); // has &dur_short
+    const stAnch = createStagingBuffer(src, 'sib.yaml', { prefix: '' });
+    addToStaging(stAnch, 0, yoursAnch); // imports dur_short with empty prefix → collides with yours' dur_short
+    checkTrue('N8g: empty-prefix anchor collision blocks', !stAnch._validation.ok);
+    checkTrue(
+        'N8g: collision kind is anchor-name-collision',
+        stAnch._validation.blocking.some((b) => b.kind === 'anchor-name-collision')
+    );
+
+    // (h) unknown command type → warning (not blocking), still imports
+    const srcUnk = parseV3Protocol(
+        mkProtocol({
+            name: 'theirs',
+            conditions:
+                '  - name: branchy\n    commands:\n      - {type: branch, target: foo}\n      - {type: wait, duration: 1}'
+        })
+    );
+    const yoursUnk = parseV3Protocol(
+        mkProtocol({ name: 'yours', conditions: '  - name: x\n    commands: [{type: wait, duration: 1}]' })
+    );
+    const stUnk = createStagingBuffer(srcUnk, 'unk.yaml');
+    addToStaging(stUnk, 0, yoursUnk);
+    checkTrue('N8h: unknown command type recorded', stUnk.items[0].unknownCommandTypes.includes('branch'));
+    checkTrue('N8h: unknown command type does NOT block', stUnk._validation.ok);
+    const sumUnk = commitStaging(stUnk, yoursUnk);
+    check('N8h: condition with unknown command still imports', sumUnk.conditionsAdded.join(','), 'branchy');
+    checkTrue('N8h: unknown command type surfaced as warning', sumUnk.warnings.some((w) => w.kind === 'unknown-command-type'));
+    checkTrue('N8h: raw command type preserved in output', /type:\s*branch/.test(yoursUnk._doc.toString()));
+
+    // (i) transitive alias closure — led_settings pulls in color_power
+    const yoursTr = parseV3Protocol(readFixture('v3_no_variables.yaml'));
+    const stTr = createStagingBuffer(src, 'sib.yaml');
+    addToStaging(stTr, 1, yoursTr); // "sibling led" → params: *led_settings (→ *color_power)
+    checkTrue(
+        'N8i: transitive closure registers led_settings + color_power',
+        stTr.batch.anchorRegistry.has('led_settings') && stTr.batch.anchorRegistry.has('color_power')
+    );
+}
+
+// ─── Suite N9: edge cases ────────────────────────────────────────────────────
+console.log('\n--- Suite N9: edge cases ---');
+{
+    const src = parseV3Protocol(readFixture('v3_sibling_source.yaml'));
+
+    // no variables: in target → section created, commit re-parses
+    const noVars = parseV3Protocol(readFixture('v3_no_variables.yaml'));
+    const st1 = createStagingBuffer(src, 'sib.yaml');
+    addToStaging(st1, 0, noVars);
+    commitStaging(st1, noVars);
+    const o1 = noVars._doc.toString();
+    checkTrue('N9: created variables: precedes conditions:', o1.indexOf('variables:') < o1.indexOf('conditions:'));
+    checkTrue('N9: no-variables target re-parses after import', (() => { try { parseV3Protocol(o1); return true; } catch (e) { return false; } })());
+
+    // no plugins: in target → plugin section created
+    const noPlugins = parseV3Protocol(
+        mkProtocol({ name: 'yours', conditions: '  - name: x\n    commands: [{type: wait, duration: 1}]' })
+    );
+    checkTrue('N9: precondition target has no plugins:', noPlugins.plugins.length === 0);
+    const st2 = createStagingBuffer(src, 'sib.yaml');
+    addToStaging(st2, 0, noPlugins); // sibling check uses camera
+    commitStaging(st2, noPlugins);
+    checkTrue('N9: plugins: section created + camera added', noPlugins.plugins.some((p) => p.name === 'sib__camera' || p.name === 'sibling_source__camera'));
+    checkTrue('N9: no-plugins target re-parses', (() => { try { parseV3Protocol(noPlugins._doc.toString()); return true; } catch (e) { return false; } })());
+
+    // zero-alias condition → imports clean, no anchors
+    const srcZero = parseV3Protocol(
+        mkProtocol({ name: 'theirs', conditions: '  - name: plain\n    commands: [{type: controller, command_name: allOn}, {type: wait, duration: 2}]' })
+    );
+    const yoursZero = parseV3Protocol(
+        mkProtocol({ name: 'yours', conditions: '  - name: x\n    commands: [{type: wait, duration: 1}]' })
+    );
+    const stZ = createStagingBuffer(srcZero, 'z.yaml');
+    addToStaging(stZ, 0, yoursZero);
+    check('N9: zero-alias condition → no anchors registered', stZ.batch.anchorRegistry.size, 0);
+    const sumZ = commitStaging(stZ, yoursZero);
+    check('N9: zero-alias condition imports', sumZ.conditionsAdded.join(','), 'plain');
+
+    // depth-3 anchor chain a → b → c, topo order in output
+    const srcChain = parseV3Protocol(
+        mkProtocol({
+            name: 'theirs',
+            variables: 'variables:\n  c: &c 1\n  b: &b\n    inner: *c\n  a: &a\n    mid: *b',
+            conditions: '  - name: chain\n    commands:\n      - {type: plugin, plugin_name: log, command_name: dump, params: *a}'
+        })
+    );
+    const yoursChain = parseV3Protocol(
+        mkProtocol({ name: 'yours', conditions: '  - name: x\n    commands: [{type: wait, duration: 1}]' })
+    );
+    const stC = createStagingBuffer(srcChain, 'chain.yaml');
+    addToStaging(stC, 0, yoursChain);
+    check('N9: depth-3 chain registers all 3 anchors', stC.batch.anchorRegistry.size, 3);
+    commitStaging(stC, yoursChain);
+    const oc = yoursChain._doc.toString();
+    const ia = oc.indexOf('&chain__a');
+    const ib = oc.indexOf('&chain__b');
+    const ic = oc.indexOf('&chain__c');
+    checkTrue('N9: topo order — &c before &b before &a', ic < ib && ib < ia && ic >= 0);
+    checkTrue('N9: depth-3 chain re-parses', (() => { try { parseV3Protocol(oc); return true; } catch (e) { return false; } })());
+
+    // self-edge vs genuine cycle in the anchor topo sort (design §5c). A
+    // self-referential anchor (&A {self: *A}) is a self-edge → ignored, no false
+    // cycle. A true a↔b cycle → ANCHOR_CYCLE blocking. We exercise the topo logic
+    // through validateStaging with a hand-built registry (a truly *circular* value
+    // used as command params can't be JS-mirrored at all — a pre-existing
+    // JSON.stringify-of-cycles limit in extractCommand, out of D4's scope).
+    const yoursTopo = parseV3Protocol(
+        mkProtocol({ name: 'yours', conditions: '  - name: x\n    commands: [{type: wait, duration: 1}]' })
+    );
+    // self-edge: anchor "n" whose value references *n
+    const selfDoc = rawDoc('n: &n {label: leaf}\n');
+    const selfNode = selfDoc.getIn(['n'], true);
+    selfNode.items.push(new YAML.Pair(selfDoc.createNode('self'), new YAML.Alias('n')));
+    const selfStaging = {
+        items: [],
+        batch: {
+            anchorRegistry: new Map([['n', { srcValueNode: selfNode, plannedName: 'sib__n', override: false }]]),
+            pluginRegistry: new Map()
+        }
+    };
+    const selfVal = validateStaging(selfStaging, yoursTopo);
+    checkTrue('N9: self-edge anchor is NOT reported as a cycle', selfVal.ok);
+
+    // genuine cycle: a → b and b → a
+    const cycDoc = rawDoc('a: &a {x: 1}\nb: &b {y: 1}\n');
+    const aN = cycDoc.getIn(['a'], true);
+    const bN = cycDoc.getIn(['b'], true);
+    aN.items[0].value = new YAML.Alias('b'); // a.x → *b
+    bN.items[0].value = new YAML.Alias('a'); // b.y → *a
+    const cycStaging = {
+        items: [],
+        batch: {
+            anchorRegistry: new Map([
+                ['a', { srcValueNode: aN, plannedName: 'sib__a', override: false }],
+                ['b', { srcValueNode: bN, plannedName: 'sib__b', override: false }]
+            ]),
+            pluginRegistry: new Map()
+        }
+    };
+    const cycVal = validateStaging(cycStaging, yoursTopo);
+    checkTrue('N9: genuine a↔b cycle is blocked', !cycVal.ok);
+    checkTrue('N9: cycle reported as anchor-cycle', cycVal.blocking.some((b) => b.kind === 'anchor-cycle'));
+
+    // failed-commit rollback: sabotage the LATER topo anchor; assert partial mutations reverted
+    const yoursRb = parseV3Protocol(readFixture('v3_no_variables.yaml'));
+    const stRb = createStagingBuffer(src, 'sib.yaml');
+    addToStaging(stRb, 1, yoursRb); // color_power (first) + led_settings (second)
+    const before = yoursRb._doc.toString();
+    stRb.batch.anchorRegistry.get('led_settings').srcValueNode = {}; // not cloneable → throws after color_power inserted
+    checkThrows('N9: sabotaged commit throws COMMIT_FAILED', () => commitStaging(stRb, yoursRb), 'COMMIT_FAILED');
+    check('N9: rollback restored yours._doc exactly', yoursRb._doc.toString(), before);
+    checkTrue('N9: rollback restored mirror (no partial anchors)', !yoursRb.variables.some((v) => /^sib(ling_source)?__/.test(v.name)));
+}
+
+// ─── Suite N10: preflight rejection ──────────────────────────────────────────
+console.log('\n--- Suite N10: preflight rejection ---');
+{
+    // duplicate anchor names in source → createStagingBuffer rejects
+    const dupText = mkProtocol({
+        name: 'theirs',
+        variables: 'variables:\n  a: &dup 1\n  b: &dup 2',
+        conditions: '  - name: c\n    commands: [{type: wait, duration: *dup}]'
+    });
+    const dupSrc = parseV3Protocol(dupText);
+    check('N10: detectDuplicateAnchors finds the dup', detectDuplicateAnchors(dupSrc._doc).join(','), 'dup');
+    checkThrows('N10: createStagingBuffer rejects duplicate-anchor source', () => createStagingBuffer(dupSrc, 'dup.yaml'), 'DUPLICATE_ANCHOR_SOURCE');
+
+    // broken-alias source → parseV3Protocol throws (can never enter import mode)
+    const brokenText = mkProtocol({
+        name: 'theirs',
+        conditions: '  - name: c\n    commands: [{type: wait, duration: *missing}]'
+    });
+    checkThrows('N10: broken-alias source rejected at parse (cannot enter import)', () => parseV3Protocol(brokenText));
+
+    // derivePrefix sanitization
+    check('N10: derivePrefix strips path + ext', derivePrefix('/a/b/Sibling Lab.yaml'), 'Sibling_Lab__');
+    check('N10: derivePrefix empty for empty name', derivePrefix(''), '');
+    check('N10: suggestUniqueName bumps suffix', suggestUniqueName('x', new Set(['x', 'x_2'])), 'x_3');
 }
 
 // ─── Results ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this is

**Milestones 1 and 2 of D4 (cross-library import)** for the v3 Experiment
Designer, in a single PR to `main`. The full node-based substrate that copies
conditions (plus their anchors and plugin declarations) from a second YAML
document into yours — primitives, document-level inserts, the staging buffer,
and the commit pipeline. **Node-only, no UI** (the three-pane UI is Milestone 3,
an interactive session — not in this PR).

Pre-work landed first: the rev-2→rev-3 fix list was applied to the design doc
and `codex-plan-review` findings were addressed before any code was written
(commit `26c6f17`).

## Milestone 1 — cross-doc primitives + node-based helpers (commit `c6d8fd5`)
`js/v3-import.js` (new, dual-export):
- `collectAliasReferences` — document-order alias walk, incl. transitive.
- `resolveAlias` — resolves via `alias.resolve(doc)` (last-wins), **not** name lookup.
- `cloneNodeAcrossDocs` — one shared `aliasRewriteMap`; rewrites inline anchor
  definitions + aliases; preserves comments.
- `yamlNodeStructuralEquals` + `sortedJson` — recursive key-sorted comparison.

`js/protocol-yaml-v3.js`:
- `ensureTopLevelSection`, `docInsertConditionNode`, `docInsertVariableNode`,
  `docInsertPluginNode` — node-based, comment/alias preserving.

Test suites **N1–N6**.

## Milestone 2 — staging buffer + commit pipeline (commit `6330bfb`)
`js/v3-import.js`:
- `createStagingBuffer` — duplicate-anchor preflight; filename-derived prefix.
- `addToStaging` — visited-set transitive anchor closure into a per-batch
  registry; plugin merge-vs-namespace; alias-bound `plugin_name` detection;
  built-in `log` left alone; unknown-command notes; walks plugin `config` aliases.
- `removeFromStaging` / `setStagingPrefix` / `setItemTargetName` — overrides
  persist across prefix recompute.
- `commitStaging` — one shared `aliasRewriteMap`; topological anchor insert
  (self-edges ignored); `name:`/`plugin_name` rewrite; **plugin merge-by-default**
  when class+config match; provenance stamps; atomic (validate → snapshot →
  rollback on any throw).

Test suites **N7–N10**.

## Decisions from review (confirmed by repo owner)
- **Plugins merge by default** when the same runtime resource — identity = all
  plugin fields except `name`, plus same `rig` when both are config-less.
- **Comment-stamp imported nodes** for provenance (`# imported from <source>`).

## Tests
```
npm test → arena 10/10 · v2 137/137 · v3 576/576  (was 510, +66 D4 checks)
```
All suites N1–N10 present and green. Footer **v0.13 → v0.15**.

## Not in scope
M3 three-pane UI + locking; M4 polish/docs. **Do not merge** — open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
