### PR TITLE
feat(v3): always-visible Variables panel + v3 polish (v0.18)

### DIFF
--- a/docs/development/v3-editor-handoff-2.md
+++ b/docs/development/v3-editor-handoff-2.md
@@ -149,11 +149,12 @@ import, multi-doc YAML streams, pattern-path validation, a per-anchor
 
 ### Tier 5: polish
 
-- **Phase 8** — write `docs/development/v3-matlab-validation.md` describing the
-  MCP-driven flow that confirms web output loads in MATLAB (the original Phase 1
-  gate item 4, deferred).
-- **Phase 9** — `experiment_designer_v3_quickstart.html`, a step-by-step
-  walkthrough modeled on `experiment_designer_quickstart.html` (the v2 one).
+- **Phase 8** ✅ — `docs/development/v3-matlab-validation.md` describes the
+  MCP-driven flow that confirms web output loads in MATLAB (web side is CI-green;
+  the MATLAB-side script is documented as a manual gate, still to be committed in
+  maDisplayTools).
+- **Phase 9** ✅ — `experiment_designer_v3_quickstart.html` shipped (step-by-step
+  walkthrough incl. the D4 cross-library import flow; linked from the editor header).
 - **Phase 7 leftovers** (optional): params-level anchor cases, deeper
   validation-error matrices. Core Phase 7 shipped in #78 (Suite 31).
 

