### PR TITLE
feat(g6): Web Serial control substrate — arena-link + arena-wire-g6 (LAB-88, LAB-89)

### DIFF
--- a/js/arena-link.js
+++ b/js/arena-link.js
@@ -1,0 +1,456 @@
+/**
+ * arena-link.js — Web Serial transport for the G6 Arena controller.
+ *
+ * Talks to the G6 Arena controller (Teensy 4.1) over its USB-CDC serial port.
+ * This module is pure transport: it opens the port, runs a background reader
+ * that de-frames the byte stream into length-prefixed frames, correlates each
+ * response with the request that is waiting for it, and surfaces disconnects.
+ * It has minimal protocol knowledge — only the length-prefix framing (first
+ * byte = number of bytes that follow) and the echo_cmd byte used to correlate
+ * a reply with its request. Build request bytes and decode response payloads
+ * with js/arena-wire-g6.js.
+ *
+ *   const link = new ArenaLink({ onDisconnect: () => {...} });
+ *   await link.requestPort();        // inside a user gesture (click)
+ *   await link.open();               // baudRate defaults to 115200
+ *   const frame = await link.send(ArenaWireG6.encodeGetControllerInfo());
+ *   const info  = ArenaWireG6.decodeControllerInfo(ArenaWireG6.decodeResponse(frame));
+ *
+ * Correlation model — SINGLE-FLIGHT + echo-verified:
+ *   The handoff requires correlating responses by echo_cmd. This protocol has
+ *   no request id and can send the same opcode twice, so echo matching alone
+ *   can't disambiguate two identical in-flight commands. We therefore serialize
+ *   sends (only one outstanding at a time; concurrent send() calls queue) AND
+ *   verify that the response's echo_cmd matches the in-flight request's opcode
+ *   before resolving — a mismatch is surfaced as a desync rather than silently
+ *   resolving the wrong request. On timeout the rx buffer is flushed so a late
+ *   reply can't be mis-matched to the next request. This is a deliberate
+ *   divergence from the reference scripts/web-serial/main.js, which resolves the
+ *   oldest pending await regardless of echo (fine for its one-shot button UI,
+ *   too loose for the shared substrate the runner will build on).
+ *
+ * Gotchas (from the reference README — all still apply):
+ *   - Web Serial is Chromium-only (Chrome / Edge / Opera / Brave / Arc) on a
+ *     desktop OS. Firefox and Safari do NOT implement navigator.serial — gate
+ *     UI on ArenaLink.isSupported().
+ *   - requestPort() must run inside a user gesture (e.g. a click handler).
+ *   - Permissions are per-origin: opening from file:// and from an http origin
+ *     prompts the port chooser separately for each.
+ *   - baudRate is meaningless on USB CDC — the controller honors any value.
+ *     115200 is a conventional placeholder.
+ *   - Only one process can hold the port. Close pio device monitor / dwfpy /
+ *     other terminals before connecting.
+ *   - DEBUG_SERIAL firmware builds interleave diagnostic text on the same pipe;
+ *     a stray byte is treated as a frame length and can stall the parser behind
+ *     a bogus length. The single-flight timeout (which flushes the rx buffer) is
+ *     the resync: the request times out, the buffer clears, the next command
+ *     starts clean. Prefer a non-DEBUG_SERIAL build for interactive use.
+ *
+ * Browser-global + Node CommonJS export, mirroring js/crc.js / js/arena-wire-g6.js.
+ * No ES `export` keyword (a top-level `export` would break plain `<script src=>`
+ * loading). Browser callers load via `<script src="js/arena-link.js">` and read
+ * `window.ArenaLink`. Loading in Node is safe (navigator is only touched inside
+ * methods); isSupported() simply returns false there.
+ */
+
+const ArenaLink = (function () {
+    'use strict';
+
+    const DEFAULT_BAUD_RATE = 115200; // ignored by USB CDC; conventional placeholder
+    const DEFAULT_TIMEOUT_MS = 500; // controller replies in well under 1 ms
+    const HEX_LOG_LIMIT = 32; // truncate longer payloads in the trace log
+
+    const hex = (bytes) =>
+        Array.from(bytes)
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join(' ');
+
+    // Truncate long payloads (e.g. future stream frames) so the log stays readable.
+    const hexDump = (bytes) =>
+        bytes.length > HEX_LOG_LIMIT
+            ? hex(bytes.subarray(0, 16)) + ' … (' + bytes.length + ' bytes)'
+            : hex(bytes);
+
+    class ArenaLink {
+        /**
+         * @param {object} [options]
+         * @param {function():void}        [options.onDisconnect] device unplugged / port lost
+         * @param {function(Error):void}   [options.onError]      background read-loop error
+         * @param {function(string):void}  [options.onLog]        line-oriented trace log
+         */
+        constructor(options) {
+            options = options || {};
+            this._onDisconnect = options.onDisconnect || null;
+            this._onError = options.onError || null;
+            this._onLog = options.onLog || null;
+
+            this._port = null;
+            this._reader = null;
+            this._writer = null;
+            this._readLoopPromise = null;
+            this._connected = false;
+            this._closing = false;
+
+            // Accumulator for incoming bytes — complete [length, ...] frames are
+            // pulled off the front as they arrive.
+            this._rxBuf = new Uint8Array(0);
+            // The single outstanding request, or null. Shape:
+            // { expectedCmd, resolve, reject, timer }. Single-flight: there is
+            // never more than one.
+            this._inflight = null;
+            // Serializes concurrent send() callers into one-at-a-time requests.
+            this._sendQueue = Promise.resolve();
+
+            // Bind so add/removeEventListener share one reference.
+            this._handleSerialDisconnect = this._handleSerialDisconnect.bind(this);
+        }
+
+        /** Feature-detect: Web Serial is Chromium-desktop only. */
+        static isSupported() {
+            return typeof navigator !== 'undefined' && !!navigator.serial;
+        }
+
+        get connected() {
+            return this._connected;
+        }
+
+        get port() {
+            return this._port;
+        }
+
+        _log() {
+            if (this._onLog) this._onLog(Array.prototype.join.call(arguments, ' '));
+        }
+
+        _assertSupported() {
+            if (!ArenaLink.isSupported()) {
+                throw new Error(
+                    'Web Serial API unavailable — use a Chromium-based browser ' +
+                        '(Chrome / Edge / Opera) on desktop.'
+                );
+            }
+        }
+
+        /**
+         * Prompt the OS serial-port chooser and remember the selection. MUST be
+         * called from a user gesture (click). Optional `options` is passed
+         * straight to navigator.serial.requestPort() (e.g. { filters }).
+         */
+        async requestPort(options) {
+            this._assertSupported();
+            this._port = await navigator.serial.requestPort(options || {});
+            return this._port;
+        }
+
+        /**
+         * Open the selected port and start the background reader.
+         * @param {object} [opts]
+         * @param {number} [opts.baudRate=115200]
+         */
+        async open(opts) {
+            this._assertSupported();
+            if (!this._port) {
+                throw new Error('No port selected — call requestPort() first (in a user gesture).');
+            }
+            if (this._connected) return;
+
+            const baudRate = (opts && opts.baudRate) || DEFAULT_BAUD_RATE;
+            await this._port.open({ baudRate });
+
+            try {
+                this._writer = this._port.writable.getWriter();
+                this._reader = this._port.readable.getReader();
+            } catch (err) {
+                // Roll back the open so we don't leak an opened-but-unusable port.
+                this._writer = null;
+                this._reader = null;
+                try {
+                    await this._port.close();
+                } catch (_) {
+                    /* best-effort */
+                }
+                throw err;
+            }
+
+            this._rxBuf = new Uint8Array(0);
+            this._closing = false;
+            this._connected = true;
+
+            // Surface the device being physically unplugged.
+            navigator.serial.addEventListener('disconnect', this._handleSerialDisconnect);
+
+            this._readLoopPromise = this._readLoop();
+            this._log('-- connected');
+        }
+
+        /** Convenience: requestPort() then open(). Must run in a user gesture. */
+        async connect(opts) {
+            opts = opts || {};
+            await this.requestPort(opts.filters ? { filters: opts.filters } : undefined);
+            await this.open(opts);
+            return this._port;
+        }
+
+        /**
+         * Write a request and resolve with the correlated response FRAME
+         * (Uint8Array, including the length byte — pass it straight to
+         * ArenaWireG6.decodeResponse). Concurrent calls are serialized
+         * (single-flight). Rejects on write error, timeout, echo desync, or
+         * disconnect.
+         * @param {Uint8Array|number[]} bytes request frame
+         * @param {object} [opts]
+         * @param {number} [opts.timeoutMs=500]
+         * @returns {Promise<Uint8Array>}
+         */
+        send(bytes, opts) {
+            // Chain onto the queue so only one request is in flight at a time.
+            // `run` fires whether the previous send resolved or rejected.
+            const run = () => this._sendOne(bytes, opts);
+            const result = this._sendQueue.then(run, run);
+            // Keep the queue tail from rejecting so the next send still chains.
+            this._sendQueue = result.then(
+                () => {},
+                () => {}
+            );
+            return result;
+        }
+
+        async _sendOne(bytes, opts) {
+            if (!this._writer) throw new Error('ArenaLink.send: not connected');
+            const timeoutMs = (opts && opts.timeoutMs) || DEFAULT_TIMEOUT_MS;
+            const payload = bytes instanceof Uint8Array ? bytes : Uint8Array.from(bytes);
+            const expectedCmd = payload[1]; // request frame is [length, cmd, ...params]
+
+            // Park the await BEFORE writing so a very fast reply can't arrive
+            // before its promise exists. The executor runs synchronously, so
+            // `_inflight` is set before we write.
+            const respPromise = new Promise((resolve, reject) => {
+                const entry = { expectedCmd, resolve, reject, timer: null };
+                entry.timer = setTimeout(() => {
+                    if (this._inflight !== entry) return;
+                    this._inflight = null;
+                    // Flush partial/late bytes so a tardy reply can't be
+                    // mis-matched to the NEXT request.
+                    this._rxBuf = new Uint8Array(0);
+                    reject(
+                        new Error(
+                            'response timeout after ' +
+                                timeoutMs +
+                                ' ms (cmd 0x' +
+                                (expectedCmd === undefined ? '??' : expectedCmd.toString(16)) +
+                                ')'
+                        )
+                    );
+                }, timeoutMs);
+                this._inflight = entry;
+            });
+
+            this._log('->', hexDump(payload));
+            try {
+                await this._writer.write(payload);
+            } catch (err) {
+                if (this._inflight) {
+                    clearTimeout(this._inflight.timer);
+                    this._inflight = null;
+                }
+                throw err;
+            }
+            return respPromise;
+        }
+
+        /** Close the port and tear down I/O. Safe to call when already closed. */
+        async close() {
+            const wasConnected = this._connected;
+            this._closing = true;
+            this._connected = false;
+            if (ArenaLink.isSupported()) {
+                navigator.serial.removeEventListener('disconnect', this._handleSerialDisconnect);
+            }
+            this._rejectInflight(new Error('port closed'));
+
+            try {
+                if (this._reader) {
+                    await this._reader.cancel();
+                    try {
+                        this._reader.releaseLock();
+                    } catch (_) {
+                        /* already released */
+                    }
+                }
+            } catch (_) {
+                /* best-effort */
+            }
+            this._reader = null;
+
+            try {
+                if (this._writer) this._writer.releaseLock();
+            } catch (_) {
+                /* best-effort */
+            }
+            this._writer = null;
+
+            try {
+                if (this._readLoopPromise) await this._readLoopPromise;
+            } catch (_) {
+                /* read loop ended */
+            }
+            this._readLoopPromise = null;
+
+            try {
+                if (this._port) await this._port.close();
+            } catch (_) {
+                /* best-effort */
+            }
+            this._port = null;
+            this._closing = false;
+            if (wasConnected) this._log('-- disconnected');
+        }
+
+        // ───────────────────────── internals ─────────────────────────
+
+        // Append a chunk and pull every complete [length, ...] frame off the
+        // front. With single-flight, a complete frame belongs to the one
+        // outstanding request — but only if its echo_cmd matches. Same framing as
+        // the firmware's SerialManager / NetworkManager: first byte = count of
+        // bytes that follow.
+        _consumeIncoming(chunk) {
+            const merged = new Uint8Array(this._rxBuf.length + chunk.length);
+            merged.set(this._rxBuf, 0);
+            merged.set(chunk, this._rxBuf.length);
+            this._rxBuf = merged;
+
+            while (this._rxBuf.length >= 1) {
+                const claimedLen = this._rxBuf[0];
+                const totalNeeded = 1 + claimedLen;
+                if (this._rxBuf.length < totalNeeded) break;
+
+                // Independent copy so the resolved frame doesn't alias rxBuf.
+                const frame = this._rxBuf.slice(0, totalNeeded);
+                this._rxBuf = this._rxBuf.slice(totalNeeded);
+
+                // A real response is [len>=2, status, echo_cmd, ...]. Anything
+                // shorter is a stray/runt byte (e.g. DEBUG noise) — ignore it.
+                if (claimedLen < 2) {
+                    this._log('  !! ignoring runt frame', hexDump(frame));
+                    continue;
+                }
+
+                this._log('  <-', hexDump(frame));
+
+                const entry = this._inflight;
+                if (!entry) {
+                    // No request is waiting — late/unsolicited frame.
+                    this._log('  !! unsolicited frame, dropped');
+                    continue;
+                }
+
+                const echoCmd = frame[2];
+                if (echoCmd !== entry.expectedCmd) {
+                    // Response opcode doesn't match the in-flight request: a
+                    // host/firmware desync. Surface it rather than hide it.
+                    clearTimeout(entry.timer);
+                    this._inflight = null;
+                    entry.reject(
+                        new Error(
+                            'response echo 0x' +
+                                echoCmd.toString(16) +
+                                ' does not match in-flight request 0x' +
+                                (entry.expectedCmd === undefined
+                                    ? '??'
+                                    : entry.expectedCmd.toString(16)) +
+                                ' (desync)'
+                        )
+                    );
+                    continue;
+                }
+
+                clearTimeout(entry.timer);
+                this._inflight = null;
+                entry.resolve(frame);
+            }
+        }
+
+        async _readLoop() {
+            try {
+                while (this._port && this._port.readable && this._reader) {
+                    const { value, done } = await this._reader.read();
+                    if (done) break;
+                    if (value && value.length) this._consumeIncoming(value);
+                }
+            } catch (err) {
+                if (this._closing) return; // intentional teardown via close()
+                if (err && err.name !== 'AbortError') {
+                    this._failConnection(err, true);
+                }
+            }
+        }
+
+        _rejectInflight(err) {
+            if (this._inflight) {
+                clearTimeout(this._inflight.timer);
+                const entry = this._inflight;
+                this._inflight = null;
+                entry.reject(err);
+            }
+        }
+
+        // Shared failure path for read-loop errors and device disconnects.
+        // Idempotent: once disconnected (or after an explicit close()), it's a
+        // no-op. Does NOT close the port (the caller may still want to), just
+        // drops I/O state and notifies.
+        _failConnection(err, reportError) {
+            if (!this._connected) return;
+            this._connected = false;
+            this._rejectInflight(err);
+
+            if (ArenaLink.isSupported()) {
+                navigator.serial.removeEventListener('disconnect', this._handleSerialDisconnect);
+            }
+            try {
+                if (this._reader) this._reader.releaseLock();
+            } catch (_) {
+                /* best-effort */
+            }
+            this._reader = null;
+            try {
+                if (this._writer) this._writer.releaseLock();
+            } catch (_) {
+                /* best-effort */
+            }
+            this._writer = null;
+            this._rxBuf = new Uint8Array(0);
+            this._readLoopPromise = null;
+
+            this._log('-- connection lost:', (err && err.message) || err);
+            if (reportError && this._onError) this._onError(err);
+            if (this._onDisconnect) this._onDisconnect();
+        }
+
+        // navigator.serial 'disconnect' — the device was unplugged.
+        _handleSerialDisconnect(event) {
+            // Fail-safe: only ignore the event if we can POSITIVELY identify a
+            // DIFFERENT port. Some Chromium versions deliver the event at
+            // navigator.serial (target is the Serial object, not the SerialPort);
+            // if we can't tell, fall through to cleanup rather than no-op.
+            const target = event && event.target;
+            const isPort = typeof SerialPort !== 'undefined' && target instanceof SerialPort;
+            if (this._port && isPort && target !== this._port) {
+                return; // a different port disconnected
+            }
+            this._failConnection(new Error('port disconnected'), false);
+        }
+    }
+
+    return ArenaLink;
+})();
+
+// Export for Node.js (CommonJS) — used by tests/test-arena-link.js.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = ArenaLink;
+}
+
+// Export for browser (global) — used by <script src=> callers (the G6 web
+// console, LAB-93) which read window.ArenaLink.
+if (typeof window !== 'undefined') {
+    window.ArenaLink = ArenaLink;
+}

