### PR TITLE
feat(g6): pattern pickers backed by the active set — W/C source [LAB-96, LAB-95]

### DIFF
--- a/arena_console.html
+++ b/arena_console.html
@@ -5,9 +5,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Arena Console — G6 live control</title>
         <!--
-          Arena Console v1 — the experimenter-facing PControl successor for the
-          G6 arena. A standalone live-control page built entirely on the
-          Milestone-A Web Serial substrate (LAB-88/89):
+          Arena Console v2 — the experimenter-facing PControl successor for the
+          G6 arena. A standalone live-control page built on the Milestone-A Web
+          Serial substrate (LAB-88/89) with a pattern-set name picker (LAB-95):
             js/arena-wire-g6.js  (window.ArenaWireG6 — encoders/decoders)
             js/arena-link.js     (window.ArenaLink   — transport)
           loaded via <script src> (window-global dual-export path).
@@ -213,6 +213,35 @@
             .l-dim {
                 color: var(--dim);
             }
+            /* LAB-95 pattern picker — animated cylindrical preview thumbnail. */
+            #ps-preview-host {
+                min-height: 90px;
+                display: flex;
+                align-items: center;
+            }
+            .pat-preview {
+                position: relative;
+                display: inline-block;
+                line-height: 0;
+            }
+            .pat-preview img {
+                width: 90px;
+                height: 90px;
+                border-radius: 6px;
+                border: 1px solid var(--border);
+                background: var(--bg);
+            }
+            .pat-preview-badge {
+                position: absolute;
+                bottom: 3px;
+                right: 3px;
+                background: rgba(0, 0, 0, 0.7);
+                color: var(--accent);
+                font-size: 10px;
+                padding: 0 4px;
+                border-radius: 3px;
+                font-family: 'JetBrains Mono', monospace;
+            }
         </style>
     </head>
     <body>
@@ -281,6 +310,25 @@
 
             <div class="panel">
                 <h2>Pattern / Trial params (0x08)</h2>
+                <div class="row">
+                    <label title="Active pattern set (manifest.json)">set</label>
+                    <button
+                        id="btn-loadset"
+                        title="Load a built SD-bundle folder (manifest.json + patterns/) to pick patterns by name + preview. Defaults to the built-in library served with this tool."
+                    >
+                        Load set…
+                    </button>
+                    <span id="ps-status" class="l-dim">loading built-in library…</span>
+                    <input id="ps-folder" type="file" webkitdirectory directory style="display: none" />
+                </div>
+                <div class="row">
+                    <label title="Pick a pattern by name from the active set">name</label>
+                    <select
+                        id="tp-pat-name"
+                        title="Pick a pattern by name — fills the 1-based SD index below and shows a preview"
+                    ></select>
+                    <div id="ps-preview-host"></div>
+                </div>
                 <div class="row">
                     <label title="Display mode">mode</label>
                     <select
@@ -435,11 +483,17 @@
             diagnose framing problems.
         </div>
 
-        <footer id="footer">Arena Console v1 | 2026-06-08 19:04 ET</footer>
+        <footer id="footer">Arena Console v2 | 2026-06-10 19:58 ET</footer>
 
         <!-- Milestone-A substrate — window-global dual-export path (no build, no ES import). -->
         <script src="js/arena-wire-g6.js"></script>
         <script src="js/arena-link.js"></script>
+        <!-- LAB-95 pattern picker. pattern-set.js + pat-preview.js are classic-safe
+             (window.PatternSet / window.PatPreview); the import-only modules
+             (pat-parser, arena-configs, icon-generator) load in the deferred module
+             block at the end of <body>. -->
+        <script src="js/pattern-set.js"></script>
+        <script src="js/pat-preview.js"></script>
         <script>
             'use strict';
             const Wire = window.ArenaWireG6;
@@ -598,6 +652,186 @@
             cmdButtons().forEach((b) => (b.onclick = HANDLERS[b.dataset.cmd]));
 
             log('ready. Connect a G6 controller over USB, then click Connect.', 'dim');