--- a/docs/development/v3-matlab-validation.md
+++ b/docs/development/v3-matlab-validation.md
@@ -1,0 +1,138 @@
+# Protocol v3 — Web → MATLAB Validation
+
+Validates that Protocol **v3** YAML produced/edited by the **v3 Experiment Designer**
+(`experiment_designer_v3.html`) is loadable by the **MATLAB experiment runner**
+(`ProtocolParser` + `ProtocolRunner`) in maDisplayTools.
+
+This is the v3 analogue of [`protocol-roundtrip-testing.md`](protocol-roundtrip-testing.md)
+(v1/v2). It documents Phase 1 gate item 4 (the MATLAB cross-check, deferred to Phase 8).
+
+> **Status.** The **web side is implemented and CI-green** (576 checks in
+> `tests/test-protocol-roundtrip-v3.js`). The **MATLAB side is a manual gate**:
+> there is no v3-specific validation script in maDisplayTools yet (only the v2
+> `validate_web_protocol_roundtrip.m`). This doc describes the flow and how to run
+> the cross-check via the MATLAB MCP tools until that script is written.
+
+## Architecture
+
+The v3 editor differs from v2 in one load-bearing way: **the YAML document is the
+single source of truth.** The editor parses a v3 YAML into a `YAML.Document`, edits
+it through node-level helpers, and exports via `_doc.toString()` — so anchors,
+comments, and key order survive the round-trip. Validation therefore checks that
+*the editor's exported YAML* (not a freshly-generated one) loads in MATLAB.
+
+```
+Web (JavaScript)                         MATLAB (maDisplayTools)
+─────────────────                        ──────────────────────
+experiment_designer_v3.html              ProtocolParser.m
+  └─ parseV3Protocol()  ── edits ──┐       └─ parse()   (v3-aware)
+       (js/protocol-yaml-v3.js)    │            │
+       │  (YAML.Document model)    │            ▼
+       ▼                           │     Parsed protocol struct
+  exported v3 YAML  ───────────────┴───▶   (version 3, rig, plugins,
+   (anchors + comments preserved)          variables/anchors resolved,
+       │                                    conditions, experiment[])
+       ▼                                         │
+  test-protocol-roundtrip-v3.js                  ▼
+   (parse → re-emit → compare,             ProtocolRunner constructor
+    576 checks, anchors/comments)            (dry-run, validates structure;
+                                             no hardware init)
+```
+
+## Test coverage
+
+| Layer | Test | Runs in CI? |
+|-------|------|-------------|
+| Web parse → re-emit round-trip (anchors + comments preserved) | `tests/test-protocol-roundtrip-v3.js` | Yes (Node.js) |
+| Web node-edit helpers + D4 cross-library import (suites N1–N10) | `tests/test-protocol-roundtrip-v3.js` | Yes (Node.js) |
+| MATLAB parse + anchor/plugin resolution (v3) | *manual gate — script TBD* | No (needs MATLAB) |
+| MATLAB `ProtocolRunner` construction (v3, dry-run) | *manual gate — script TBD* | No (needs MATLAB) |
+
+## Running the validation
+
+### 1. Web-side (CI, no dependencies)
+
+```bash
+cd webDisplayTools
+npm run test:protocol-v3          # or: node tests/test-protocol-roundtrip-v3.js
+```
+
+576 checks across the v3 round-trip suites + the D4 cross-library-import suites
+(N1–N10). Covers: parsing the two canonical v3 YAMLs (pinned from maDisplayTools
+`origin/version3`) plus coverage-gap fixtures; re-emitting them byte-stably with
+anchors and comments intact; the node-level edit helpers; and the cross-doc import
+substrate. Exit code 0 = all passed.
+
+The canonical fixtures are kept in sync with upstream via
+[`tests/refresh-v3-canonical.sh`](../../tests/refresh-v3-canonical.sh) — if upstream
+changes the spec YAMLs, that surfaces the drift so the parser/tests can be updated.
+
+### 2. MATLAB-side cross-check (manual gate)
+
+The goal: confirm an editor-exported v3 YAML loads in MATLAB end to end.
+
+1. In the editor, load (or import-and-commit) a protocol that exercises the features
+   you care about, then **Export YAML** to a file under
+   `maDisplayTools/tests/web_generated_patterns/` (e.g. `test_protocol_v3.yaml`).
+2. Run the MATLAB cross-check. Until a dedicated `validate_web_protocol_roundtrip('v3')`
+   path exists, drive it through the MATLAB MCP tools:
+   - `check_matlab_code` — static-analyze the parser entry point.
+   - `run_matlab_file` / `evaluate_matlab_code` — execute, e.g.:
+     ```matlab
+     p = ProtocolParser('tests/web_generated_patterns/test_protocol_v3.yaml').parse();
+     assert(p.version == 3);
+     % anchors resolved to literal values; plugins present; conditions/experiment populated
+     r = ProtocolRunner(p);            % dry-run: constructs + validates, no hardware
+     ```
+3. Confirm: version = 3; every `*alias` resolved to its anchor's literal value;
+   `plugins:` entries present; `conditions:` and `experiment:` populated; the
+   `ProtocolRunner` constructor succeeds.
+
+When this stabilizes, promote it into a committed
+`maDisplayTools/tests/validate_web_protocol_roundtrip.m` v3 branch (mirroring the v2
+checks) so it becomes a repeatable gate.
+
+## Files
+
+### Web side (`webDisplayTools/`)
+| File | Purpose |
+|------|---------|
+| `experiment_designer_v3.html` | The v3 editor; exports via `_doc.toString()` |
+| `js/protocol-yaml-v3.js` | v3 parser/generator + node-level edit helpers |
+| `js/v3-import.js` | D4 cross-library import substrate (dual-export) |
+| `tests/test-protocol-roundtrip-v3.js` | v3 round-trip + import tests (576 checks) |
+| `tests/fixtures/v3_*.yaml` | Canonical + coverage-gap fixtures |
+| `tests/refresh-v3-canonical.sh` | Pull canonical v3 YAMLs from upstream |
+
+### MATLAB side (`maDisplayTools/`)
+| File | Purpose |
+|------|---------|
+| `tests/validate_web_protocol_roundtrip.m` | v2 validator (v3 branch TBD) |
+| `tests/web_generated_patterns/` | Drop exported v3 YAMLs here for the cross-check |
+| Authoritative v3 spec | `docs/development/yaml_protocol_documentation_v3.md` on `origin/version3` |
+
+## What to update when the v3 format changes
+
+1. Refresh the canonical fixtures: `tests/refresh-v3-canonical.sh`, then
+   `git diff tests/fixtures/v3_canonical_*.yaml` to see upstream drift.
+2. Update the parser/generator/helpers in `js/protocol-yaml-v3.js` (and
+   `js/v3-import.js` if the import substrate is affected) to match.
+3. Run `npm run test:protocol-v3` — must stay green.
+4. Re-export a sample and re-run the MATLAB cross-check (step 2 above).
+5. Update `docs/development/v3-spec.md`'s pinned SHA if the spec moved.
+
+## Known constraints
+
+- **Dry-run only.** The MATLAB cross-check validates parse + construction, not
+  `run()` — it does not initialize hardware (PanelsController).
+- **`ProtocolParser.m` is upstream code** (Lisa's) — DO NOT MODIFY. If the editor's
+  output doesn't parse, fix the web side or discuss the spec, don't patch the parser.
+- **Anchors are document-local.** The editor resolves `*alias` to the anchoring
+  document only. Cross-document anchor reuse is not a thing; D4 import namespaces
+  imported anchors into the target document (see D4 design §3).
+- **Complex anchors are read-only in the UI.** Map/sequence anchors render as a
+  badge and are edited in YAML directly; the round-trip still preserves them.
+- **D4-imported snippets are runnable, not behavioral clones** (D4 design §12):
+  import copies conditions + their direct anchor/plugin dependencies and appends a
+  bare sequence ref. It does not reproduce the source's block membership,
+  repetitions, randomize, or intertrial placement.

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -68,18 +68,6 @@
             color: var(--accent);
             font-weight: 700;
         }