--- a/js/arena-wire-g6.js
+++ b/js/arena-wire-g6.js
@@ -1,0 +1,337 @@
+/**
+ * arena-wire-g6.js — G6 Arena controller wire protocol (encoders + decoder).
+ *
+ * Pure bytes-in / bytes-out: every encoder returns a Uint8Array request frame,
+ * `decodeResponse` parses a response frame, and the field decoders pull typed
+ * values out of a decoded response. There is NO I/O here — that lives in
+ * js/arena-link.js (the Web Serial transport). Keeping this module pure makes
+ * it trivially Node-testable (see tests/test-arena-wire-g6.js).
+ *
+ * This is a PORT of an already-proven protocol, not a new design. The wire
+ * format and opcodes are lifted from, and cross-checked against, the firmware
+ * (LED-Display_G6_Firmware_Arena: src/commands.h, src/CommandProcessor.cpp,
+ * src/SerialManager.cpp) and the reference host encoders (scripts/web-serial/
+ * main.js, scripts/play_pattern.py, scripts/all_on.py, scripts/controller_info.py).
+ * The firmware wins any disagreement.
+ *
+ * Wire format (identical on the USB-CDC serial path and the legacy TCP path):
+ *   Request  frame: [length, cmd, params...]   length = #bytes AFTER it.
+ *   Response frame: [length, status, echo_cmd, ...payload]   length = #bytes
+ *                   after it (status + echo + payload). status == 0 means OK;
+ *                   payload is ASCII for most commands, raw bytes for GET_*.
+ *
+ * So: all-off = `01 00`, all-on = `01 FF`, stop = `01 30`.
+ *
+ * Browser-global + Node CommonJS export, mirroring js/crc.js / js/g6-encoding.js.
+ * No ES `export` keyword on purpose — a top-level `export` would make the file
+ * module-only and break plain `<script src=>` loading. Browser callers load via
+ * `<script src="js/arena-wire-g6.js">` and read `window.ArenaWireG6`; Node
+ * callers use `require('./arena-wire-g6.js')`.
+ */
+
+const ArenaWireG6 = (function () {
+    'use strict';
+
+    // G4-compatible host command opcodes (src/commands.h). Not every opcode is
+    // encoded here — this is the Milestone-A substrate set. Stream-frame (0x32,
+    // Mode 5) pixel assembly is deliberately out of scope (it belongs with the
+    // runner, not this transport substrate).
+    const OPCODES = {
+        ALL_OFF: 0x00,
+        TRIAL_PARAMS: 0x08, // selects mode + pattern (Modes 2/3/4)
+        SET_REFRESH_RATE: 0x16,
+        SET_SPI_CLOCK: 0x17, // uint16 LE MHz (1..30); echoes applied MHz
+        GET_SPI_CLOCK: 0x18, // returns uint16 LE current MHz
+        GET_FRAMES_SENT: 0x19, // returns uint32 LE frames pushed to panels
+        RESET_FRAMES_SENT: 0x1a, // zeroes the frames-sent counter
+        STOP_DISPLAY: 0x30,
+        GET_ETHERNET_IP: 0x66,
+        GET_CONTROLLER_INFO: 0x67, // returns {version, capability_bitmap}
+        SET_FRAME_POSITION: 0x70, // Mode 3: host-commanded frame index
+        ALL_ON: 0xff
+    };
+
+    // Display modes (trial-params `mode` byte). 5 = stream is set via a
+    // different command and is not encodable here.
+    const MODES = {
+        OPEN_LOOP: 2, // host-free frame advance at frame_rate
+        SHOW_FRAME: 3, // host sets the frame via SET_FRAME_POSITION
+        CLOSED_LOOP: 4 // analog-in × gain, computed on the controller
+    };
+
+    // Capability bitmap bits in the get-controller-info (0x67) reply
+    // (controller_info.py / main.js, g6_03-controller.md § 5).
+    const CAPABILITY_BITS = [
+        [0, 'g6_mode'],
+        [1, 'v2_local_storage'],
+        [2, 'mode_1_tsi'],
+        [3, 'v3_triggered'],
+        [4, 'v3_gated']
+    ];
+
+    // ───────────────────────── validation helpers ─────────────────────────
+
+    function requireInt(value, name) {
+        if (typeof value !== 'number' || !Number.isInteger(value)) {
+            throw new TypeError(name + ' must be an integer, got ' + value);
+        }
+        return value;
+    }
+
+    // Validate a uint8 and return it.
+    function u8(value, name) {
+        requireInt(value, name);
+        if (value < 0 || value > 0xff) {
+            throw new RangeError(name + ' must be 0..255, got ' + value);
+        }
+        return value;
+    }
+
+    // Validate a uint16 and return it as [lo, hi] little-endian.
+    function u16le(value, name) {
+        requireInt(value, name);
+        if (value < 0 || value > 0xffff) {
+            throw new RangeError(name + ' must be 0..65535, got ' + value);
+        }
+        return [value & 0xff, (value >> 8) & 0xff];
+    }
+
+    // Validate a signed int8 and return the unsigned wire byte (two's
+    // complement). e.g. gain -50 -> 0xCE. This is the easy-to-get-wrong case
+    // the golden tests pin.
+    function int8Byte(value, name) {
+        requireInt(value, name);
+        if (value < -128 || value > 127) {
+            throw new RangeError(name + ' must be -128..127 (int8), got ' + value);
+        }
+        return value & 0xff;
+    }
+
+    // Validate a trial-params display mode. The firmware only accepts 2/3/4 and
+    // rejects anything else with a controller-side error glyph, so we fail fast
+    // here rather than emit a known-bad frame.
+    function requireMode(value) {
+        requireInt(value, 'mode');
+        if (
+            value !== MODES.OPEN_LOOP &&
+            value !== MODES.SHOW_FRAME &&
+            value !== MODES.CLOSED_LOOP
+        ) {
+            throw new RangeError(
+                'mode must be 2 (open-loop), 3 (show-frame), or 4 (closed-loop), got ' + value
+            );
+        }
+        return value;
+    }
+
+    // Frame a command: [length, cmd, ...params] with length = #bytes after it.
+    function frame(cmd, params) {
+        params = params || [];
+        return Uint8Array.from([params.length + 1, cmd, ...params]);
+    }
+
+    // ───────────────────────────── encoders ───────────────────────────────
+    // Each returns a Uint8Array request frame ready to write to the transport.
+
+    function encodeAllOn() {
+        return frame(OPCODES.ALL_ON); // 01 FF
+    }
+
+    function encodeAllOff() {
+        return frame(OPCODES.ALL_OFF); // 01 00
+    }
+
+    function encodeStop() {
+        return frame(OPCODES.STOP_DISPLAY); // 01 30
+    }
+
+    /**
+     * trial-params (0x08) — select display mode + pattern + timing.
+     * Emits the documented 13-byte combined command:
+     *   [0C 08 mode pat(LE16) rate(LE16) gain init(LE16) 00 00 00]
+     * The length byte 0x0C = 12 = cmd + 11 param bytes. The 3 trailing reserved
+     * bytes pad the combined-command length; the firmware reads only the first
+     * 8 param bytes.
+     *
+     * @param {object} p
+     * @param {number} [p.mode=2]       display mode (2 open / 3 show-frame / 4 closed)
+     * @param {number} [p.patternId=1]  1-based pattern id (Nth .pat in /patterns)
+     * @param {number} [p.frameRate=0]  frame-advance rate in Hz (Mode 2)
+     * @param {number} [p.gain=0]       signed int8 velocity gain (×10 fps/V in Mode 4)
+     * @param {number} [p.initPos=0]    initial frame index (0-based)
+     */
+    function encodeTrialParams(p) {
+        p = p || {};
+        const mode = requireMode(p.mode === undefined ? MODES.OPEN_LOOP : p.mode);
+        const patternId = p.patternId === undefined ? 1 : p.patternId;
+        requireInt(patternId, 'patternId');
+        if (patternId < 1) {
+            throw new RangeError('patternId must be >= 1 (1-based), got ' + patternId);
+        }
+        const pat = u16le(patternId, 'patternId');
+        const rate = u16le(p.frameRate === undefined ? 0 : p.frameRate, 'frameRate');
+        const gain = int8Byte(p.gain === undefined ? 0 : p.gain, 'gain');
+        const init = u16le(p.initPos === undefined ? 0 : p.initPos, 'initPos');
+        // mode, pat(2), rate(2), gain, init(2), reserved(3) = 11 param bytes.
+        const params = [mode, ...pat, ...rate, gain, ...init, 0, 0, 0];
+        return frame(OPCODES.TRIAL_PARAMS, params); // 0C 08 ...
+    }
+
+    // set-frame-position (0x70) — Mode 3 host-commanded frame index (u16 LE).
+    function encodeSetFramePosition(index) {
+        return frame(OPCODES.SET_FRAME_POSITION, u16le(index, 'index')); // 03 70 lo hi
+    }
+
+    // set-refresh-rate (0x16) — host override of the panel re-transmit rate (Hz, u16 LE).
+    function encodeSetRefreshRate(hz) {
+        return frame(OPCODES.SET_REFRESH_RATE, u16le(hz, 'hz')); // 03 16 lo hi
+    }
+
+    // set-spi-clock (0x17) — panel SPI master clock in whole MHz (u16 LE); echoes
+    // applied MHz. The firmware clamps to 1..30 MHz, so reject out-of-range here.
+    function encodeSetSpiClock(mhz) {
+        requireInt(mhz, 'mhz');
+        if (mhz < 1 || mhz > 30) {
+            throw new RangeError('mhz must be 1..30, got ' + mhz);
+        }
+        return frame(OPCODES.SET_SPI_CLOCK, u16le(mhz, 'mhz')); // 03 17 lo hi
+    }
+
+    function encodeGetSpiClock() {
+        return frame(OPCODES.GET_SPI_CLOCK); // 01 18
+    }
+
+    function encodeGetFramesSent() {
+        return frame(OPCODES.GET_FRAMES_SENT); // 01 19
+    }
+
+    function encodeResetFramesSent() {
+        return frame(OPCODES.RESET_FRAMES_SENT); // 01 1A
+    }
+
+    function encodeGetIp() {
+        return frame(OPCODES.GET_ETHERNET_IP); // 01 66
+    }
+
+    function encodeGetControllerInfo() {
+        return frame(OPCODES.GET_CONTROLLER_INFO); // 01 67
+    }
+
+    // ───────────────────────────── decoders ───────────────────────────────
+
+    /**
+     * Parse a complete response frame [length, status, echo_cmd, ...payload].
+     * `length` counts the bytes after itself. Returns a structured object, or
+     * null for an absent / incomplete / too-short-to-be-a-response frame.
+     *
+     * @param {Uint8Array|number[]} bytes a full response frame (incl. length byte)
+     * @returns {{length:number,status:number,echoCmd:number,payload:Uint8Array,ok:boolean}|null}
+     */
+    function decodeResponse(bytes) {
+        if (!bytes || bytes.length === 0) return null;
+        // Normalize to Uint8Array so a plain number[] works too (TypedArray.slice
+        // throws on a non-typed-array receiver — see tests).
+        const buf = bytes instanceof Uint8Array ? bytes : Uint8Array.from(bytes);
+        const length = buf[0];
+        // A response carries at least status + echo_cmd, so length >= 2.
+        if (length < 2) return null;
+        // Need every byte the length claims; otherwise the frame is incomplete.
+        if (buf.length < 1 + length) return null;
+        const status = buf[1];
+        const echoCmd = buf[2];
+        // payload = the bytes after echo_cmd, bounded by the claimed length.
+        const payload = buf.slice(3, 1 + length);
+        return { length, status, echoCmd, payload, ok: status === 0 };
+    }
+
+    // Coerce either a decoded response object or a raw frame into a decoded
+    // object, so the field decoders accept whichever the caller has on hand.
+    function asResponse(resp) {
+        if (!resp) return null;
+        if (resp.payload !== undefined && resp.status !== undefined) return resp;
+        return decodeResponse(resp); // assume a raw frame
+    }
+
+    /**
+     * get-controller-info (0x67) reply -> {version, capability, capabilities[]}.
+     * Payload is {version_byte, capability_bitmap}.
+     */
+    function decodeControllerInfo(resp) {
+        const r = asResponse(resp);
+        if (!r || !r.ok || r.payload.length < 2) return null;
+        const version = r.payload[0];
+        const capability = r.payload[1];
+        const capabilities = CAPABILITY_BITS.filter(([bit]) => capability & (1 << bit)).map(
+            ([, name]) => name
+        );
+        return { version, capability, capabilities };
+    }
+
+    // set/get-spi-clock (0x17/0x18) reply carries the clock as uint16 LE MHz.
+    function decodeSpiClock(resp) {
+        const r = asResponse(resp);
+        if (!r || !r.ok || r.payload.length < 2) return null;
+        return r.payload[0] | (r.payload[1] << 8);
+    }
+
+    // get-frames-sent (0x19) reply carries the master-sent count as uint32 LE.
+    function decodeFramesSent(resp) {
+        const r = asResponse(resp);
+        if (!r || !r.ok || r.payload.length < 4) return null;
+        const m = r.payload;
+        return (m[0] | (m[1] << 8) | (m[2] << 16) | (m[3] << 24)) >>> 0;
+    }
+
+    // get-ip (0x66) reply carries the dotted-quad address as ASCII bytes.
+    function decodeIp(resp) {
+        const r = asResponse(resp);
+        if (!r || !r.ok || r.payload.length === 0) return null;
+        let s = '';
+        for (let i = 0; i < r.payload.length; i++) {
+            const b = r.payload[i];
+            if (b >= 0x20 && b < 0x7f) s += String.fromCharCode(b);
+        }
+        return s;
+    }
+
+    return {
+        // Constants
+        OPCODES,
+        MODES,
+        CAPABILITY_BITS,
+
+        // Encoders (request frames)
+        encodeAllOn,
+        encodeAllOff,
+        encodeStop,
+        encodeTrialParams,
+        encodeSetFramePosition,
+        encodeSetRefreshRate,
+        encodeSetSpiClock,
+        encodeGetSpiClock,
+        encodeGetFramesSent,
+        encodeResetFramesSent,
+        encodeGetIp,
+        encodeGetControllerInfo,
+        // Alias under the name the handoff lists for the get-info request.
+        getControllerInfo: encodeGetControllerInfo,
+
+        // Decoders
+        decodeResponse,
+        decodeControllerInfo,
+        decodeSpiClock,
+        decodeFramesSent,
+        decodeIp
+    };
+})();
+
+// Export for Node.js (CommonJS) — used by tests/test-arena-wire-g6.js.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = ArenaWireG6;
+}
+
+// Export for browser (global) — used by <script src=> callers (the G6 web
+// console, LAB-93) which read window.ArenaWireG6.
+if (typeof window !== 'undefined') {
+    window.ArenaWireG6 = ArenaWireG6;
+}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
     "version": "1.0.1",
     "description": "Web-based tools for configuring and editing display patterns for modular arena systems",
     "scripts": {
-        "test": "node tests/validate-arena-calculations.js && node tests/test-protocol-roundtrip.js && node tests/test-protocol-roundtrip-v3.js",
+        "test": "node tests/validate-arena-calculations.js && node tests/test-protocol-roundtrip.js && node tests/test-protocol-roundtrip-v3.js && node tests/test-arena-wire-g6.js && node tests/test-arena-link.js",
         "test:arena": "node tests/validate-arena-calculations.js",
         "test:protocol-v2": "node tests/test-protocol-roundtrip.js",
         "test:protocol-v3": "node tests/test-protocol-roundtrip-v3.js",
+        "test:wire": "node tests/test-arena-wire-g6.js",
+        "test:link": "node tests/test-arena-link.js",
         "validate": "node tests/validate-arena-calculations.js",
         "format": "prettier --write \"**/*.js\"",
         "format:check": "prettier --check \"**/*.js\""

--- a/serial_raw_monitor.html
+++ b/serial_raw_monitor.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>raw serial monitor — wire truth</title>
+        <!--
+          THROWAWAY diagnostic. Opens the controller's serial port directly
+          (no framing, no arena-link) and dumps EVERY inbound byte as hex+ascii,
+          so we can see exactly what's on the wire — e.g. DEBUG_SERIAL text
+          interleaved with the binary protocol. It also scans the stream for a
+          get-controller-info reply (`?? 00 67 <ver> <cap>`) and flags it, so we
+          can confirm the arena IS replying correctly even when debug text breaks
+          the framing. Chrome/Edge only.
+        -->
+        <style>
+            :root {
+                --bg: #0f1419;
+                --surface: #1a1f26;
+                --border: #2d3640;
+                --text: #e6edf3;
+                --dim: #8b949e;
+                --accent: #00e676;
+                --rx: #58a6ff;
+                --err: #ff6b6b;
+                --hit: #ffd166;
+            }
+            * { box-sizing: border-box; }
+            body {
+                margin: 0; background: var(--bg); color: var(--text);
+                font-family: 'IBM Plex Mono', ui-monospace, Menlo, Consolas, monospace;
+                font-size: 13px; line-height: 1.5;
+            }
+            header { padding: 14px 18px; border-bottom: 1px solid var(--border); }
+            h1 { font-size: 15px; margin: 0 0 2px; color: var(--accent); }
+            .sub { color: var(--dim); font-size: 12px; }
+            #banner { background: #3a1d1d; color: var(--err); padding: 10px 18px; border-bottom: 1px solid var(--border); }
+            .bar { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; padding: 12px 18px; }
+            button {
+                background: var(--surface); color: var(--text); border: 1px solid var(--border);
+                border-radius: 5px; padding: 7px 11px; font-family: inherit; font-size: 12px; cursor: pointer;
+            }
+            button:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+            button:disabled { opacity: 0.4; cursor: not-allowed; }
+            button.primary { background: var(--accent); color: #04140a; border-color: var(--accent); font-weight: 600; }
+            input {
+                background: var(--bg); color: var(--text); border: 1px solid var(--border);
+                border-radius: 4px; padding: 6px 8px; font-family: inherit; font-size: 12px; width: 220px;
+            }
+            label { color: var(--dim); }
+            #status { font-weight: 600; color: var(--err); }
+            #status.on { color: var(--accent); }
+            #log {
+                background: #0a0e12; border: 1px solid var(--border); border-radius: 6px;
+                margin: 0 18px 18px; padding: 10px; height: 420px; overflow-y: auto;
+                white-space: pre-wrap; word-break: break-word; font-size: 12px;
+            }
+            .l-tx { color: var(--accent); }
+            .l-rx { color: var(--rx); }
+            .l-hit { color: var(--hit); font-weight: 600; }
+            .l-err { color: var(--err); }
+            .l-dim { color: var(--dim); }
+        </style>
+    </head>
+    <body>
+        <header>
+            <h1>raw serial monitor</h1>
+            <div class="sub">
+                Dumps every inbound byte as hex + ASCII (no framing). Use it to see DEBUG_SERIAL
+                text on the wire and confirm the controller still replies to commands underneath it.
+            </div>
+        </header>
+
+        <div id="banner" hidden>
+            ⚠ Web Serial unavailable — use Chrome / Edge (desktop).
+        </div>
+
+        <div class="bar">
+            <button id="connect" class="primary" title="Open the controller's serial port (115200)">Connect</button>
+            <button id="disconnect" disabled title="Close the port">Disconnect</button>
+            <span>Status: <span id="status">disconnected</span></span>
+        </div>
+        <div class="bar">
+            <label>send hex</label>
+            <input id="hex" value="01 67" title="Bytes to send (whitespace/0x ignored). 01 67 = get-controller-info" />
+            <button id="send" disabled title="Write these bytes to the port">Send</button>
+            <button id="clear" title="Clear the log">Clear</button>
+            <label style="margin-left:auto"><input type="checkbox" id="autoscan" checked style="width:auto" /> flag <code>?? 00 67</code> replies</label>
+        </div>
+
+        <div id="log"></div>
+
+        <script>
+            'use strict';
+            const $ = (id) => document.getElementById(id);
+            const logEl = $('log');
+            const hex = (b) => Array.from(b).map((x) => x.toString(16).padStart(2, '0')).join(' ');
+            const ascii = (b) =>
+                Array.from(b).map((x) => (x >= 0x20 && x < 0x7f ? String.fromCharCode(x) : '·')).join('');
+
+            function log(text, cls) {
+                const d = document.createElement('div');
+                d.className = 'l-' + (cls || 'dim');
+                d.textContent = `[${new Date().toLocaleTimeString()}] ${text}`;
+                logEl.appendChild(d);
+                logEl.scrollTop = logEl.scrollHeight;
+            }
+
+            let port = null, reader = null, writer = null, readLoop = null;
+            // Rolling buffer of recent RX bytes, scanned for a controller-info reply.
+            let scan = [];
+
+            if (!('serial' in navigator)) {
+                $('banner').hidden = false;
+                $('connect').disabled = true;
+            }
+
+            function setConnected(on) {
+                $('connect').disabled = on;
+                $('disconnect').disabled = !on;
+                $('send').disabled = !on;
+                const s = $('status');
+                s.textContent = on ? 'connected' : 'disconnected';
+                s.classList.toggle('on', on);
+            }
+
+            // Scan the rolling buffer for `?? 00 67 ver cap` (a get-controller-info
+            // reply) and flag it — proves the arena answered even if debug text
+            // broke the framing.
+            function scanForReply(chunk) {
+                if (!$('autoscan').checked) return;
+                for (const b of chunk) scan.push(b);
+                if (scan.length > 512) scan = scan.slice(scan.length - 512);
+                for (let i = 0; i + 4 < scan.length; i++) {
+                    if (scan[i] === 0x00 && scan[i + 1] === 0x67) {
+                        const len = scan[i - 1], ver = scan[i + 2], cap = scan[i + 3];
+                        log(
+                            `✓ controller-info reply found in stream: len=0x${(len ?? 0)
+                                .toString(16)} status=00 echo=0x67 → version ${ver}, cap 0x${cap
+                                .toString(16).padStart(2, '0')}`,
+                            'hit'
+                        );
+                        scan = scan.slice(i + 4); // consume past it
+                        return;
+                    }
+                }
+            }
+
+            async function pump() {
+                try {
+                    while (port && port.readable && reader) {
+                        const { value, done } = await reader.read();
+                        if (done) break;
+                        if (value && value.length) {
+                            log(`<- ${hex(value)}`, 'rx');
+                            log(`   "${ascii(value)}"`, 'dim');
+                            scanForReply(value);
+                        }
+                    }
+                } catch (e) {
+                    if (e.name !== 'AbortError') log('read error: ' + (e.message || e), 'err');
+                }
+            }
+
+            $('connect').onclick = async () => {
+                try {
+                    port = await navigator.serial.requestPort();
+                    await port.open({ baudRate: 115200 });
+                    writer = port.writable.getWriter();
+                    reader = port.readable.getReader();
+                    scan = [];
+                    setConnected(true);
+                    log('-- connected; watching the raw stream', 'dim');
+                    readLoop = pump();
+                } catch (e) {
+                    log('connect: ' + (e.message || e), 'err');
+                    port = null;
+                }
+            };
+
+            $('disconnect').onclick = async () => {
+                setConnected(false);
+                try { if (reader) { await reader.cancel(); reader.releaseLock(); } } catch (_) {}
+                reader = null;
+                try { if (writer) writer.releaseLock(); } catch (_) {}
+                writer = null;
+                try { if (readLoop) await readLoop; } catch (_) {}
+                try { if (port) await port.close(); } catch (_) {}
+                port = null;
+                log('-- disconnected', 'dim');
+            };
+
+            $('send').onclick = async () => {
+                const raw = $('hex').value.replace(/0x/gi, '').replace(/[^0-9a-fA-F]/g, '');
+                if (!raw || raw.length % 2) { log('hex must be whole bytes', 'err'); return; }
+                const bytes = [];
+                for (let i = 0; i < raw.length; i += 2) bytes.push(parseInt(raw.slice(i, i + 2), 16));
+                try {
+                    await writer.write(Uint8Array.from(bytes));
+                    log(`-> ${hex(bytes)}`, 'tx');
+                } catch (e) {
+                    log('write error: ' + (e.message || e), 'err');
+                }
+            };
+
+            $('clear').onclick = () => (logEl.textContent = '');
+            log('ready. Connect, then Send (default 01 67 = get-controller-info).', 'dim');
+        </script>
+    </body>
+</html>

--- a/tests/test-arena-link.js
+++ b/tests/test-arena-link.js
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+/**
+ * Hardware-free tests for js/arena-link.js (the Web Serial transport).
+ *
+ * Run: node tests/test-arena-link.js
+ *
+ * A real arena needs manual verification, but the risky logic — stream
+ * de-framing across chunk boundaries, single-flight + echo-verified
+ * correlation, timeout cleanup + rx flush, read-error/disconnect teardown, and
+ * partial-open rollback — is all exercised here with a fake reader/writer/port
+ * and an injected `navigator.serial`. No browser, no hardware.
+ *
+ * Exits 0 on PASS, 1 on any FAIL. Wired into `npm test` for CI.
+ */
+
+'use strict';
+
+const ArenaLink = require('../js/arena-link.js');
+const Wire = require('../js/arena-wire-g6.js');
+
+let totalChecks = 0;
+let failures = 0;
+
+const hex = (bytes) =>
+    Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join(' ');
+
+function checkBool(name, ok, info) {
+    totalChecks++;
+    console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${info ? ' — ' + info : ''}`);
+    if (!ok) failures++;
+}
+
+function checkBytes(name, got, expectedHex) {
+    totalChecks++;
+    const gotHex = hex(got);
+    const ok = gotHex === expectedHex;
+    console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}: got [${gotHex}], expected [${expectedHex}]`);
+    if (!ok) failures++;
+}
+
+// Assert a promise rejects, optionally matching the message.
+async function checkRejects(name, promise, matcher) {
+    totalChecks++;
+    let rejected = false;
+    let msg = '';
+    try {
+        await promise;
+    } catch (e) {
+        rejected = true;
+        msg = (e && e.message) || String(e);
+    }
+    const ok = rejected && (!matcher || matcher.test(msg));
+    console.log(
+        `  ${ok ? 'PASS' : 'FAIL'}  ${name}${rejected ? ' — ' + msg : ' (did NOT reject)'}`
+    );
+    if (!ok) failures++;
+}
+
+const flush = (ms = 5) => new Promise((r) => setTimeout(r, ms));
+
+// ───────────────────────── fakes ─────────────────────────
+
+class FakeReader {
+    constructor() {
+        this.waiters = [];
+        this.queue = [];
+        this.canceled = false;
+        this.error = null;
+    }
+    read() {
+        if (this.error) return Promise.reject(this.error);
+        if (this.queue.length) return Promise.resolve(this.queue.shift());
+        if (this.canceled) return Promise.resolve({ value: undefined, done: true });
+        return new Promise((resolve, reject) => this.waiters.push({ resolve, reject }));
+    }
+    // Test driver: deliver an incoming chunk to the read loop.
+    push(chunk) {
+        const item = { value: Uint8Array.from(chunk), done: false };
+        if (this.waiters.length) this.waiters.shift().resolve(item);
+        else this.queue.push(item);
+    }
+    // Test driver: make the in-flight read() reject (simulate I/O failure).
+    fail(err) {
+        this.error = err;
+        const ws = this.waiters;
+        this.waiters = [];
+        ws.forEach((w) => w.reject(err));
+    }
+    async cancel() {
+        this.canceled = true;
+        const ws = this.waiters;
+        this.waiters = [];
+        ws.forEach((w) => w.resolve({ value: undefined, done: true }));
+    }
+    releaseLock() {}
+}
+
+class FakeWriter {
+    constructor(opts) {
+        this.writes = [];
+        this._opts = opts || {};
+    }
+    async write(bytes) {
+        if (this._opts.failWrite) throw new Error('write failed');
+        this.writes.push(Uint8Array.from(bytes));
+    }
+    releaseLock() {}
+}
+
+class FakePort {
+    constructor(reader, writer, opts) {
+        this._reader = reader;
+        this._writer = writer;
+        this._opts = opts || {};
+        this.opened = false;
+        this.closed = false;
+    }
+    async open() {
+        this.opened = true;
+    }
+    async close() {
+        this.closed = true;
+    }
+    get readable() {
+        return { getReader: () => this._reader };
+    }
+    get writable() {
+        return {
+            getWriter: () => {
+                if (this._opts.failGetWriter) throw new Error('getWriter failed');
+                return this._writer;
+            }
+        };
+    }
+}
+
+// Build a fresh link + injected navigator.serial for one scenario.
+function setup(opts) {
+    opts = opts || {};
+    const reader = new FakeReader();
+    const writer = new FakeWriter(opts.writer);
+    const port = new FakePort(reader, writer, opts.port);
+    const listeners = {};
+    global.navigator = {
+        serial: {
+            requestPort: async () => port,
+            addEventListener: (t, fn) => {
+                (listeners[t] = listeners[t] || []).push(fn);
+            },
+            removeEventListener: (t, fn) => {
+                const a = listeners[t] || [];
+                const i = a.indexOf(fn);
+                if (i >= 0) a.splice(i, 1);
+            },
+            _dispatch: (t, ev) => {
+                (listeners[t] || []).slice().forEach((fn) => fn(ev));
+            }
+        }
+    };
+    const events = { errors: [], disconnects: 0 };
+    const link = new ArenaLink({
+        onError: (e) => events.errors.push(e),
+        onDisconnect: () => {
+            events.disconnects++;
+        }
+    });
+    return { link, reader, writer, port, events };
+}
+
+// Canonical request encoders + matching response frames.
+const REQ_INFO = '01 67';
+const REQ_SPI = '01 18';
+const RESP_INFO = Uint8Array.from([0x04, 0x00, 0x67, 0x02, 0x11]); // echo 0x67
+const RESP_SPI = Uint8Array.from([0x04, 0x00, 0x18, 0x14, 0x00]); // echo 0x18
+
+async function main() {
+    console.log('=== feature detection ===');
+    delete global.navigator;
+    checkBool('isSupported() false without navigator.serial', ArenaLink.isSupported() === false);
+
+    console.log('\n=== guards ===');
+    {
+        const { link } = setup();
+        checkBool('isSupported() true with navigator.serial', ArenaLink.isSupported() === true);
+        await checkRejects(
+            'send before connect rejects',
+            link.send(Wire.encodeGetControllerInfo()),
+            /not connected/
+        );
+    }
+
+    console.log('\n=== connect + correlated response round-trip ===');
+    {
+        const { link, reader, writer, port } = setup();
+        await link.connect();
+        checkBool('connected after connect()', link.connected === true);
+        const p = link.send(Wire.encodeGetControllerInfo());
+        await flush();
+        checkBytes('request written to port', writer.writes[0], REQ_INFO);
+        reader.push(RESP_INFO);
+        const frame = await p;
+        checkBytes('resolves with response frame', frame, '04 00 67 02 11');
+        const info = Wire.decodeControllerInfo(Wire.decodeResponse(frame));
+        checkBool('frame decodes (version=2)', info && info.version === 2);
+        await link.close();
+        checkBool('not connected after close()', link.connected === false);
+        checkBool('port closed after close()', port.closed === true);
+    }
+
+    console.log('\n=== echo verification (desync) ===');
+    {
+        const { link, reader } = setup();
+        await link.connect();
+        const p = link.send(Wire.encodeGetControllerInfo()); // expects echo 0x67
+        await flush();
+        reader.push(RESP_SPI); // echo 0x18 — wrong
+        await checkRejects('mismatched echo rejects as desync', p, /desync/);
+        await link.close();
+    }
+
+    console.log('\n=== de-framing across chunk boundaries ===');
+    {
+        const { link, reader } = setup();
+        await link.connect();
+        const p = link.send(Wire.encodeGetControllerInfo());
+        await flush();
+        reader.push([0x04, 0x00]); // first half of the frame
+        await flush();
+        reader.push([0x67, 0x02, 0x11]); // second half
+        const frame = await p;
+        checkBytes('split frame reassembled', frame, '04 00 67 02 11');
+        await link.close();
+    }
+
+    console.log('\n=== runt/stray bytes ignored ===');
+    {
+        const { link, reader } = setup();
+        await link.connect();
+        const p = link.send(Wire.encodeGetControllerInfo());
+        await flush();
+        reader.push([0x00]); // claimedLen 0 — runt
+        reader.push([0x01, 0x00]); // claimedLen 1, no echo — runt
+        await flush();
+        reader.push(RESP_INFO); // the real reply
+        const frame = await p;
+        checkBytes('runts skipped, real frame resolves', frame, '04 00 67 02 11');
+        await link.close();
+    }
+
+    console.log('\n=== timeout + rx flush recovery ===');
+    {
+        const { link, reader } = setup();
+        await link.connect();
+        const p = link.send(Wire.encodeGetControllerInfo(), { timeoutMs: 20 });
+        await flush();
+        await checkRejects('send times out with no reply', p, /timeout/);
+        // rxBuf was flushed + inflight cleared — a fresh send still works.
+        const p2 = link.send(Wire.encodeGetControllerInfo());
+        await flush();
+        reader.push(RESP_INFO);
+        const frame = await p2;
+        checkBytes('send works again after a timeout', frame, '04 00 67 02 11');
+        await link.close();
+    }
+
+    console.log('\n=== late response after timeout does not poison the next request ===');
+    {
+        const { link, reader } = setup();
+        await link.connect();
+        const p1 = link.send(Wire.encodeGetControllerInfo(), { timeoutMs: 20 }); // echo 67
+        await flush();
+        await checkRejects('first request times out', p1, /timeout/);
+        reader.push(RESP_INFO); // the tardy echo-67 reply — no request waiting, dropped
+        await flush();
+        const p2 = link.send(Wire.encodeGetSpiClock()); // echo 18
+        await flush();
+        reader.push(RESP_SPI); // echo 18
+        const frame = await p2;
+        checkBytes('next request gets its OWN reply, not the stale one', frame, '04 00 18 14 00');
+        await link.close();
+    }
+
+    console.log('\n=== single-flight serialization ===');
+    {
+        const { link, reader, writer } = setup();
+        await link.connect();
+        const p1 = link.send(Wire.encodeGetControllerInfo()); // echo 67
+        const p2 = link.send(Wire.encodeGetSpiClock()); // echo 18
+        await flush();
+        checkBool('only the first request is written', writer.writes.length === 1);
+        checkBytes('first write is get-info', writer.writes[0], REQ_INFO);
+        reader.push(RESP_INFO); // resolves p1, releases p2 to write
+        const f1 = await p1;
+        await flush();
+        checkBool('second request written after first resolves', writer.writes.length === 2);
+        checkBytes('second write is get-spi', writer.writes[1], REQ_SPI);
+        reader.push(RESP_SPI);
+        const f2 = await p2;
+        checkBytes('p1 resolved with get-info reply', f1, '04 00 67 02 11');
+        checkBytes('p2 resolved with get-spi reply', f2, '04 00 18 14 00');
+        await link.close();
+    }
+
+    console.log('\n=== read-loop error -> connection failure ===');
+    {
+        const { link, reader, events } = setup();
+        await link.connect();
+        const p = link.send(Wire.encodeGetControllerInfo());
+        await flush();
+        reader.fail(new Error('USB read failure'));
+        await checkRejects('in-flight request rejected on read error', p, /USB read failure/);
+        checkBool('onError fired', events.errors.length === 1);
+        checkBool('onDisconnect fired', events.disconnects === 1);
+        checkBool('not connected after read error', link.connected === false);
+        await link.close();
+    }
+
+    console.log('\n=== disconnect event -> clean teardown ===');
+    {
+        const { link, reader, port, events } = setup();
+        await link.connect();
+        const p = link.send(Wire.encodeGetControllerInfo());
+        await flush();
+        global.navigator.serial._dispatch('disconnect', { target: port });
+        await checkRejects('in-flight request rejected on disconnect', p, /disconnected/);
+        checkBool('onDisconnect fired (event)', events.disconnects === 1);
+        checkBool('onError NOT fired on clean unplug', events.errors.length === 0);
+        checkBool('not connected after disconnect', link.connected === false);
+        reader.cancel(); // release the lingering read loop
+        await link.close();
+    }
+
+    console.log('\n=== partial open() rollback ===');
+    {
+        const { link, port } = setup({ port: { failGetWriter: true } });
+        await checkRejects(
+            'open() rejects when getWriter throws',
+            link.connect(),
+            /getWriter failed/
+        );
+        checkBool('port closed on open rollback', port.closed === true);
+        checkBool('not connected after failed open', link.connected === false);
+    }
+
+    console.log(`\n=== Summary ===\n${totalChecks - failures} / ${totalChecks} checks passed`);
+    process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+    console.error('test harness crashed:', e);
+    process.exit(1);
+});

