### PR TITLE
feat(v3): D4 Milestone 4 — import-mode beforeunload guard + docs (v0.17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -583,6 +583,85 @@ Filmstrip + lane view:
 - **Phase shallow copy bug**: `{ ...DEFAULT_PHASE }` shares the `commands` array reference between pretrial/intertrial/posttrial. Must use `JSON.parse(JSON.stringify(...))` for deep clone.
 - **Visual editor first-click alert**: The table view's `.btn-row-delete` class overlapped with visual editor delete buttons, causing a "Phase 3" alert on first click. Fixed by giving visual editor buttons a separate `.cmd-delete-btn` class.
 
+## v3 Experiment Designer — D4 Cross-Library Import
+
+`experiment_designer_v3.html` (the v3 editor) lets a user open a **second** v3
+protocol YAML and copy selected conditions — with the anchors and plugin
+declarations they transitively depend on — into the currently-loaded protocol,
+preserving comments/aliases. This is "D4" (the library-copy feature). The v3
+editor's general architecture lives in the handoff docs (see below); this section
+documents D4 specifically.
+
+### Module split
+- **`js/v3-import.js`** (new in D4) — the cross-doc substrate + staging buffer +
+  commit pipeline. **Dual-export** (window global `V3Import` + ES named exports +
+  CommonJS for tests), mirroring `js/protocol-yaml-v3.js`.
+- **`js/protocol-yaml-v3.js`** — D4 added node-based inserters
+  `ensureTopLevelSection`, `docInsertConditionNode`, `docInsertVariableNode`,
+  `docInsertPluginNode` (preserve comments/aliases, unlike the JS-object-building
+  `docInsertCondition`).
+
+### v3-import.js API (what the UI drives)
+- **Primitives:** `collectAliasReferences`, `resolveAlias` (via
+  `alias.resolve(doc)` — **not** name lookup), `cloneNodeAcrossDocs` (one shared
+  `aliasRewriteMap`), `yamlNodeStructuralEquals` + `sortedJson` (recursive key
+  sort, used only on the plugin-merge path).
+- **Staging:** `createStagingBuffer` (duplicate-anchor preflight; filename-derived
+  prefix), `addToStaging` (visited-set transitive anchor closure + per-batch
+  dependency registry), `removeFromStaging`, `setStagingPrefix` (recompute planned
+  names; per-item overrides persist), `setItemTargetName`, `setAnchorPlannedName`,
+  `setPluginPlannedName`, `refreshStagingValidation`, `commitStaging`.
+
+### The anchor/plugin asymmetry (the core product rule)
+- **Anchors namespace by default** (`&dur_short` → `&prefix__dur_short`). They're
+  data aliases — safe to prefix.
+- **Plugins MERGE by default** when `matlab.class` + `config` match (identity =
+  all plugin fields except `name`, plus same `rig` when both are config-less);
+  namespace only on mismatch. Plugins are runtime resources (cameras, controllers)
+  — duplicating one is a real runtime bug. The built-in `log` plugin is always
+  left as-is.
+- Imported nodes are **comment-stamped** `# imported from <source>` for provenance.
+
+### `commitStaging` contract (important for UI wiring)
+- **Atomic:** validates first (throws `V3ImportError` `COMMIT_BLOCKED` with
+  `.blocking`), snapshots `yours._doc.toString()`, and rolls back on any
+  mid-commit throw (`COMMIT_FAILED`). All-or-nothing.
+- **Does NOT call `pushUndo`** — the UI wrapper does, once, so the whole batch is
+  a single undo step. Validate *before* `pushUndo` so a blocked attempt leaves no
+  spurious undo entry; on a `COMMIT_FAILED` throw, `undoStack.pop()` (nothing
+  changed).
+- Handles bare-ref appending internally when `staging.addBareRefs` is true.
+
+### Import-mode UI (in `experiment_designer_v3.html`)
+- `enterImportMode` / `exitImportMode` / `commitImport` swap the three-zone layout:
+  `#libraryZone` → "yours" locked, `#sequenceZone` → read-only "import source"
+  pane, `#inspectorZone` → staging-item detail / source preview. A top
+  `#importBanner` carries the editable prefix, staged count, "append bare refs"
+  toggle, and Cancel/Commit.
+- **`renderConditionList(listEl, conditions, opts)`** is the shared row renderer
+  extracted from `renderLibrary`; reused by the locked "yours" pane and the
+  read-only "theirs" pane. `opts`: `getUsage`, `isSelected`, `onRowClick`,
+  `extraButtons`, `draggable`, `rowClass`, `emptyText`.
+- **Locking (D4 design fix #8):** every target-doc mutation entry point guards on
+  `if (importMode) return` **and** the controls are disabled on enter — never a
+  global `pushUndo` suppression (commit itself pushes the one snapshot). When
+  adding a new mutation handler to the v3 editor, **add an `importMode` guard.**
+- Entering import mode must **not** `setDirty(true)` (cancelling mutates nothing);
+  only a successful commit does. The `beforeunload` guard fires on `dirty ||
+  importMode`.
+
+### Tests + scope
+- `tests/test-protocol-roundtrip-v3.js` suites **N1–N10** cover the whole
+  substrate in Node (no browser). Run `npm test` after any `v3-import.js` or
+  `protocol-yaml-v3.js` change.
+- **Out of scope for D4 v1** (design §12): sequence/block-membership import,
+  multi-doc YAML streams, pattern-path validation, a per-anchor "merge with
+  existing" toggle. Imported conditions are *runnable* (bare ref appended), not
+  behaviorally identical to how the sibling ran them.
+- Authoritative docs: `docs/development/v3-d4-design.md` (rev 3),
+  `docs/development/v3-d4-implementation-handoff.md`,
+  `docs/development/v3-d4-design-reviews.md`.
+
 ## Planning Best Practices
 
 ### Project Size Assessment

--- a/docs/development/v3-editor-handoff-2.md
+++ b/docs/development/v3-editor-handoff-2.md
@@ -1,9 +1,9 @@
 # v3 Experiment Designer — Handoff for Next Session (Round 2)
 
-**Last updated:** 2026-05-29
-**State:** v0.13 = manual-testing fixes (toolbar reflow + editable settings), on a branch → PR.
-**Editor version:** v3 Experiment Designer **v0.13**
-**`main` HEAD:** `7b9e72e` (#78) — prior `9dca364` (#77)
+**Last updated:** 2026-06-01
+**State:** D4 (cross-library import) shipped — M1+M2 (#84) and M3 UI (#85) merged to `main`. M4 (polish + docs) in progress.
+**Editor version:** v3 Experiment Designer **v0.16** (M4 → v0.17)
+**`main` HEAD:** `5bf08f4` (Merge #85) — D4 M1–M3
 **Pinned upstream:** maDisplayTools `origin/version3` at `649d7ef`
 
 This is the live handoff for the v3 designer. It supersedes the original
@@ -15,19 +15,18 @@ and the known gotchas.
 
 ## 0. TL;DR
 
-The v3 designer is **feature-complete for single-document editing** and merged
-to `main` at v0.12. Phases 1–7 all shipped. Tests green at **arena 10/10,
-v2 137/137, v3 467/467**.
+The v3 designer is **feature-complete for single-document editing** AND now ships
+**D4 (cross-library import)** — Phases 1–7 plus D4 M1–M3 are merged to `main`.
+Tests green at **arena 10/10, v2 137/137, v3 576/576**.
 
 Live: <https://reiserlab.github.io/webDisplayTools/experiment_designer_v3.html>
 
-**Only one substantial feature remains: D4 (cross-library import).** Everything
-else left is polish (a MATLAB-validation doc, a quickstart page) or optional
-tech-debt. See §3.
+**D4 is done** (M1 cross-doc primitives, M2 staging + commit, M3 three-pane UI;
+M4 = polish + docs). The D4 reference now lives in **CLAUDE.md → "v3 Experiment
+Designer — D4 Cross-Library Import"** plus the three `v3-d4-*` docs. What remains
+is polish: a MATLAB-validation doc, a quickstart page, optional tech-debt. See §3.
 
-If the next session is short, good quick wins are in §3 Tier 5 / §4. If it's a
-big one, D4 (§3 Tier 4) is the headline — but read its design + review docs and
-re-run a design pass first.
+If the next session is short, good quick wins are in §3 Tier 5 / §4.
 
 ---
 
@@ -66,6 +65,9 @@ stress test reveals the cliff.
 | #70–#74 | Phase 4 — sequence reorder, +Ref/+Block, drag library→sequence, block trial editing, timeline ribbon, ref↔block convert, missing-trial create | v0.8 |
 | **#77** | Phase 4 cleanup (the 4 Codex bugs) + **Phase 5 Variables editor** + **Phase 6 validation modal / Reset / library delete** | v0.9 → v0.11 |
 | **#78** | **Phase 7 test hardening** + **validation error line numbers** + modal double-bullet fix | v0.12 |
+| #81 | Toolbar-reflow + editable-settings fixes | v0.13 |
+| **#84** | **D4 M1** (cross-doc primitives + node helpers) + **D4 M2** (staging buffer + commit pipeline; suites N1–N10) | v0.14 → v0.15 |
+| **#85** | **D4 M3** — three-pane cross-library import UI (`renderConditionList` extraction, import-mode swap, locking) | v0.16 |
 
 ### What the editor can do today (v0.12)
 
@@ -122,24 +124,28 @@ passthrough; 10 demo fixtures), **plus**:
 
 Phases 1–7 are done. Remaining work, by size:
 
-### Tier 4: D4 — cross-library import (the one big feature, ~5+ days)
+### Tier 4: D4 — cross-library import ✅ SHIPPED (M1–M3 merged; M4 in progress)
 
-> **Executable handoff:** `docs/development/v3-d4-implementation-handoff.md` —
-> milestones with completion gates, the rev-3 fix list, pre-answered open
-> questions, and dynamic-workflow guidance. Start there.
+Pull conditions (+ their anchors and plugin declarations) from one protocol into
+another. **Done across #84 (M1+M2) and #85 (M3).** Reference:
+**CLAUDE.md → "v3 Experiment Designer — D4 Cross-Library Import"**, plus
+`docs/development/v3-d4-design.md` (rev 3),
+`docs/development/v3-d4-implementation-handoff.md`, and
+`docs/development/v3-d4-design-reviews.md`.
 
-Pull conditions/plugins/variables from one protocol into another. Design is
-preserved at `docs/development/v3-d4-design.md` (rev 2) with the review-fix list
-at `docs/development/v3-d4-design-reviews.md`. Before implementing:
+How it landed vs. the original plan:
+1. Rev-2→rev-3 fix list applied; a fresh `codex-plan-review` pass ran before M1.
+2. Plugins **merge by default when class+config match** (Codex-adv's point);
+   anchors namespace by default.
+3. The `applySequenceEdit` reducer refactor (§1) was **NOT** needed — the staging
+   buffer stayed self-contained and commits via the documented node primitives
+   (design §13). The path-based mirror model held.
+4. **M4 (this milestone):** `beforeunload` guard during import mode + these doc
+   updates + footer bump. That completes D4 v1.
 
-1. Apply the rev-2 review fix list (~11 corrections before Milestone 1).
-2. Switch from plugin namespacing to **plugin merge-by-default when class+config
-   match** (Codex-adv's strongest point).
-3. Re-run a Codex design pass on the rev-3 doc.
-4. Expect this to be the trigger for the `applySequenceEdit` reducer refactor
-   (§1) — D4's cross-doc primitives won't fit the current per-helper pattern
-   cleanly. Phase 5's Variables table is the prefix-clutter mitigation D4 needs,
-   so that dependency is satisfied.
+Explicitly **out of scope for D4 v1** (design §12): sequence/block-membership
+import, multi-doc YAML streams, pattern-path validation, a per-anchor
+"merge with existing" toggle. Candidates for a future v1.1.
 
 ### Tier 5: polish
 

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -1322,7 +1322,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.16 | <span id="footerTimestamp">2026-06-01 07:47 ET</span>
+        v3 Experiment Designer v0.17 | <span id="footerTimestamp">2026-06-01 08:31 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -1426,9 +1426,13 @@
             $('dirtyIndicator').style.display = dirty ? 'inline-block' : 'none';
         }
 
-        // Warn before close/reload if there are unsaved edits.
+        // Warn before close/reload if there are unsaved edits, OR if a
+        // cross-library import is in progress (the staging buffer is not yet
+        // committed and would be lost). Import mode is tracked separately from
+        // `dirty` because entering import mode intentionally does NOT mark the
+        // document dirty (design §7) — only a successful commit does.
         window.addEventListener('beforeunload', (e) => {
-            if (dirty) {
+            if (dirty || importMode) {
                 e.preventDefault();
                 e.returnValue = '';
             }


### PR DESCRIPTION
## What this is

**Milestone 4 of D4 (cross-library import) — the final piece: polish + docs.**
Completes the D4 Definition of Done (handoff §9). Targets `main` directly
(M1–M3 already merged via #84/#85).

## Changes
- **`beforeunload` guard during import mode** (`experiment_designer_v3.html`):
  warns on `dirty || importMode`, so an accidental tab-close mid-import — when
  the staging buffer is built but not yet committed — prompts before losing it.
  Tracked separately from `dirty` because entering import mode intentionally does
  **not** mark the document dirty (design §7); only a successful commit does.
  Browser-verified: fires during import, silent before/after.
- **CLAUDE.md** — new reference section *"v3 Experiment Designer — D4
  Cross-Library Import"*: module split (`v3-import.js`), the staging API, the
  anchor-namespace / plugin-merge-by-default rule, the `commitStaging` atomicity +
  no-`pushUndo` contract, the import-mode UI + locking (incl. the rule that new
  mutation handlers need an `importMode` guard), the test suites, and the
  out-of-scope list.
- **`v3-editor-handoff-2.md`** — marked D4 shipped: header/TL;DR/shipped-table/
  Tier 4 refreshed; records that the `applySequenceEdit` reducer refactor was
  **not** needed (the staging buffer stayed self-contained and commits via the
  documented node primitives).
- Footer **v0.16 → v0.17**.

## Tests
```
npm test → arena 10/10 · v2 137/137 · v3 576/576  (docs/polish only — no logic change)
```

## D4 status after this merges
M1 (#84) · M2 (#84) · M3 (#85) · **M4 (this)** → **D4 v1 complete.** Future v1.1
candidates (design §12): sequence/block-membership import, multi-doc YAML
streams, pattern-path validation, per-anchor "merge with existing" toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