-        .beta-badge {
-            display: inline-block;
-            padding: 0.1rem 0.5rem;
-            font-size: 0.65rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            background: rgba(41, 182, 246, 0.15);
-            color: var(--beta);
-            border: 1px solid var(--beta);
-            border-radius: 3px;
-        }
         .header-spacer { flex: 1; }
         .header-btn {
             background: var(--surface-2);
@@ -492,7 +480,7 @@
         /* ── 3-zone main area ────────────────────────────────────────── */
         .three-zone {
             display: grid;
-            grid-template-columns: 280px 1fr 360px;
+            grid-template-columns: 320px 1fr 360px;
             flex: 1;
             min-height: 0;
             border-bottom: 1px solid var(--border);
@@ -504,6 +492,17 @@
             min-height: 0;
         }
         .zone:last-child { border-right: none; }
+        /* Left column is split into two stacked panels: Conditions + Variables. */
+        #libraryZone .lib-split {
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
+        }
+        #libraryZone .lib-split.lib-split-conditions { flex: 1.5; }
+        #libraryZone .lib-split.lib-split-variables {
+            flex: 1;
+            border-top: 1px solid var(--border);
+        }
         .zone-header {
             padding: 0.5rem 0.75rem;
             background: var(--surface);
@@ -1184,7 +1183,6 @@
     <!-- Header -->
     <div class="app-header">
         <h1>v3 Experiment Designer</h1>
-        <span class="beta-badge">Beta / Editor</span>
         <!-- Dirty indicator lives in the LEFT cluster (before the flex spacer)
              so that when it toggles visible it's absorbed by the spacer and
              does NOT shift the right-aligned action buttons (Undo/Redo/Reset).
@@ -1195,7 +1193,7 @@
         <button id="undoBtn" class="header-btn" disabled title="Undo last edit (Ctrl+Z)">↶ Undo</button>
         <button id="redoBtn" class="header-btn" disabled title="Redo (Ctrl+Y)">↷ Redo</button>
         <button id="resetBtn" class="header-btn" disabled title="Clear everything to a blank minimum-valid v3 skeleton (reversible with Undo)">⟲ Reset</button>
-        <button id="settingsToggle" class="header-btn" title="Show/hide experiment metadata, rig, plugins, variables">Settings ▾</button>
+        <button id="settingsToggle" class="header-btn" title="Show/hide experiment metadata, rig, and plugins">Settings ▾</button>
         <select id="demoSelect" class="header-btn" title="Load a bundled demo YAML or start from a blank skeleton">
             <option value="">Load demo ▾</option>
             <option value="__blank__">New (blank) — minimum-valid v3 skeleton</option>
@@ -1215,6 +1213,7 @@
         <input type="file" id="importFromInput" accept=".yaml,.yml" style="display: none;">
         <button id="importFromBtn" class="header-btn" disabled title="Copy conditions from a second v3 YAML into this one (brings their anchors + plugins along)">Import from YAML…</button>
         <button id="exportBtn" class="header-btn" disabled title="Export the (possibly edited) YAML">Export YAML</button>
+        <a href="experiment_designer_v3_quickstart.html" target="_blank" class="header-btn" style="text-decoration: none; display: inline-flex; align-items: center;" title="Open the v3 Experiment Designer quick-start guide in a new tab">Quick Start</a>
         <a href="index.html" class="header-btn" style="text-decoration: none; display: inline-flex; align-items: center;">← All tools</a>
     </div>
 
@@ -1267,17 +1266,28 @@
 
     <!-- 3-zone main -->
     <div class="three-zone">
-        <!-- LIBRARY -->
+        <!-- LIBRARY (split: Conditions on top, Variables below) -->
         <div class="zone" id="libraryZone">
-            <div class="zone-header">
-                <span id="libZoneTitle">Library</span>
-                <span class="count" id="libCount">0</span>
-                <button id="addCondBtn" class="zone-head-btn" title="Add a new condition (also appends a bare ref to the sequence)" disabled>+ Add</button>
+            <div class="lib-split lib-split-conditions">
+                <div class="zone-header">
+                    <span id="libZoneTitle">Library</span>
+                    <span class="count" id="libCount">0</span>
+                    <button id="addCondBtn" class="zone-head-btn" title="Add a new condition (also appends a bare ref to the sequence)" disabled>+ Add</button>
+                </div>
+                <div class="zone-body">
+                    <input type="text" class="library-search" id="librarySearch" placeholder="Search conditions..." disabled>
+                    <div id="libraryList">
+                        <div class="empty-state">Import a v3 YAML to populate the conditions library.</div>
+                    </div>
+                </div>
             </div>
-            <div class="zone-body">
-                <input type="text" class="library-search" id="librarySearch" placeholder="Search conditions..." disabled>
-                <div id="libraryList">
-                    <div class="empty-state">Import a v3 YAML to populate the conditions library.</div>
+            <div class="lib-split lib-split-variables">
+                <div class="zone-header">
+                    <span>Variables</span>
+                    <span class="count" id="varCount">0</span>
+                </div>
+                <div class="zone-body" id="variablesPanel">
+                    <div class="empty-state">Import a v3 YAML to view its variables (anchors).</div>
                 </div>
             </div>
         </div>
@@ -1322,7 +1332,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.17 | <span id="footerTimestamp">2026-06-01 08:31 ET</span>
+        v3 Experiment Designer v0.18 | <span id="footerTimestamp">2026-06-01 09:10 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -1921,38 +1931,55 @@
                 root.appendChild(pluginBox);
             }
 
