### PR TITLE
test(v3): add real rig YAML fixtures from maDisplayTools (for #91/#89)

### DIFF
--- a/tests/fixtures/rigs/README.md
+++ b/tests/fixtures/rigs/README.md
@@ -1,0 +1,19 @@
+# Rig YAML fixtures
+
+Verbatim copies of real rig config files from **maDisplayTools** (`main` @ `4592cea`,
+`configs/rigs/`). Not hand-written — do not edit; re-copy from upstream if they drift.
+
+Provided as ready test inputs for the rig-aware plugin work
+([#91](https://github.com/reiserlab/webDisplayTools/issues/91) /
+[#89](https://github.com/reiserlab/webDisplayTools/issues/89)): parsing a rig's
+`plugins:` block to derive the plugins a rig supports.
+
+| File | Why it's here |
+|---|---|
+| `test_rig_1.yaml` | **Richest case** — `backlight` + `camera` *enabled* with full config; `type: "LED Controller"` / `"Bias"`, `port`, `config_path`. The happy path for "derive enabled plugins + their classes." |
+| `example_rig.yaml` | **Schema-variation case** — `backlight` has *no* `type` and uses `com_port` / `ir_power`…; camera `type: "BIAS"` (different casing). Exercises the tolerant rig→`matlab.class` mapping called out in #91. |
+| `test_rig_2.yaml` | **Minimal case** — all plugins `enabled: false`, no config. Exercises the "rig supports nothing enabled" path. |
+
+Canonical rig plugin names are `backlight`, `camera`, `temperature` — these are the
+names an experiment YAML's `plugins:` must use to inherit the rig's config (the crux
+of #89).

--- a/tests/fixtures/rigs/example_rig.yaml
+++ b/tests/fixtures/rigs/example_rig.yaml
@@ -1,0 +1,35 @@
+# Example rig configuration
+# Copy and modify this file for your specific setup
+
+format_version: "1.0"
+name: "Example Rig"
+description: "Example rig configuration - customize for your setup"
+
+# Reference to arena configuration (relative path from this file)
+arena: "../arenas/G41_2x12_cw.yaml"
+
+# Controller settings
+controller:
+  host: "10.102.40.47"    # Replace with your controller IP
+  port: 62222
+
+# Plugin configurations (optional)
+plugins:
+  backlight:
+    enabled: false
+    com_port: "COM3"      # Replace with your COM port
+    ir_power: 50
+    red_power: 0
+    green_power: 0
+    blue_power: 0
+  camera:
+    enabled: false
+    type: "BIAS"
+    ip: "127.0.0.1"
+    port: 5010
+    config_file: 'path/to/json/file'
+    executable_file: 'path/to/BIAS/exe/file'
+  temperature:
+    enabled: false
+    daq_device: "ni"
+    channel: "ai0"

--- a/tests/fixtures/rigs/test_rig_1.yaml
+++ b/tests/fixtures/rigs/test_rig_1.yaml
@@ -1,0 +1,29 @@
+# Test Rig 1
+# MAC: 02:E8:61:68:14:D7
+
+format_version: "1.0"
+name: "Test Rig 1"
+description: "Test rig at 10.102.40.61"
+
+arena: "../arenas/G41_2x12_cw.yaml" # You might replace this with the absolute path.
+
+controller:
+  host: "10.102.40.61"
+  port: 62222
+
+plugins:
+  backlight:
+    enabled: true
+    type: "LED Controller"
+    port: 'COM6'
+    # Does backlight require other config? 
+  camera:
+    enabled: true
+    type: "Bias"
+    ip: "127.0.0.1"
+    port: 5010
+    config_path: 'C:\Users\labadmin\Documents\FlyBowl1Rig\bias_config_default1.json'
+    bias_executable: 'C:\Users\labadmin\Documents\FlyBowl1Rig\BIAS_exe_spinnaker_win64_v0_73_1\v0.73.1\test_gui.exe'
+  temperature:
+    enabled: false
+

--- a/tests/fixtures/rigs/test_rig_2.yaml
+++ b/tests/fixtures/rigs/test_rig_2.yaml
@@ -1,0 +1,20 @@
+# Test Rig 2
+# MAC: 02:E8:61:08:96:d7
+
+format_version: "1.0"
+name: "Test Rig 2"
+description: "Test rig at 10.102.40.174"
+
+arena: "../arenas/G41_2x12_cw.yaml"
+
+controller:
+  host: "10.102.40.174"
+  port: 62222
+
+plugins:
+  backlight:
+    enabled: false
+  camera:
+    enabled: false
+  temperature:
+    enabled: false


### PR DESCRIPTION
Ready test inputs for the rig-aware plugin work ([#91](https://github.com/reiserlab/webDisplayTools/issues/91)) and the imported-plugin-name bug ([#89](https://github.com/reiserlab/webDisplayTools/issues/89)).

Three rig configs copied **verbatim** from `maDisplayTools` (`main` @ `4592cea`, `configs/rigs/`) into `tests/fixtures/rigs/` — not hand-written:

| File | Why |
|---|---|
| `test_rig_1.yaml` | Richest — `backlight` + `camera` *enabled* with full config + `type` strings (happy path). |
| `example_rig.yaml` | Schema variation — no `type`, `com_port`, `"BIAS"` casing (exercises the tolerant rig→class mapping). |
| `test_rig_2.yaml` | Minimal — all plugins disabled ("nothing enabled" path). |

Plus a `README.md` documenting provenance + intent. **Fixtures only** — inert inputs, no suite reads them; `npm test` green (arena 10 · v2 137 · v3 592).

🤖 Generated with [Claude Code](https://claude.com/claude-code)