+        </script>
+
+        <!-- LAB-95 pattern picker (deferred module). Imports the bare-export modules
+             directly; reads window.PatternSet / window.PatPreview from the classic tags
+             above. Browsers can't read the SD card, so the source is either the served
+             built-in library (auto-loaded on startup, present across tabs/reloads) or a
+             built SD-bundle folder the operator picks. Selecting a name fills #tp-pat
+             with the resolved 1-based SD index, which the existing trial handler sends.
+             Note: ES-module imports can serve stale on GitHub Pages — hard-refresh after
+             a deploy (Cmd+Shift+R). -->
+        <script type="module">
+            import PatParser from './js/pat-parser.js';
+            import { getConfig } from './js/arena-configs.js'; // also sets window.PANEL_SPECS
+            import { generatePatternIcon } from './js/icon-generator.js';
+
+            const PS = window.PatternSet;
+            const PP = window.PatPreview;
+            const $ = (id) => document.getElementById(id);
+            const tpPat = $('tp-pat');
+            const nameSel = $('tp-pat-name');
+            const statusEl = $('ps-status');
+            const previewHost = $('ps-preview-host');
+            const folderInput = $('ps-folder');
+
+            const BUILTIN_BASE = './patterns/g6_2x10/'; // the served default library
+
+            let activeManifest = null;
+            let byteSource = null; // (sd_name) => Promise<ArrayBuffer>
+            let previewCache = {};
+
+            const setStatus = (text, cls) => {
+                statusEl.textContent = text;
+                statusEl.className = cls || 'l-dim';
+            };
+
+            function arenaForManifest(m) {
+                const cfg = m && m.arenaConfig ? getConfig(m.arenaConfig) : null;
+                return cfg && cfg.arena;
+            }
+
+            function applyPick(name) {
+                const p = activeManifest && activeManifest.patterns[name];
+                if (p && p.index != null) tpPat.value = p.index; // the resolved 1-based SD index
+                renderPreview(name);
+            }
+
+            function populateDropdown(m) {
+                nameSel.innerHTML = '';
+                const names = Object.keys(m.patterns || {});
+                if (!names.length) {
+                    const o = document.createElement('option');
+                    o.value = '';
+                    o.textContent = '(empty set)';
+                    nameSel.appendChild(o);
+                    previewHost.innerHTML = '';
+                    return;
+                }
+                names.sort((a, b) => (m.patterns[a].index || 0) - (m.patterns[b].index || 0));
+                for (const n of names) {
+                    const p = m.patterns[n];
+                    const o = document.createElement('option');
+                    o.value = n;
+                    o.textContent = (p.index != null ? p.index + ' · ' : '') + n;
+                    nameSel.appendChild(o);
+                }
+                nameSel.value = names[0];
+                applyPick(names[0]);
+            }
+
+            async function renderPreview(name) {
+                previewHost.innerHTML = '';
+                if (!activeManifest || !byteSource) return;
+                const p = activeManifest.patterns[name];
+                if (!p) return;
+                const meta = p.preview || {};
+                try {
+                    let sampled = previewCache[name];
+                    if (!sampled) {
+                        const ab = await byteSource(p.sd_name);
+                        const parsed = PatParser.parsePatFile(ab);
+                        sampled = PP.samplePreviewFrames(parsed, arenaForManifest(activeManifest), {
+                            renderIcon: generatePatternIcon,
+                            iconOpts: { width: 90, height: 90, backgroundColor: '#1a1f26',
+                                innerRadiusRatio: 0.4, padding: 2, showGaps: false, showOutlines: false }
+                        });
+                        previewCache[name] = sampled;
+                    }
+                    if (!sampled.frames.length) {
+                        previewHost.appendChild(metaSpan(meta));
+                        return;
+                    }
+                    const container = document.createElement('div');
+                    container.className = 'pat-preview';
+                    const img = document.createElement('img');
+                    img.src = sampled.frames[sampled.staticIndex];
+                    img.alt = name;
+                    img.title = name + ' — ' + (meta.frames || 1) + ' frame' + ((meta.frames || 1) === 1 ? '' : 's') +
+                        ' · GS' + (meta.gs || '?') + (sampled.frames.length > 1 ? ' · hover to animate' : '');
+                    container.appendChild(img);
+                    if ((meta.frames || 1) > 1) {
+                        const b = document.createElement('span');
+                        b.className = 'pat-preview-badge';
+                        b.textContent = meta.frames + 'f';
+                        container.appendChild(b);
+                    }
+                    if (sampled.frames.length > 1) {
+                        let iv = null, k = 0;
+                        container.addEventListener('mouseenter', () => {
+                            k = 0;
+                            iv = setInterval(() => { k = (k + 1) % sampled.frames.length; img.src = sampled.frames[k]; }, 150);
+                        });
+                        container.addEventListener('mouseleave', () => {
+                            if (iv) { clearInterval(iv); iv = null; }
+                            img.src = sampled.frames[sampled.staticIndex];
+                        });
+                    }
+                    previewHost.appendChild(container);
+                } catch (e) {
+                    previewHost.appendChild(metaSpan(meta)); // bytes unavailable → metadata only
+                }
+            }
+
+            function metaSpan(meta) {
+                const s = document.createElement('span');
+                s.className = 'l-dim';
+                s.textContent = 'preview: ' + (meta.frames || '?') + 'f · GS' + (meta.gs || '?') +
+                    ' · ' + (meta.rows || '?') + '×' + (meta.cols || '?');
+                return s;
+            }
+
+            nameSel.addEventListener('change', () => applyPick(nameSel.value));
+
+            async function loadBuiltin() {
+                try {
+                    const resp = await fetch(BUILTIN_BASE + 'manifest.json', { cache: 'no-store' });
+                    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                    const m = PS.loadManifestJson(await resp.json());
+                    activeManifest = m;
+                    byteSource = async (sd) => {
+                        const r = await fetch(BUILTIN_BASE + 'patterns/' + sd, { cache: 'no-store' });
+                        if (!r.ok) throw new Error('HTTP ' + r.status);
+                        return r.arrayBuffer();
+                    };
+                    previewCache = {};
+                    const cfg = getConfig(m.arenaConfig);
+                    setStatus('built-in · ' + ((cfg && cfg.label) || m.arenaConfig) + ' · ' +
+                        Object.keys(m.patterns || {}).length + ' patterns' + (m.set_id ? ' · ' + m.set_id : ''));
+                    populateDropdown(m);
+                } catch (e) {
+                    setStatus('built-in library unavailable — use “Load set…”', 'l-err');
+                }
+            }
+
+            $('btn-loadset').addEventListener('click', () => folderInput.click());
+            folderInput.addEventListener('change', async () => {
+                const files = Array.from(folderInput.files || []);
+                folderInput.value = '';
+                if (!files.length) return;
+                const manifestFile = files.find((f) => f.name === 'manifest.json');
+                if (!manifestFile) { setStatus('no manifest.json in that folder', 'l-err'); return; }
+                try {
+                    const m = PS.loadManifestJson(JSON.parse(await manifestFile.text()));
+                    const map = {};
+                    for (const f of files) map[f.name] = f; // sd_name === base filename
+                    activeManifest = m;
+                    byteSource = (sd) => {
+                        const f = map[sd];
+                        return f ? f.arrayBuffer() : Promise.reject(new Error('missing ' + sd));
+                    };
+                    previewCache = {};
+                    const cfg = getConfig(m.arenaConfig);
+                    setStatus('loaded · ' + ((cfg && cfg.label) || m.arenaConfig || '(unknown arena)') + ' · ' +
+                        Object.keys(m.patterns || {}).length + ' patterns' + (m.set_id ? ' · ' + m.set_id : ''));
+                    populateDropdown(m);
+                } catch (e) {
+                    setStatus('load failed: ' + (e.message || e), 'l-err');
+                }
+            });
+
+            loadBuiltin();
         </script>
     </body>
 </html>

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -660,10 +660,29 @@
         .arena-test-btn:disabled { opacity: 0.45; cursor: not-allowed; background: var(--border); color: var(--text-dim); }
         .arena-test-note { font-size: 0.66rem; color: var(--text-dim); }
         .arena-test-note.dim { font-style: italic; }