-            // Variables — inline-editable (Phase 5, v0.10)
-            // Always render the section even when empty so the user can add
-            // the first variable. Complex anchors (maps/seqs) render as
-            // read-only badges; scalar anchors are name + value editable.
-            const varBox = el('div', { class: 'settings-section' });
-            const varCount = experiment.variables ? experiment.variables.length : 0;
-            varBox.appendChild(el('h3', {}, 'Variables (' + varCount + ')'));
+            // Variables moved out of the drawer into the always-visible left-column
+            // panel (#variablesPanel) — see renderVariables(). The drawer now holds
+            // only Experiment Info, Rig, and Plugins.
+        }
+
+        // Variables (anchors) editor — always-visible panel below the conditions
+        // library (was in the Settings drawer through v0.17). Renders into
+        // `hostEl` (#variablesPanel). Complex anchors (maps/seqs) show a read-only
+        // badge; scalar anchors are name + value editable. In import mode the
+        // panel is read-only (the target document is locked — design fix #8).
+        function renderVariables(hostEl) {
+            if (!hostEl) return;
+            hostEl.innerHTML = '';
+            const varCount = experiment && experiment.variables ? experiment.variables.length : 0;
+            const countBadge = $('varCount');
+            if (countBadge) countBadge.textContent = varCount;
+
+            if (!experiment) {
+                hostEl.appendChild(el('div', { class: 'empty-state' },
+                    'Import a v3 YAML to view its variables (anchors).'));
+                return;
+            }
+
+            const locked = importMode;  // target doc is read-only during import
             const table = el('table', { class: 'vars-table' });
-            const thead = el('thead', {}, el('tr', {},
+            table.appendChild(el('thead', {}, el('tr', {},
                 el('th', {}, 'Anchor'),
                 el('th', {}, 'Value'),
                 el('th', { style: 'width: 1.5em;' }, '')
-            ));
-            table.appendChild(thead);
+            )));
             const tbody = el('tbody');
             for (const v of experiment.variables || []) {
                 const isComplex = variableIsComplex(experiment, v.name);
                 const row = el('tr', { class: 'var-row' });
 
-                // Name cell — always editable (rename cascades)
+                // Name cell — editable (rename cascades), read-only while importing.
                 const nameInput = el('input', {
                     type: 'text',
                     value: v.name,
                     class: 'var-name-input',
-                    title: 'Rename anchor. Renaming cascades to every *alias reference.',
+                    disabled: locked,
+                    title: locked
+                        ? 'Locked during import — finish or cancel the import first.'
+                        : 'Rename anchor. Renaming cascades to every *alias reference.',
                 });
-                // change fires on blur, so each visit to the input produces
-                // at most one pushUndo (inside onVariableRename).
                 nameInput.addEventListener('change', () => onVariableRename(v.name, nameInput.value.trim()));
                 row.appendChild(el('td', {}, nameInput));
 
-                // Value cell — editable scalar OR read-only badge for complex
+                // Value cell — editable scalar OR read-only badge for complex.
                 if (isComplex) {
                     row.appendChild(el('td', {},
                         el('span', {
@@ -1966,62 +1993,68 @@
                         type: isNum ? 'number' : 'text',
                         value: isNum ? String(v.value) : String(v.value ?? ''),
                         class: 'var-value-input ' + (isNum ? 'num' : 'str'),
-                        title: 'Edit the anchor value. Every *alias to this anchor will resolve to the new value.',
+                        disabled: locked,
+                        title: locked
+                            ? 'Locked during import — finish or cancel the import first.'
+                            : 'Edit the anchor value. Every *alias to this anchor will resolve to the new value.',
                     });
                     valInput.addEventListener('change', () => onVariableValueEdit(v.name, valInput.value, isNum));
                     row.appendChild(el('td', {}, valInput));
                 }
 
-                // Delete cell
-                const delBtn = el('button', {
-                    class: 'var-del-btn',
-                    title: 'Delete this anchor. Blocked if it has *alias references; the prompt will offer cascade-unbind.',
-                    onClick: () => onVariableDelete(v.name),
-                }, '✕');
-                row.appendChild(el('td', {}, delBtn));
+                // Delete cell — hidden while importing.
+                if (locked) {
+                    row.appendChild(el('td', {}, ''));
+                } else {
+                    row.appendChild(el('td', {}, el('button', {
+                        class: 'var-del-btn',
+                        title: 'Delete this anchor. Blocked if it has *alias references; the prompt will offer cascade-unbind.',
+                        onClick: () => onVariableDelete(v.name),
+                    }, '✕')));
+                }
 
                 tbody.appendChild(row);
             }
 
-            // + Add variable row (always at end)
-            const addRow = el('tr', { class: 'var-add-row' });
-            const addNameInput = el('input', {
-                type: 'text',
-                placeholder: 'new_anchor_name',
-                class: 'var-name-input',
-                title: 'Anchor name (letters, digits, _, -). Pressing Enter or Tab creates the anchor with the value to the right.',
-            });
-            const addValInput = el('input', {
-                type: 'text',
-                placeholder: 'value',
-                class: 'var-value-input',
-                title: 'Initial value. Numeric strings become numbers; everything else stays a string.',
-            });
-            const addBtn = el('button', {
-                class: 'var-add-btn',
-                title: 'Create the new anchor.',
-                onClick: () => {
-                    const name = addNameInput.value.trim();
-                    const val = addValInput.value;
-                    if (!name) return;
-                    onVariableAdd(name, val);
-                    addNameInput.value = '';
-                    addValInput.value = '';
-                    addNameInput.focus();
-                },
-            }, '+ Add');
-            // Enter in either input submits the add
-            const submitOnEnter = (e) => { if (e.key === 'Enter') { e.preventDefault(); addBtn.click(); } };
-            addNameInput.addEventListener('keydown', submitOnEnter);
-            addValInput.addEventListener('keydown', submitOnEnter);
-            addRow.appendChild(el('td', {}, addNameInput));
-            addRow.appendChild(el('td', {}, addValInput));
-            addRow.appendChild(el('td', {}, addBtn));
-            tbody.appendChild(addRow);
+            // + Add variable row (always at end) — omitted while importing.
+            if (!locked) {
+                const addRow = el('tr', { class: 'var-add-row' });
+                const addNameInput = el('input', {
+                    type: 'text',
+                    placeholder: 'new_anchor_name',
+                    class: 'var-name-input',
+                    title: 'Anchor name (letters, digits, _, -). Pressing Enter or Tab creates the anchor with the value to the right.',
+                });
+                const addValInput = el('input', {
+                    type: 'text',
+                    placeholder: 'value',
+                    class: 'var-value-input',
+                    title: 'Initial value. Numeric strings become numbers; everything else stays a string.',
+                });
+                const addBtn = el('button', {
+                    class: 'var-add-btn',
+                    title: 'Create the new anchor.',
+                    onClick: () => {
+                        const name = addNameInput.value.trim();
+                        const val = addValInput.value;
+                        if (!name) return;
+                        onVariableAdd(name, val);
+                        addNameInput.value = '';
+                        addValInput.value = '';
+                        addNameInput.focus();
+                    },
+                }, '+ Add');
+                const submitOnEnter = (e) => { if (e.key === 'Enter') { e.preventDefault(); addBtn.click(); } };
+                addNameInput.addEventListener('keydown', submitOnEnter);
+                addValInput.addEventListener('keydown', submitOnEnter);
+                addRow.appendChild(el('td', {}, addNameInput));
+                addRow.appendChild(el('td', {}, addValInput));
+                addRow.appendChild(el('td', {}, addBtn));
+                tbody.appendChild(addRow);
+            }
 
             table.appendChild(tbody);
-            varBox.appendChild(table);
-            root.appendChild(varBox);
+            hostEl.appendChild(table);
         }
 
         // ─── Variables editor handlers ─────────────────────────────────────
@@ -2041,7 +2074,7 @@
             if (oldName === newName) return;
             if (!newName) {
                 showError('Rename failed', 'Anchor name cannot be empty.');
-                renderSettings();
+                renderVariables($('variablesPanel'));
                 return;
             }
             if (!isValidAnchorName(newName)) {
@@ -2049,12 +2082,12 @@
                     'Rename failed',
                     'Invalid anchor name: must contain only letters, digits, underscores, and hyphens.'
                 );
-                renderSettings();
+                renderVariables($('variablesPanel'));
                 return;
             }
             if (anchorExists(experiment, newName)) {
                 showError('Rename failed', 'Anchor name "' + newName + '" is already in use.');
-                renderSettings();
+                renderVariables($('variablesPanel'));
                 return;
             }
             const refs = findAliasesTo(experiment, oldName);
@@ -2065,7 +2098,7 @@
                     list: refs.map((r) => '• ' + r.humanLabel),
                     confirmLabel: 'Rename',
                 });