--- a/tests/test-arena-wire-g6.js
+++ b/tests/test-arena-wire-g6.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Golden-vector tests for js/arena-wire-g6.js (the G6 wire encoders + decoder).
+ *
+ * Run: node tests/test-arena-wire-g6.js
+ *
+ * Every encoder is pinned against bytes lifted from the reference host
+ * encoders and the firmware:
+ *   - scripts/play_pattern.py  (trial-params, set-frame-position)
+ *   - scripts/all_on.py        (all-on / all-off)
+ *   - scripts/web-serial/main.js (every button's byte sequence)
+ *   - src/commands.h           (opcodes)
+ * in the sibling repo LED-Display_G6_Firmware_Arena. The negative-gain int8
+ * Mode-4 case is pinned explicitly — it's the easy-to-get-wrong one.
+ *
+ * Exits 0 on PASS, 1 on any FAIL. Wired into `npm test` for CI.
+ */
+
+'use strict';
+
+const Wire = require('../js/arena-wire-g6.js');
+
+let totalChecks = 0;
+let failures = 0;
+
+const hex = (bytes) =>
+    Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join(' ');
+
+// Assert an encoder's bytes equal an expected hex string (e.g. '0c 08 02').
+function checkBytes(name, got, expectedHex) {
+    totalChecks++;
+    const gotHex = hex(got);
+    const ok = gotHex === expectedHex;
+    console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}: got [${gotHex}], expected [${expectedHex}]`);
+    if (!ok) failures++;
+}
+
+function check(name, got, expected) {
+    totalChecks++;
+    const ok = got === expected;
+    console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}: got ${got}, expected ${expected}`);
+    if (!ok) failures++;
+}
+
+function checkBool(name, ok, info) {
+    totalChecks++;
+    console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${info ? ' — ' + info : ''}`);
+    if (!ok) failures++;
+}
+
+// Assert a call throws (used for encoder range validation).
+function checkThrows(name, fn) {
+    totalChecks++;
+    let threw = false;
+    try {
+        fn();
+    } catch (_) {
+        threw = true;
+    }
+    console.log(`  ${threw ? 'PASS' : 'FAIL'}  ${name}: ${threw ? 'threw' : 'did NOT throw'}`);
+    if (!threw) failures++;
+}
+
+console.log('=== Simple command frames (all_on.py / main.js) ===');
+checkBytes('encodeAllOn', Wire.encodeAllOn(), '01 ff');
+checkBytes('encodeAllOff', Wire.encodeAllOff(), '01 00');
+checkBytes('encodeStop', Wire.encodeStop(), '01 30');
+checkBytes('encodeGetIp', Wire.encodeGetIp(), '01 66');
+checkBytes('encodeGetControllerInfo', Wire.encodeGetControllerInfo(), '01 67');
+checkBytes('getControllerInfo (alias)', Wire.getControllerInfo(), '01 67');
+checkBytes('encodeGetSpiClock', Wire.encodeGetSpiClock(), '01 18');
+checkBytes('encodeGetFramesSent', Wire.encodeGetFramesSent(), '01 19');
+checkBytes('encodeResetFramesSent', Wire.encodeResetFramesSent(), '01 1a');
+
+console.log('\n=== uint16 set-commands (main.js framing) ===');
+checkBytes('encodeSetSpiClock(20)', Wire.encodeSetSpiClock(20), '03 17 14 00');
+checkBytes('encodeSetRefreshRate(100)', Wire.encodeSetRefreshRate(100), '03 16 64 00');
+checkBytes('encodeSetRefreshRate(200)', Wire.encodeSetRefreshRate(200), '03 16 c8 00');
+checkBytes('encodeSetFramePosition(10)', Wire.encodeSetFramePosition(10), '03 70 0a 00');
+// index 258 = 0x0102 exercises the high byte of the u16 LE.
+checkBytes('encodeSetFramePosition(258)', Wire.encodeSetFramePosition(258), '03 70 02 01');
+
+console.log('\n=== trial-params (0x08) — golden vectors from play_pattern.py ===');
+// Mode 2, pattern 1, 30 fps, init 0 — the canonical golden vector.
+checkBytes(
+    'trial mode2 pat1 30fps init0',
+    Wire.encodeTrialParams({ mode: 2, patternId: 1, frameRate: 30, initPos: 0 }),
+    '0c 08 02 01 00 1e 00 00 00 00 00 00 00'
+);
+// Defaults: mode=2, patternId=1, frameRate=0, gain=0, initPos=0.
+checkBytes(
+    'trial defaults (mode2 pat1)',
+    Wire.encodeTrialParams(),
+    '0c 08 02 01 00 00 00 00 00 00 00 00 00'
+);
+// Mode 4 closed-loop, NEGATIVE gain -50 -> int8 byte 0xCE (the must-pin case).
+checkBytes(
+    'trial mode4 gain -50 -> 0xCE',
+    Wire.encodeTrialParams({ mode: 4, patternId: 1, frameRate: 0, gain: -50, initPos: 0 }),
+    '0c 08 04 01 00 00 00 ce 00 00 00 00 00'
+);
+// play_pattern.py docstring example: Mode 4 gain -20 -> int8 byte 0xEC.
+checkBytes(
+    'trial mode4 gain -20 -> 0xEC',
+    Wire.encodeTrialParams({ mode: 4, patternId: 1, gain: -20 }),
+    '0c 08 04 01 00 00 00 ec 00 00 00 00 00'
+);
+// int8 boundaries: -128 -> 0x80, 127 -> 0x7F, -1 -> 0xFF.
+check('gain -128 byte', Wire.encodeTrialParams({ gain: -128 })[7], 0x80);
+check('gain 127 byte', Wire.encodeTrialParams({ gain: 127 })[7], 0x7f);
+check('gain -1 byte', Wire.encodeTrialParams({ gain: -1 })[7], 0xff);
+// Mode 3 show-frame with a large pattern id / init exercises both u16 hi bytes.
+checkBytes(
+    'trial mode3 pat300 init513',
+    Wire.encodeTrialParams({ mode: 3, patternId: 300, initPos: 513 }),
+    '0c 08 03 2c 01 00 00 00 01 02 00 00 00'
+);
+// Length byte is always 0x0C (12 bytes follow: cmd + 11 params); total = 13 B.
+check('trial frame total length', Wire.encodeTrialParams().length, 13);
+check('trial length byte', Wire.encodeTrialParams()[0], 0x0c);
+
+console.log('\n=== encoder range validation (throws) ===');
+checkThrows('gain -129 throws', () => Wire.encodeTrialParams({ gain: -129 }));
+checkThrows('gain 128 throws', () => Wire.encodeTrialParams({ gain: 128 }));
+checkThrows('patternId 70000 throws', () => Wire.encodeTrialParams({ patternId: 70000 }));
+checkThrows('frame position -1 throws', () => Wire.encodeSetFramePosition(-1));
+checkThrows('frame position 70000 throws', () => Wire.encodeSetFramePosition(70000));
+checkThrows('non-integer mhz throws', () => Wire.encodeSetSpiClock(20.5));
+
+console.log('\n=== firmware domain validation (modes 2/3/4, patternId>=1, SPI 1..30) ===');
+// Firmware only accepts modes 2/3/4 — fail fast instead of emitting a bad frame.
+checkThrows('mode 1 throws', () => Wire.encodeTrialParams({ mode: 1 }));
+checkThrows('mode 5 (stream) throws', () => Wire.encodeTrialParams({ mode: 5 }));
+checkThrows('mode 0 throws', () => Wire.encodeTrialParams({ mode: 0 }));
+checkBool('mode 2 ok', Wire.encodeTrialParams({ mode: 2 })[2] === 2);
+checkBool('mode 3 ok', Wire.encodeTrialParams({ mode: 3 })[2] === 3);
+checkBool('mode 4 ok', Wire.encodeTrialParams({ mode: 4 })[2] === 4);
+// patternId is 1-based on the firmware.
+checkThrows('patternId 0 throws', () => Wire.encodeTrialParams({ patternId: 0 }));
+// SPI clock is clamped to 1..30 MHz on the firmware.
+checkThrows('SPI clock 0 throws', () => Wire.encodeSetSpiClock(0));
+checkThrows('SPI clock 31 throws', () => Wire.encodeSetSpiClock(31));
+checkBytes('SPI clock 1 ok', Wire.encodeSetSpiClock(1), '03 17 01 00');
+checkBytes('SPI clock 30 ok', Wire.encodeSetSpiClock(30), '03 17 1e 00');
+
+console.log('\n=== decodeResponse framing ===');
+// get-controller-info reply: [len=4, status=0, echo=0x67, version=2, cap=0x11].
+// length byte = 4 = status + echo + 2 payload bytes.
+const ciFrame = Uint8Array.from([0x04, 0x00, 0x67, 0x02, 0x11]);
+const ci = Wire.decodeResponse(ciFrame);
+checkBool('decodeResponse returns object', !!ci);
+check('  .length', ci.length, 4);
+check('  .status', ci.status, 0);
+check('  .echoCmd', ci.echoCmd, 0x67);
+check('  .ok', ci.ok, true);
+checkBytes('  .payload', ci.payload, '02 11');
+
+// A rejected command: status != 0 -> ok false.
+const rej = Wire.decodeResponse(Uint8Array.from([0x02, 0x01, 0x08]));
+check('rejected status', rej.status, 1);
+check('rejected ok=false', rej.ok, false);
+
+// Absent / malformed / incomplete frames -> null.
+checkBool('empty frame -> null', Wire.decodeResponse(new Uint8Array([])) === null);
+checkBool('length<2 -> null', Wire.decodeResponse(Uint8Array.from([0x01, 0x00])) === null);
+checkBool(
+    'incomplete frame -> null',
+    Wire.decodeResponse(Uint8Array.from([0x05, 0x00, 0x67, 0x02])) === null,
+    'claims 5 bytes, only 3 present'
+);
+// Regression: a plain number[] must NOT throw (TypedArray.slice rejects a
+// non-typed-array receiver — decodeResponse normalizes to Uint8Array first).
+const ciArr = Wire.decodeResponse([0x04, 0x00, 0x67, 0x02, 0x11]);
+checkBool('decodeResponse(number[]) does not throw', !!ciArr);
+checkBytes('decodeResponse(number[]) payload', ciArr.payload, '02 11');
+
+console.log('\n=== field decoders (main.js / controller_info.py) ===');
+// 0x11 = bit0 (g6_mode) + bit4 (v3_gated).
+const info = Wire.decodeControllerInfo(ci);
+check('controller version', info.version, 2);
+check('controller capability', info.capability, 0x11);
+check('controller caps', info.capabilities.join(','), 'g6_mode,v3_gated');
+// Field decoders also accept a raw frame directly (asResponse coercion).
+checkBool(
+    'decodeControllerInfo accepts raw frame',
+    Wire.decodeControllerInfo(ciFrame).version === 2
+);
+// A non-OK controller-info reply must not be decoded as valid metadata.
+checkBool(
+    'decodeControllerInfo rejects status!=0',
+    Wire.decodeControllerInfo(Uint8Array.from([0x04, 0x01, 0x67, 0x02, 0x11])) === null
+);
+
+// SPI clock reply: [len=4, status=0, echo=0x18, 20, 0] -> 20 MHz.
+check('decodeSpiClock', Wire.decodeSpiClock(Uint8Array.from([0x04, 0x00, 0x18, 0x14, 0x00])), 20);
+checkBool(
+    'decodeSpiClock rejects status!=0',
+    Wire.decodeSpiClock(Uint8Array.from([0x04, 0x01, 0x18, 0x14, 0x00])) === null
+);
+
+// frames-sent reply: u32 LE. 0x12345678 -> 78 56 34 12.
+check(
+    'decodeFramesSent',
+    Wire.decodeFramesSent(Uint8Array.from([0x06, 0x00, 0x19, 0x78, 0x56, 0x34, 0x12])),
+    0x12345678
+);
+// High-bit-set value confirms unsigned (>>> 0) handling: 0xFFFFFFFF.
+check(
+    'decodeFramesSent unsigned',
+    Wire.decodeFramesSent(Uint8Array.from([0x06, 0x00, 0x19, 0xff, 0xff, 0xff, 0xff])),
+    4294967295
+);
+
+// get-ip reply: ASCII payload "10.0.0.5".
+const ipAscii = '10.0.0.5';
+const ipBytes = [ipAscii.length + 2, 0x00, 0x66, ...Array.from(ipAscii, (c) => c.charCodeAt(0))];
+check('decodeIp', Wire.decodeIp(Uint8Array.from(ipBytes)), '10.0.0.5');
+
+console.log(`\n=== Summary ===\n${totalChecks - failures} / ${totalChecks} checks passed`);
+process.exit(failures > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Milestone-A substrate for **G6 Web Control (CSHL)** — two reusable, dual-export JS modules the console (LAB-93) and runner (LAB-94) build on. Ported from the firmware repo's hardware-proven `scripts/web-serial/main.js`; wire authority cross-checked against firmware `commands.h` / `CommandProcessor.cpp` / `SerialManager.cpp`.

- **`js/arena-wire-g6.js`** ([LAB-89](https://linear.app/reiser-lab/issue/LAB-89)) — pure command encoders (`encodeAllOn/Off/Stop`, `encodeTrialParams`, `encodeSetFramePosition`, `encodeSetSpiClock`, `encodeGetControllerInfo`, …) + `decodeResponse` and field decoders. No I/O.
- **`js/arena-link.js`** ([LAB-88](https://linear.app/reiser-lab/issue/LAB-88)) — Web Serial transport: single-flight + echo-verified correlation, timeout + rx-flush, shared `_failConnection` teardown, disconnect fail-safe, partial-open rollback, non-Chromium feature-detect. No command knowledge.
- **`serial_raw_monitor.html`** — serial-debug tool (raw hex/ascii dump; flags replies buried in DEBUG_SERIAL noise).

## Tests
- `tests/test-arena-wire-g6.js` — 64 golden-vector checks (every encoder vs firmware/Python bytes incl. negative-gain int8, range validation, decoders).
- `tests/test-arena-link.js` — 33 hardware-free transport checks (de-framing across chunks, echo desync, timeout + rx-flush, late-response isolation, read-error/disconnect teardown, partial-open rollback).
- Wired into `npm test` (`test:wire`, `test:link`); full chain green.

## Hardware verification
Real G6 controller over Web Serial (non-DEBUG `teensy41` build):
```
-> 01 67
<- 04 00 67 01 01   → version 1, capability 0x01 [g6_mode]
```
The transport correctly rejected a `DEBUG_SERIAL` build's interleaved diagnostic text as an echo desync (the correlation fix working as designed); flashing the quiet `teensy41` env cleared it.

## Review
Hardened per an adversarial Codex (GPT-5.5) cross-review: FIFO → single-flight + echo correlation (the handoff's `echo_cmd` requirement), `decodeResponse(number[])` crash fix, read-loop teardown, firmware-domain encoder validation.

Implements [LAB-88](https://linear.app/reiser-lab/issue/LAB-88) and [LAB-89](https://linear.app/reiser-lab/issue/LAB-89) (both verified + marked Done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)