-        /* Passive "web-runnable" badge in the Library — the run control is in the Inspector. */
-        .lib-row-runnable {
-            color: var(--accent); font-size: 0.7rem; margin-left: 0.2rem;
-            opacity: 0.85; cursor: default; user-select: none;
+        /* LAB-96: W/C pattern-source chip. W = web (the trialParams pattern is in the
+           active set, browser-displayable, carries an SD index); C = computer/MATLAB
+           (a pattern path not in the set). Used in the library rows (compact "W"/"C")
+           and the inspector pattern field ("W · web" / "C · computer"). */
+        .wc-chip {
+            font-family: 'JetBrains Mono', monospace; font-size: 0.62rem; font-weight: 700;
+            margin-left: 0.2rem; padding: 0 0.4rem; border-radius: 9px; line-height: 1.5;
+            cursor: default; user-select: none; letter-spacing: 0.03em; white-space: nowrap;
+        }
+        .wc-w { color: var(--accent); border: 1px solid var(--accent); background: rgba(0, 230, 118, 0.12); }
+        .wc-c { color: #6cb1ff; border: 1px solid #3b6ea5; background: rgba(88, 166, 255, 0.12); }
+        /* LAB-96: animated pattern preview next to the picker dropdown. */
+        .pat-preview-host { margin-top: 0.35rem; }
+        .pat-preview { position: relative; display: inline-block; line-height: 0; }
+        .pat-preview img {
+            width: 96px; height: 96px; border-radius: 6px;
+            border: 1px solid var(--border); background: var(--surface);
+        }
+        .pat-preview-badge {
+            position: absolute; bottom: 3px; right: 3px;
+            background: rgba(0,0,0,0.7); color: var(--accent);
+            font-size: 0.6rem; padding: 0 0.25rem; border-radius: 3px;
+            font-family: 'JetBrains Mono', monospace;
         }
         .zone-body {
             flex: 1;
@@ -1473,7 +1492,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.27 | <span id="footerTimestamp">2026-06-10 15:43 ET</span>
+        v3 Experiment Designer v0.28 | <span id="footerTimestamp">2026-06-10 20:35 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -1496,13 +1515,15 @@
     <script src="js/arena-link.js"></script>
     <script src="js/arena-runner-g6.js"></script>
 
-    <!-- LAB-92 Pattern Set builder. pat-encoder.js + pattern-set.js are classic-safe
-         (window.PatEncoder / window.PatternSet, no bare ES export) so they load as
-         classic <script> and dodge the ES-import-failure bug; pat-parser.js and
-         arena-configs.js have bare exports, so the module below imports those. JSZip
-         (CDN, pinned) powers the bundle ZIP export. -->
+    <!-- LAB-92 Pattern Set builder + LAB-96 pattern picker. pat-encoder.js,
+         pattern-set.js, and pat-preview.js are classic-safe (window.PatEncoder /
+         window.PatternSet / window.PatPreview, no bare ES export) so they load as
+         classic <script> and dodge the ES-import-failure bug; pat-parser.js,
+         arena-configs.js, and icon-generator.js have bare exports, so the module
+         below imports those. JSZip (CDN, pinned) powers the bundle ZIP export. -->
     <script src="js/pat-encoder.js"></script>
     <script src="js/pattern-set.js"></script>
+    <script src="js/pat-preview.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 
     <script type="module">
@@ -1579,6 +1600,10 @@
         // from the classic <script> tags above (window.PatEncoder / window.PatternSet).
         import PatParser from './js/pat-parser.js';
         import { getConfig } from './js/arena-configs.js';
+        // LAB-96 — animated pattern preview: one cylindrical icon per sampled frame.
+        // arena-configs (imported above) sets window.PANEL_SPECS, which icon-generator
+        // reads at call time.
+        import { generatePatternIcon } from './js/icon-generator.js';
 
         // ═══════════════════════════════════════════════════════════════
         // State
@@ -3112,14 +3137,18 @@
                     // a trialParams command and NO plugins (LAB-94 eligibility).
                     // Plugin-bearing conditions get no ▶ (the web can't drive
                     // camera/backlight, so a run would be misleading).
-                    if (RunnerLib.isDryRunEligible(cond)) {
-                        // Passive marker only — the run control lives in the Inspector
-                        // ("▶ Test on arena"). One run entry point avoids a second,
-                        // easy-to-miss button and the import-mode edge cases.
+                    // LAB-96: W/C pattern-source chip on any trialParams condition.
+                    // W = the pattern is in the active web set (browser-displayable, carries
+                    // an SD index); C = a computer/MATLAB pattern not in the set. Plugin
+                    // runnability is a separate signal (the Inspector's “Test on arena”).
+                    if (RunnerLib.findTrialParams(cond)) {
+                        const isW = conditionPatternInActiveSet(cond);
                         btns.push(el('span', {
-                            class: 'lib-row-runnable',
-                            title: 'Web-runnable — select it, then use “▶ Test on arena” in the Inspector'
-                        }, '▶'));
+                            class: 'wc-chip ' + (isW ? 'wc-w' : 'wc-c'),
+                            title: isW
+                                ? 'Web pattern — in the active set; the browser can display it (carries an SD index). Select it, then “▶ Test on arena” in the Inspector.'
+                                : 'Computer pattern — a MATLAB pattern path not in the active web set; it runs from the MATLAB computer.'
+                        }, isW ? 'W' : 'C'));
                     }
                     btns.push(el('button', {
                         class: 'lib-row-dup',
@@ -4083,6 +4112,12 @@
                 return wrapper;
             }
 
+            // LAB-96: the trialParams `pattern` field becomes a pick-by-name dropdown +
+            // animated preview (only set by the call site when an active set exists).
+            if (opts.patternPicker) {
+                return renderPatternPickerField(wrapper, path, value, bindBtn);
+            }
+
             if (schema && schema.type === 'select' && Array.isArray(schema.options)) {
                 const select = el('select', {
                     class: 'field-edit',
@@ -4163,6 +4198,87 @@
             });
             wrapper.appendChild(input);
             wrapper.appendChild(bindBtn);
+            return wrapper;
+        }
+
+        // LAB-96: the trialParams `pattern` picker with a prominent W/C source chip.
+        //   W (web)      = the pattern is in the active set → a name dropdown + animated
+        //                  preview; selecting writes `pattern` (name) AND `pattern_ID`
+        //                  (1-based SD index) in one undo step.
+        //   C (computer) = a MATLAB pattern path not in the set → a free-text input;
+        //                  MATLAB runs the path, a browser run falls back to pattern_ID.
+        // The dropdown's trailing "C · computer / MATLAB pattern…" option switches to C.
+        // Only reached when activeSet() exists (gated at the renderCommandCard call site).
+        function renderPatternPickerField(wrapper, path, value, bindBtn) {
+            const items = activeSetValidItems();
+            const COMP = '__computer__';
+            window.PatternSet.assignIndices(activeSet());
+            const inSet = items.some((it) => it.name === value);
+
+            // Prominent source chip — W = web pattern, C = computer/MATLAB pattern.
+            wrapper.appendChild(el('span', {
+                class: 'wc-chip ' + (inSet ? 'wc-w' : 'wc-c'),
+                title: inSet
+                    ? 'Web pattern — in the active set; the browser can display it (carries an SD index).'
+                    : 'Computer pattern — a MATLAB pattern path not in the active web set; it runs from the MATLAB computer.'
+            }, inSet ? 'W · web' : 'C · computer'));
+
+            const select = el('select', { class: 'field-edit',
+                title: 'Source — pick a web pattern from the active set, or “C · computer / MATLAB pattern…” to type a path' });
+            for (const it of items) {
+                const opt = el('option', { value: it.name }, it.index + ' · ' + it.name);
+                if (it.name === value) opt.selected = true;
+                select.appendChild(opt);
+            }
+            const compOpt = el('option', { value: COMP }, 'C · computer / MATLAB pattern…');
+            if (!inSet) compOpt.selected = true;
+            select.appendChild(compOpt);
+
+            // Computer/MATLAB path input — shown only in C mode (pattern not in the set).
+            const compInput = el('input', { type: 'text', class: 'field-edit str',
+                value: inSet ? '' : (value == null ? '' : String(value)),
+                placeholder: 'patterns/my_pattern.pat',
+                title: 'Computer / MATLAB pattern file (not in the web set). MATLAB runs this path; a browser run falls back to pattern_ID.',
+                style: inSet ? 'display:none;' : '' });
+            compInput.addEventListener('change', () => {
+                if (compInput.value === value) return;
+                pushUndo();
+                try { docSet(experiment, path, compInput.value); commitInspectorEdit(); }
+                catch (err) { showError('Edit failed', err.message); compInput.value = value == null ? '' : String(value); }
+            });
+
+            const previewHost = el('div', { class: 'pat-preview-host' });
+            if (inSet) { const p = buildActiveSetPreview(value); if (p) previewHost.appendChild(p); }
+
+            select.addEventListener('change', () => {
+                const picked = select.value;
+                if (picked === COMP) {
+                    if (inSet) {
+                        // Switch web → computer: clear the web name so the source becomes C,
+                        // then re-render into the path-input mode.
+                        pushUndo();
+                        try { docSet(experiment, path, ''); commitInspectorEdit(); }
+                        catch (err) { showError('Edit failed', err.message); renderInspector(); }
+                    } else {
+                        compInput.style.display = '';
+                        compInput.focus();
+                    }
+                    return;
+                }
+                if (picked === value) return;  // unchanged
+                const idx = activeSetIndexByName(picked);
+                pushUndo();
+                try {
+                    docSet(experiment, path, picked);
+                    if (idx != null) docSet(experiment, path.slice(0, -1).concat('pattern_ID'), idx);
+                    commitInspectorEdit();  // re-render card + preview + W/C chips
+                } catch (err) { showError('Edit failed', err.message); renderInspector(); }
+            });
+
+            wrapper.appendChild(select);
+            wrapper.appendChild(compInput);
+            wrapper.appendChild(bindBtn);
+            wrapper.appendChild(previewHost);
             return wrapper;
         }
 
@@ -4619,6 +4735,15 @@
                         }
                     }
                 }