-                if (!proceed) { renderSettings(); return; }
+                if (!proceed) { renderVariables($('variablesPanel')); return; }
             }
             pushUndo();
             try {
@@ -2074,7 +2107,7 @@
                 renderAll();
             } catch (err) {
                 showError('Rename failed', err.message);
-                renderSettings();
+                renderVariables($('variablesPanel'));
             }
         }
 
@@ -2083,7 +2116,7 @@
             const coerced = isNumericInput ? Number(rawValue) : _coerceVarValue(rawValue);
             if (isNumericInput && Number.isNaN(coerced)) {
                 showError('Update failed', 'Value must be a number.');
-                renderSettings();
+                renderVariables($('variablesPanel'));
                 return;
             }
             pushUndo();
@@ -2093,7 +2126,7 @@
                 renderAll();
             } catch (err) {
                 showError('Update failed', err.message);
-                renderSettings();
+                renderVariables($('variablesPanel'));
             }
         }
 
@@ -2708,6 +2741,7 @@
             $('inspectorZoneTitle').textContent = 'Import inspector';
             $('importStagedCount').textContent = staging.items.length;
             renderYoursLockedLibrary();
+            renderVariables($('variablesPanel'));  // read-only while locked
             renderTheirsLibrary();
             renderImportInspector();
         }
@@ -4836,6 +4870,7 @@
         function renderAll() {
             renderSettings();
             renderLibrary();
+            renderVariables($('variablesPanel'));
             renderSequence();
             renderInspector();
             renderTimeline();

--- a/experiment_designer_v3_quickstart.html
+++ b/experiment_designer_v3_quickstart.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>v3 Experiment Designer Quick Start - PanelDisplayTools</title>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #0f1419;
+            --surface: #1a1f26;
+            --border: #2d3640;
+            --text: #e6edf3;
+            --text-dim: #8b949e;
+            --accent: #00e676;
+            --hover: #00c853;
+        }
+
+        body {
+            font-family: 'IBM Plex Mono', monospace;
+            background: var(--bg);
+            color: var(--text);
+            padding: 2rem;
+            line-height: 1.7;
+        }
+
+        .container {
+            max-width: 820px;
+            margin: 0 auto;
+        }
+
+        .nav-link {
+            display: inline-block;
+            color: var(--text-dim);
+            text-decoration: none;
+            margin-bottom: 1.5rem;
+            font-size: 0.85rem;
+            transition: color 0.2s;
+        }
+
+        .nav-link:hover { color: var(--accent); }
+
+        h1 {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.8rem;
+            font-weight: 700;
+            color: var(--accent);
+            margin-bottom: 0.5rem;
+        }
+
+        .subtitle {
+            color: var(--text-dim);
+            font-size: 0.85rem;
+            margin-bottom: 2rem;
+            padding-bottom: 1.5rem;
+            border-bottom: 2px solid var(--border);
+        }
+
+        h2 {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.1rem;
+            font-weight: 700;
+            color: var(--accent);
+            margin-top: 2.5rem;
+            margin-bottom: 1rem;
+        }
+
+        h3 {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.9rem;
+            font-weight: 700;
+            color: var(--text);
+            margin-top: 1.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        p {
+            margin-bottom: 0.75rem;
+            font-size: 0.88rem;
+        }
+
+        .step {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 1rem 1.25rem;
+            margin-bottom: 1rem;
+            position: relative;
+            padding-left: 3.5rem;
+        }
+
+        .step-number {
+            position: absolute;
+            left: 1rem;
+            top: 1rem;
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            font-size: 1rem;
+            color: var(--accent);
+        }
+
+        .step strong {
+            color: var(--accent);
+        }
+
+        .step p {
+            margin-bottom: 0.4rem;
+        }
+
+        .step p:last-child {
+            margin-bottom: 0;
+        }
+
+        code {
+            background: rgba(0, 230, 118, 0.1);
+            color: var(--accent);
+            padding: 0.15rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.82rem;
+        }
+
+        .hint {
+            color: var(--text-dim);
+            font-size: 0.8rem;
+            font-style: italic;
+        }
+
+        .layout-diagram {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 1.25rem;
+            margin: 1.25rem 0;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.72rem;
+            line-height: 1.5;
+            white-space: pre;
+            overflow-x: auto;
+            color: var(--text-dim);
+        }
+
+        .layout-diagram .hl {
+            color: var(--accent);
+        }
+
+        .key-list {
+            list-style: none;
+            margin: 0.5rem 0 1rem;
+        }
+
+        .key-list li {
+            padding: 0.3rem 0;
+            font-size: 0.85rem;
+        }
+
+        .key-list li code {
+            min-width: 100px;
+            display: inline-block;
+        }
+
+        .tip-box {
+            background: rgba(255, 152, 0, 0.08);
+            border: 1px solid rgba(255, 152, 0, 0.3);
+            border-radius: 6px;
+            padding: 0.75rem 1rem;
+            margin: 1rem 0;
+            font-size: 0.82rem;
+            color: #ff9800;
+        }
+
+        .tip-box strong { color: #ffb74d; }
+
+        .example-box {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 1rem 1.25rem;
+            margin: 1rem 0;
+        }
+
+        .example-box h4 {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.8rem;
+            color: var(--text-dim);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 0.75rem;
+        }
+
+        a {
+            color: var(--accent);
+            text-decoration: none;
+        }
+
+        a:hover { color: var(--hover); }
+
+        footer {
+            text-align: center;
+            margin-top: 3rem;
+            padding-top: 2rem;
+            border-top: 2px solid var(--border);
+            color: var(--text-dim);
+            font-size: 0.8rem;
+        }
+
+        footer a { color: var(--accent); text-decoration: none; }
+        footer a:hover { color: var(--hover); }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <a href="experiment_designer_v3.html" class="nav-link">&larr; Back to v3 Experiment Designer</a>
+
+        <h1>v3 Experiment Designer Quick Start</h1>
+        <p class="subtitle">v0.18 | 2026-06-01 09:10 ET — Edit Protocol v3 YAML directly, with anchors and comments preserved on round-trip.</p>
+
+        <p>The v3 Experiment Designer is a <strong>YAML round-trip editor</strong> for Protocol v3.
+        Unlike the v2 designer (which builds a protocol from scratch in a form), v3 loads an existing
+        v3 YAML, lets you edit it through a structured UI, and exports it back — <strong>preserving your
+        anchors, comments, and key order</strong>. The on-disk YAML is the single source of truth.</p>
+
+        <h2>The interface</h2>
+        <p>Three columns over a flattened-timeline preview. The left column is split into a
+        <strong>Library</strong> of conditions and an always-visible <strong>Variables</strong> (anchors) panel.</p>
+
+        <div class="layout-diagram">┌───────────────┬──────────────────────┬─────────────────┐
+│ <span class="hl">LIBRARY</span>       │ <span class="hl">EXPERIMENT SEQUENCE</span>  │ <span class="hl">INSPECTOR</span>       │
+│  conditions   │  ▸ arena check       │  selected       │
+│  (search,     │  ▾ main block        │  condition /    │
+│   + Add)      │      trials, reps    │  block /        │
+├───────────────┤  ▸ posttrial         │  ref details    │
+│ <span class="hl">VARIABLES</span>     │                      │  (edit commands │
+│  &dur_short 3 │                      │   inline)       │
+│  &dur_long 10 │                      │                 │
+│  + Add        │                      │                 │
+├───────────────┴──────────────────────┴─────────────────┤
+│ FLATTENED TIMELINE PREVIEW (every rep × trial expanded) │
+└─────────────────────────────────────────────────────────┘</div>
+
+        <ul class="key-list">
+            <li><code>Library</code> — every condition in the protocol. Click to inspect; drag onto the sequence; <code>+ Add</code> creates one.</li>
+            <li><code>Variables</code> — the <code>variables:</code> anchors. Edit a scalar value or rename an anchor and every <code>*alias</code> updates. Always visible now (no longer hidden in Settings).</li>
+            <li><code>Experiment Sequence</code> — the ordered run: bare <em>refs</em> to conditions and <em>blocks</em> (groups of trials with repetitions / randomize / intertrial).</li>
+            <li><code>Inspector</code> — edits the selected item: a condition's commands, a block's properties, a ref.</li>
+            <li><code>Timeline</code> — a read-only preview of the flattened run order.</li>
+            <li><code>Settings ▾</code> (header) — experiment metadata, the rig path, and the read-only plugins list.</li>
+        </ul>
+
+        <h2>Walkthrough: edit and export a protocol</h2>
+
+        <div class="step">
+            <span class="step-number">1</span>
+            <p><strong>Load a protocol.</strong> Use <code>Import YAML</code> to open your own file, or
+            <code>Load demo ▾</code> to start from a bundled example (e.g. <code>canonical_a</code>).</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">2</span>
+            <p><strong>Inspect a condition.</strong> Click any row in the Library. Its commands appear in the
+            Inspector — <code>controller</code> (trialParams), <code>wait</code>, and <code>plugin</code> commands.
+            Edit fields inline; changes write straight to the YAML model.</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">3</span>
+            <p><strong>Use a Variable (anchor).</strong> In the Variables panel, edit <code>&dur_long</code>'s
+            value — every command that references it via <code>*dur_long</code> resolves to the new value on export.
+            Click <code>+ Add</code> to create a new anchor, or rename one to cascade the change across all references.</p>
+            <p class="hint">Complex anchors (maps / sequences) show a read-only badge — edit those in the YAML directly; renaming still works.</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">4</span>
+            <p><strong>Arrange the sequence.</strong> Drag a Library condition onto the Experiment Sequence to add a
+            ref, use <code>+ Ref</code> / <code>+ Block</code>, reorder by dragging, and edit block repetitions /
+            randomize / intertrial in the Inspector. The Timeline preview updates live.</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">5</span>
+            <p><strong>Export.</strong> <code>Export YAML</code> writes the file back out with your anchors and
+            comments intact. A non-blocking warnings strip flags unused conditions / anchors; a blocking modal
+            catches errors (duplicate names, dangling aliases) before you export.</p>
+        </div>
+
+        <div class="tip-box">
+            <strong>Round-trip safe.</strong> Import → edit → export changes only what you touched. Anchors,
+            inline comments, and key order are preserved, so a diff against the original shows just your edits.
+        </div>
+
+        <h2>Cross-library import (copy conditions between protocols)</h2>
+        <p>Pull conditions out of a <em>second</em> v3 YAML — a sibling lab's protocol, or an older version of
+        your own — into the one you're editing, bringing along the anchors and plugin declarations they depend on.</p>
+
+        <div class="step">
+            <span class="step-number">1</span>
+            <p><strong>Open a source.</strong> With a protocol loaded, click <code>Import from YAML…</code> and pick
+            a second v3 file. The layout swaps: your protocol locks on the left, the source's conditions appear in
+            the middle, and an import inspector opens on the right.</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">2</span>
+            <p><strong>Stage conditions.</strong> Click <code>← Add</code> on a source condition. It joins
+            "Pending additions" — its referenced anchors and plugins come along automatically (transitively).</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">3</span>
+            <p><strong>Adjust names.</strong> Imported anchors and plugins get a <code>prefix__</code> (editable in
+            the banner) so they don't clash with yours; conditions keep their own names. The inspector flags any
+            name collision and suggests a fix. Plugins that match one of yours (same class + config) <em>merge</em>
+            instead of duplicating.</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">4</span>
+            <p><strong>Commit.</strong> <code>Commit import</code> applies the whole batch in one step (one
+            <code>Undo</code> reverts all of it). Imported nodes are stamped <code># imported from &lt;source&gt;</code>.
+            <code>Cancel</code> discards everything and changes nothing.</p>
+        </div>
+
+        <div class="tip-box">
+            <strong>Scope.</strong> Import copies <em>conditions</em> plus their direct dependencies and appends a
+            bare sequence ref so each is runnable. It does not reproduce the source's block membership,
+            repetitions, or intertrial placement — arrange those in your sequence afterward.
+        </div>
+
+        <h2>Key concepts</h2>
+        <ul class="key-list">
+            <li><strong>Condition</strong> — a named list of <code>commands</code> (the unit you reuse). Lives in <code>conditions:</code>.</li>
+            <li><strong>Sequence ref vs. block</strong> — the <code>experiment:</code> list is the run order. A <em>ref</em> is a single condition; a <em>block</em> groups trials with <code>repetitions</code>, <code>randomize</code>, and an optional <code>intertrial</code>.</li>
+            <li><strong>Anchor / alias</strong> — <code>&amp;name value</code> defines a reusable value in <code>variables:</code>; <code>*name</code> references it. Editing the anchor updates every reference.</li>
+            <li><strong>Plugin</strong> — a runtime resource (camera, LED controller) declared in <code>plugins:</code> and called by <code>plugin</code> commands.</li>
+            <li><strong>Controller modes</strong> — Mode 2 (constant rate, <code>frame_rate</code> set, <code>gain</code> 0) vs. Mode 4 (closed-loop, <code>gain</code> set, <code>frame_rate</code> 0).</li>
+        </ul>
+
+        <h2>Keyboard &amp; history</h2>
+        <ul class="key-list">
+            <li><code>Ctrl/Cmd+Z</code> — undo</li>
+            <li><code>Ctrl/Cmd+Y</code> — redo (also <code>Ctrl/Cmd+Shift+Z</code>)</li>
+            <li><code>⟲ Reset</code> — clear to a blank minimum-valid skeleton (reversible with undo)</li>
+        </ul>
+        <p class="hint">Edits are in-memory until you Export — the page warns before close/reload if you have unsaved
+        changes or an import in progress.</p>
+
+        <footer>
+            <p><a href="experiment_designer_v3.html">v3 Experiment Designer</a> | <a href="index.html">PanelDisplayTools</a> | <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">GitHub</a></p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## What this is

Two requested changes to the v3 Experiment Designer, in one round.

### 1. Variables always visible
The `variables:` (anchors) editor was only reachable inside the collapsible
Settings drawer. It's now a **persistent panel** in the left column: the Library
column is split into **Conditions (top) + Variables (bottom)**.

- `renderVariables(host)` extracted from `renderSettings` → renders into the new
  `#variablesPanel`; the drawer keeps Experiment Info / Rig / Plugins only.
- Wired into `renderAll` and the variable handlers' error paths. Left grid column
  widened 280→320px.
- **Import-mode aware:** while a cross-library import is in progress the panel
  renders read-only (inputs disabled, add-row/delete hidden) beside the locked
  library — consistent with the D4 lock.

### 2. v3 polish (handoff §3 Tier 5)
- **Dropped the in-tool "Beta / Editor" badge** (span + CSS). Landing-page chip
  stays "Beta" (per decision).
- **`experiment_designer_v3_quickstart.html`** (new) — modeled on the v2
  quickstart: interface overview, edit→export walkthrough, the **D4 cross-library
  import** flow, key concepts, shortcuts. Linked from a new **Quick Start** header
  button.
- **`docs/development/v3-matlab-validation.md`** (new, Phase 8) — the web→MATLAB
  validation flow: web side CI-green (576 checks), MATLAB side documented as a
  manual MCP-driven gate. Resolves the stale pointer already in the v3 test header.
- handoff-2: Phase 8 + Phase 9 marked shipped. Footer **v0.17 → v0.18**.

## Tests
```
npm test → arena 10/10 · v2 137/137 · v3 576/576   (no js/ or test changes)
```

**Browser-verified:** Variables panel renders under Conditions; edit a scalar →
single-step Undo reverts; Settings drawer no longer lists Variables (Info/Rig/
Plugins only); enter import → panel locks read-only, cancel → editable again; Beta
badge gone with layout intact; quickstart page loads with all sections + working
back link. Zero console errors. Screenshot of the split layout in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