+                // LAB-96: a new trialParams defaults to the active set's first pattern,
+                // carrying both the name (MATLAB "Pattern file") and its 1-based SD index.
+                if (commandName === 'trialParams') {
+                    const first = activeSetValidItems()[0];
+                    if (first) {
+                        cmd.pattern = first.name;
+                        cmd.pattern_ID = activeSetIndexByName(first.name);
+                    }
+                }
                 return cmd;
             }
             if (kind === 'plugin') {
@@ -4648,6 +4773,10 @@
             setDirty(true);
             renderInspector();
             renderTimeline();
+            // LAB-96: the library's ▶ web-runnable / MATLAB-only badge depends on a
+            // condition's commands (trialParams presence, plugins, pattern set-membership),
+            // so keep it in sync when commands/params change from the inspector.
+            renderLibrary();
         }
 
         function onMoveCommand(condIdx, fromIdx, toIdx) {
@@ -5044,19 +5173,24 @@
                 return;
             }
 
-            // Resolve the 1-based SD pattern index: pattern_ID if usable, else prompt.
-            let patternId = Number(cmd.pattern_ID);
-            if (!Number.isInteger(patternId) || patternId < 1) {
-                const entered = prompt(
-                    'Condition "' +
-                        cond.name +
-                        '" has no usable pattern_ID.\nEnter the 1-based SD-card pattern index to display:',
-                    ''
-                );
-                if (entered === null) return;
-                patternId = Number(entered);
+            // Resolve the 1-based SD pattern index. Preferred: the pattern name is in the
+            // active set (LAB-96) → a trustworthy, validated index. Fallback: a loaded
+            // YAML's explicit pattern_ID (legacy / MATLAB-only) — used but flagged. The
+            // raw-index prompt (the "confirm-once index dialog") is retired.
+            let patternId = activeSetIndexByName(cmd.pattern);
+            let resolvedFrom = 'set';
+            const setLabel = psState.set && psState.set.set_id ? psState.set.set_id : 'active set';
+            if (patternId == null) {
+                patternId = Number(cmd.pattern_ID);
+                resolvedFrom = 'protocol';
                 if (!Number.isInteger(patternId) || patternId < 1) {
-                    showError('Invalid pattern index', 'The SD pattern index must be a whole number ≥ 1.');
+                    showError(
+                        'No SD pattern index',
+                        'Condition "' + cond.name + '" has a computer/MATLAB pattern "' +
+                            (cmd.pattern || '(empty)') + '" that is not in the active web set, ' +
+                            'and no usable pattern_ID. Add it to the set in the Pattern Set builder ' +
+                            '(so it becomes a web pattern), or set a 1-based pattern_ID in the protocol.'
+                    );
                     return;
                 }
             }
@@ -5073,9 +5207,15 @@
             const durationSec = Number(cmd.duration) > 0 ? Number(cmd.duration) : 0;
             const skipped = RunnerLib.listSkippedPlugins(cond);
 
-            // Confirm-once: show the resolved SD index + params + what is skipped.
+            // Show the resolved SD index (validated against the active set, or flagged
+            // as coming from the protocol) + params + what is skipped.
             const list = [];
-            list.push('Pattern SD index: ' + patternId + (cmd.pattern ? '  (' + cmd.pattern + ')' : ''));
+            list.push(
+                resolvedFrom === 'set'
+                    ? "Pattern '" + cmd.pattern + "' → SD index " + patternId + ' (set ' + setLabel + ')'
+                    : 'Pattern SD index ' + patternId +
+                      (cmd.pattern ? "  ('" + cmd.pattern + "', from the protocol — not in the active set)" : ' (from the protocol)')
+            );
             list.push(
                 'mode ' + params.mode + ' · frame rate ' + params.frameRate + ' · gain ' + params.gain + ' · init pos ' + params.initPos
             );
@@ -5103,10 +5243,12 @@
                 title: 'Run "' + cond.name + '" on the arena?',
                 body:
                     'Sends ONLY the trialParams command — any waits or other commands in this ' +
-                    'condition are NOT replayed (full mini-sequence runs come later, LAB-97). Pattern SD index ' +
-                    patternId +
-                    ' will display — verify your SD card matches (this is the authored index, not yet ' +
-                    'validated against the SD bundle, LAB-91/95).',
+                    'condition are NOT replayed (full mini-sequence runs come later, LAB-97). ' +
+                    (resolvedFrom === 'set'
+                        ? "Pattern '" + cmd.pattern + "' resolves to SD index " + patternId +
+                          ' in the active set — make sure that set’s SD card is in the arena.'
+                        : 'SD index ' + patternId + ' comes from the protocol’s pattern_ID (the pattern ' +
+                          'is not in an active set) — verify your SD card matches.'),
                 list,
                 confirmLabel: 'Send to arena',
                 cancelLabel: 'Cancel'
@@ -5424,12 +5566,21 @@
             for (const k of detailKeys) {
                 if (cmd[k] === undefined) continue;
                 const fieldSchema = paramsSchema && paramsSchema[k];
+                // LAB-96: the trialParams `pattern` becomes a pick-by-name dropdown +
+                // preview when an active pattern set exists. Gated here so plugin/other
+                // `pattern` params and the no-set case keep the plain text input.
+                const fieldOpts =
+                    cmd.type === 'controller' && cmd.command_name === 'trialParams' &&
+                    k === 'pattern' && activeSet()
+                        ? { patternPicker: true }
+                        : undefined;
                 card.appendChild(
                     renderEditableField(
                         k,
                         [...cmdPath, k],
                         cmd[k],
-                        fieldSchema || FIELD_TYPES[k] || 'string'
+                        fieldSchema || FIELD_TYPES[k] || 'string',
+                        fieldOpts
                     )
                 );
             }
@@ -5765,6 +5916,78 @@
         const psArenaFolder = (arenaConfig) => String(arenaConfig || '').toLowerCase();
         const psBaseUrl = () => (psState.source === 'remote' ? psState.baseUrl.replace(/\/$/, '') : '.');
 
+        // ── LAB-96: active pattern set (the Pattern Set builder's in-memory set) ──────
+        // The picker reads the SAME set the builder holds, so a picked name resolves to
+        // the exact 1-based SD index that bundle exports. Returns null unless the set has
+        // ≥1 valid item AND matches the rig's arena (a stale arena = ignored).
+        function activeSet() {
+            const s = psState.set;
+            if (!s || !s.items || !s.items.length) return null;
+            if (s.arenaConfig !== rigArenaConfig()) return null;
+            return s.items.some((it) => it.valid) ? s : null;
+        }
+        function activeSetValidItems() {
+            const s = activeSet();
+            return s ? s.items.filter((it) => it.valid) : [];
+        }
+        function activeSetItemByName(name) {
+            const s = activeSet();
+            return s ? s.items.find((it) => it.valid && it.name === name) || null : null;
+        }
+        // 1-based SD index for a name (assignIndices numbers the ordered items; the
+        // exported bundle uses the same order). null when the name isn't a valid item.
+        function activeSetIndexByName(name) {
+            const s = activeSet();
+            if (!s) return null;
+            window.PatternSet.assignIndices(s);
+            const it = s.items.find((x) => x.name === name);
+            return it && it.valid ? it.index : null;
+        }
+        // Badge helper: does this condition's trialParams `pattern` resolve in the set?
+        function conditionPatternInActiveSet(cond) {
+            const cmd = RunnerLib.findTrialParams(cond);
+            return !!(cmd && activeSetIndexByName(cmd.pattern) != null);
+        }
+        // Build an animated preview (hover-cycles ≤10 sampled frames) for a set pattern
+        // by name — the pattern_editor tray mechanism via PatPreview + icon-generator.
+        // Returns a DOM node, or null if it can't render (no item / no arena / no frames).
+        function buildActiveSetPreview(name) {
+            const item = activeSetItemByName(name);
+            if (!item || !item.parsed) return null;
+            const cfg = getConfig(rigArenaConfig());
+            if (!cfg || !cfg.arena) return null;
+            const sampled = window.PatPreview.samplePreviewFrames(item.parsed, cfg.arena, {
+                renderIcon: generatePatternIcon,
+                iconOpts: { width: 96, height: 96, backgroundColor: '#1a1f26',
+                    innerRadiusRatio: 0.4, padding: 2, showGaps: false, showOutlines: false }
+            });
+            const frames = sampled.frames;
+            if (!frames.length) return null;
+            const meta = item.preview || {};
+            const container = el('div', { class: 'pat-preview' });
+            const img = el('img', {
+                src: frames[sampled.staticIndex], alt: name + ' preview',
+                title: name + ' — ' + (meta.frames || 1) + ' frame' + ((meta.frames || 1) === 1 ? '' : 's') +
+                    ' · GS' + (meta.gs || '?') + (frames.length > 1 ? ' · hover to animate' : '')
+            });
+            container.appendChild(img);
+            if ((meta.frames || 1) > 1) {
+                container.appendChild(el('span', { class: 'pat-preview-badge' }, meta.frames + 'f'));
+            }
+            if (frames.length > 1) {
+                let iv = null, k = 0;
+                container.addEventListener('mouseenter', () => {
+                    k = 0;
+                    iv = setInterval(() => { k = (k + 1) % frames.length; img.src = frames[k]; }, 150);
+                });
+                container.addEventListener('mouseleave', () => {
+                    if (iv) { clearInterval(iv); iv = null; }
+                    img.src = frames[sampled.staticIndex];
+                });
+            }
+            return container;
+        }
+
         function psEnsureModal() {
             if (psEl) return psEl;
             const arenaSpan = el('span', { class: 'ps-arena' });
@@ -5858,7 +6081,12 @@
             e.arenaSpan.appendChild(el('span', {}, 'Arena: '));
             e.arenaSpan.appendChild(el('span', { class: 'locked',
                 title: 'Locked — set by the rig' }, ((cfg && cfg.label) || arena) + ' (locked, from rig)'));
-            psState.set = window.PatternSet.createPatternSet({ arenaConfig: arena });
+            // Create-or-keep: the picker (LAB-96) reads psState.set as the active set,
+            // so don't wipe a set the user already built. Recreate only when there is no
+            // set yet, or the rig arena changed under it.
+            if (!psState.set || psState.set.arenaConfig !== arena) {
+                psState.set = window.PatternSet.createPatternSet({ arenaConfig: arena });
+            }
             psState.available = [];
             psState.searchText = '';
             e.search.value = '';

--- a/js/pat-preview.js
+++ b/js/pat-preview.js
@@ -1,0 +1,156 @@
+/**
+ * pat-preview.js — animated .pat thumbnail sampler for the pattern pickers (LAB-95/96).
+ *
+ * Shared by the v3 Experiment Designer pattern picker and the Arena Console picker.
+ * Replicates the pattern_editor clipboard tray's "animated thumbnail" trick: render a
+ * handful of evenly-sampled frames to small cylindrical icons, keep the middle one as
+ * the static image, and let the caller cycle `img.src` through the rest on hover. This
+ * is far cheaper than encoding a real GIF (bounded to `max` renders even for a
+ * 200-frame pattern) and reuses icon-generator's `generatePatternIcon`.
+ *
+ * Pure orchestration: it never imports icon-generator or touches the arena registry —
+ * the per-frame renderer is INJECTED (`opts.renderIcon`, the caller's
+ * `generatePatternIcon`). The only DOM use is the optional flat-canvas fallback, which
+ * is guarded by `typeof document` so this file `require()`s cleanly in Node. Mirrors
+ * pattern-set.js's dependency-injection + dual-export style (window global + Node
+ * CommonJS, NO bare ES `export`) so it loads as a plain <script src> in both tools and
+ * can't trigger the catastrophic ES-module import-failure gotcha.
+ */
+(function () {
+    'use strict';
+
+    var DEFAULT_MAX = 10;
+    var DEFAULT_SIZE = 72;
+
+    /**
+     * Pick up to `max` evenly-spaced frame indices from a [0, numFrames) range.
+     * Matches pattern_editor's frameStep sampling (floor(numFrames/max), capped).
+     */
+    function pickFrameIndices(numFrames, max) {
+        max = max || DEFAULT_MAX;
+        var n = numFrames | 0;
+        if (n <= 0) return [];
+        if (n <= max) {
+            var all = [];
+            for (var i = 0; i < n; i++) all.push(i);
+            return all;
+        }
+        var step = Math.max(1, Math.floor(n / max));
+        var idxs = [];
+        for (var f = 0; f < n && idxs.length < max; f += step) idxs.push(f);
+        return idxs;
+    }
+
+    /**
+     * Flat (rectangular) thumbnail of one frame → PNG dataURL. Green-phosphor ramp,
+     * row 0 at the bottom — mirrors pattern_editor's generateThumbnail. Browser-only:
+     * returns null where there is no `document` (Node) so callers can skip gracefully.
+     */
+    function renderFlatFrame(frameData, pixelRows, pixelCols, gsVal, size) {
+        if (typeof document === 'undefined' || !frameData || !pixelRows || !pixelCols) {
+            return null;
+        }
+        size = size || DEFAULT_SIZE;
+        var canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        var ctx = canvas.getContext('2d');
+        var scaleX = size / pixelCols;
+        var scaleY = size / pixelRows;
+        var maxVal = gsVal === 2 ? 1 : 15;
+        for (var row = 0; row < pixelRows; row++) {
+            for (var col = 0; col < pixelCols; col++) {
+                var value = frameData[row * pixelCols + col];
+                var brightness = value / maxVal;
+                if (brightness > 0) {
+                    var r = Math.round(brightness * 0.6 * 255);
+                    var g = Math.round(brightness * 255);
+                    var b = Math.round(brightness * 0.2 * 255);
+                    ctx.fillStyle = 'rgb(' + r + ',' + g + ',' + b + ')';
+                } else {
+                    ctx.fillStyle = '#1e2329';
+                }
+                // flip Y so row 0 sits at the bottom
+                var y = (pixelRows - 1 - row) * scaleY;
+                ctx.fillRect(col * scaleX, y, Math.ceil(scaleX), Math.ceil(scaleY));
+            }
+        }
+        return canvas.toDataURL();
+    }
+
+    /**
+     * Render the animated-preview frame set for a parsed .pat.
+     * @param parsed       pat-parser output ({ frames, pixelRows, pixelCols, gs_val, … }).
+     * @param arenaConfig  the arena object (getConfig(name).arena) for the cylindrical icon.
+     * @param opts {
+     *   max         max frames to sample (default 10),
+     *   renderIcon  REQUIRED (parsed, arenaConfig, iconOpts) → dataURL  (generatePatternIcon),
+     *   iconOpts    extra options merged into each renderIcon call (width/height/colors…),
+     *   flatFallback  use renderFlatFrame when renderIcon throws (default true)
+     * }
+     * @returns { frames: [dataURL…], staticIndex } — staticIndex = the middle frame.
+     */
+    function samplePreviewFrames(parsed, arenaConfig, opts) {
+        opts = opts || {};
+        var renderIcon = opts.renderIcon;
+        var iconOpts = opts.iconOpts || {};
+        var useFlat = opts.flatFallback !== false;
+        var size = iconOpts.width || DEFAULT_SIZE;
+        var numFrames = parsed && parsed.frames ? parsed.frames.length : 0;
+        var idxs = pickFrameIndices(numFrames, opts.max || DEFAULT_MAX);
+        var frames = [];
+        for (var k = 0; k < idxs.length; k++) {
+            var frameIndex = idxs[k];
+            var url = null;
+            if (typeof renderIcon === 'function') {
+                try {
+                    url = renderIcon(
+                        parsed,
+                        arenaConfig,
+                        merge(iconOpts, { frameIndex: frameIndex })
+                    );
+                } catch (e) {
+                    url = null;
+                }
+            }
+            if (!url && useFlat) {
+                url = renderFlatFrame(
+                    parsed.frames[frameIndex],
+                    parsed.pixelRows,
+                    parsed.pixelCols,
+                    parsed.gs_val,
+                    size
+                );
+            }
+            if (url) frames.push(url);
+        }
+        return { frames: frames, staticIndex: frames.length ? Math.floor(frames.length / 2) : 0 };
+    }
+
+    /** Shallow merge (Object.assign is fine in browser + Node, but keep it explicit). */
+    function merge(a, b) {
+        var out = {};
+        var k;
+        for (k in a) if (Object.prototype.hasOwnProperty.call(a, k)) out[k] = a[k];
+        for (k in b) if (Object.prototype.hasOwnProperty.call(b, k)) out[k] = b[k];
+        return out;
+    }
+
+    var PatPreview = {
+        DEFAULT_MAX: DEFAULT_MAX,
+        DEFAULT_SIZE: DEFAULT_SIZE,
+        pickFrameIndices: pickFrameIndices,
+        renderFlatFrame: renderFlatFrame,
+        samplePreviewFrames: samplePreviewFrames
+    };
+
+    // Dual export — browser global + Node (CommonJS). Deliberately NO bare top-level ES
+    // `export`, so this is safe to load as a plain <script src> (window global) in both
+    // tools, mirroring js/pattern-set.js and js/pat-encoder.js.
+    if (typeof window !== 'undefined') {
+        window.PatPreview = PatPreview;
+    }
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = PatPreview;
+    }
+})();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.1",
     "description": "Web-based tools for configuring and editing display patterns for modular arena systems",
     "scripts": {
-        "test": "node tests/validate-arena-calculations.js && node tests/test-protocol-roundtrip.js && node tests/test-protocol-roundtrip-v3.js && node tests/test-arena-wire-g6.js && node tests/test-arena-link.js && node tests/test-arena-runner-g6.js && node tests/test-pattern-set.js",
+        "test": "node tests/validate-arena-calculations.js && node tests/test-protocol-roundtrip.js && node tests/test-protocol-roundtrip-v3.js && node tests/test-arena-wire-g6.js && node tests/test-arena-link.js && node tests/test-arena-runner-g6.js && node tests/test-pattern-set.js && node tests/test-pat-preview.js",
         "test:arena": "node tests/validate-arena-calculations.js",
         "test:protocol-v2": "node tests/test-protocol-roundtrip.js",
         "test:protocol-v3": "node tests/test-protocol-roundtrip-v3.js",
@@ -11,6 +11,7 @@
         "test:link": "node tests/test-arena-link.js",
         "test:runner": "node tests/test-arena-runner-g6.js",
         "test:pattern-set": "node tests/test-pattern-set.js",
+        "test:pat-preview": "node tests/test-pat-preview.js",
         "validate": "node tests/validate-arena-calculations.js",
         "format": "prettier --write \"**/*.js\"",
         "format:check": "prettier --check \"**/*.js\""

--- a/tests/test-pat-preview.js
+++ b/tests/test-pat-preview.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Tests for js/pat-preview.js (LAB-95/96) — browser-free.
+ *
+ * pat-preview is pure orchestration: it samples evenly-spaced frame indices and calls
+ * an INJECTED per-frame renderer (the browser passes icon-generator's
+ * generatePatternIcon). Here we inject a string stub so the sampling logic, the
+ * frameIndex pass-through, iconOpts merging, the staticIndex (middle frame), and the
+ * skip-on-throw path are all exercised without a DOM. The DOM flat fallback is
+ * browser-verified; in Node renderFlatFrame must return null (no document).
+ */
+
+const PP = require('../js/pat-preview.js');
+
+let totalChecks = 0;
+let failures = 0;
+
+function check(name, got, expected) {
+    totalChecks++;
+    const ok = JSON.stringify(got) === JSON.stringify(expected);
+    console.log(
+        `  ${ok ? 'PASS' : 'FAIL'}  ${name}: got ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`
+    );
+    if (!ok) failures++;
+}
+
+function checkBool(name, ok, info) {
+    totalChecks++;
+    console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${info ? ' — ' + info : ''}`);
+    if (!ok) failures++;
+}
+
+/** Build a fake pat-parser output with N frames (pixel data unused by the stub). */
+function fakeParsed(n) {
+    const frames = [];
+    for (let i = 0; i < n; i++) frames.push(new Uint8Array(40 * 200));
+    return { frames, pixelRows: 40, pixelCols: 200, gs_val: 2, numFrames: n };
+}
+
+// ── 1. pickFrameIndices ─────────────────────────────────────────────────────────
+console.log('\n=== pickFrameIndices ===');
+check('0 frames → []', PP.pickFrameIndices(0, 10), []);
+check('n <= max → all indices', PP.pickFrameIndices(4, 10), [0, 1, 2, 3]);
+check('n == max → all indices', PP.pickFrameIndices(10, 10), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+check(
+    '200 frames, max 10 → step 20',
+    PP.pickFrameIndices(200, 10),
+    [0, 20, 40, 60, 80, 100, 120, 140, 160, 180]
+);
+checkBool('never exceeds max (200,10)', PP.pickFrameIndices(200, 10).length === 10);
+checkBool('never exceeds max (15,10)', PP.pickFrameIndices(15, 10).length <= 10);
+checkBool('default max applies when omitted', PP.pickFrameIndices(200).length === PP.DEFAULT_MAX);
+
+// ── 2. samplePreviewFrames — sampling, staticIndex, frameIndex pass-through ───────
+console.log('\n=== samplePreviewFrames (stub renderIcon) ===');
+{
+    const seen = [];
+    const renderIcon = (parsed, arena, opts) => {
+        seen.push(opts.frameIndex);
+        return 'icon-' + opts.frameIndex;
+    };
+    const res = PP.samplePreviewFrames(fakeParsed(5), { generation: 'G6' }, { renderIcon });
+    check('5 frames → 5 thumbs', res.frames, ['icon-0', 'icon-1', 'icon-2', 'icon-3', 'icon-4']);
+    check('staticIndex = middle (5)', res.staticIndex, 2);
+    check('renderIcon got each frameIndex', seen, [0, 1, 2, 3, 4]);
+}
+{
+    const res = PP.samplePreviewFrames(
+        fakeParsed(200),
+        { generation: 'G6' },
+        {
+            renderIcon: (p, a, o) => 'f' + o.frameIndex
+        }
+    );
+    checkBool('200 frames capped to 10 thumbs', res.frames.length === 10, res.frames.join(','));
+    check('staticIndex = middle (10)', res.staticIndex, 5);
+}
+{
+    // iconOpts merged into each call (width passed through alongside frameIndex)
+    let sawWidth = null;
+    PP.samplePreviewFrames(
+        fakeParsed(3),
+        {},
+        {
+            renderIcon: (p, a, o) => {
+                sawWidth = o.width;
+                return 'x';
+            },
+            iconOpts: { width: 96 }
+        }
+    );
+    check('iconOpts.width passed through', sawWidth, 96);
+}
+
+// ── 3. skip-on-throw (no flat fallback in Node) ──────────────────────────────────
+console.log('\n=== samplePreviewFrames (renderIcon throws) ===');
+{
+    const res = PP.samplePreviewFrames(
+        fakeParsed(4),
+        {},
+        {
+            renderIcon: () => {
+                throw new Error('boom');
+            },
+            flatFallback: false
+        }
+    );
+    check('all throws skipped → []', res.frames, []);
+    check('empty staticIndex = 0', res.staticIndex, 0);
+}
+{
+    // flatFallback defaults on, but Node has no document → renderFlatFrame returns null → skipped
+    const res = PP.samplePreviewFrames(
+        fakeParsed(4),
+        {},
+        {
+            renderIcon: () => {
+                throw new Error('boom');
+            }
+        }
+    );
+    check('throws + no DOM flat → []', res.frames, []);
+}
+
+// ── 4. renderFlatFrame is null in Node ───────────────────────────────────────────
+console.log('\n=== renderFlatFrame (Node, no document) ===');
+checkBool(
+    'returns null without a document',
+    PP.renderFlatFrame(new Uint8Array(10), 2, 5, 2, 64) === null
+);
+
+console.log('\n=== Summary ===');
+console.log(`${totalChecks - failures} / ${totalChecks} checks passed`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Backs the v3 Experiment Designer and Arena Console `trial_params` pattern fields with the active pattern-set manifest (LAB-92): **pick by name + animated preview**, carrying both the **SD index** (`pattern_ID`, browser runner) and the **MATLAB path** (`pattern`). Retires the dry-run's confirm-once index dialog.

**W / C source** (per design): each trialParams pattern shows a prominent **W · web** (in the active set) or **C · computer** (MATLAB path) chip — in the inspector field and on every library row.

- **`js/pat-preview.js`** (new; dual-export, dependency-injected) — `samplePreviewFrames` renders ≤10 sampled cylindrical-icon frames, hover-cycled like the pattern_editor tray. `tests/test-pat-preview.js` (17 checks) wired into `npm test`.
- **v3 designer (LAB-96, v0.28)** — `trialParams.pattern` → W/C picker; new conditions default to the set's first pattern; dry-run resolves the index by name (falls back to the protocol's `pattern_ID` for legacy YAMLs).
- **Arena Console (LAB-95, v2)** — auto-loads the served built-in manifest on startup + a "Load set…" folder override; name dropdown + preview fills the 1-based SD index sent via `trial_params`.

Verified: `npm test` green (incl. 17 new checks), browser-tested (picker, preview, W↔C, export carries both fields, backward-compat). Hardware send is the bench acceptance step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)