### PR TITLE
fix(g6): pattern-picker UX polish — in-column preview, locked console index, neg-rate msg [LAB-95, LAB-96]

### DIFF
--- a/arena_console.html
+++ b/arena_console.html
@@ -242,6 +242,12 @@
                 border-radius: 3px;
                 font-family: 'JetBrains Mono', monospace;
             }
+            /* LAB-95: the pattern # is locked (driven by the name dropdown) when a set is loaded. */
+            #tp-pat[readonly] {
+                opacity: 0.55;
+                cursor: not-allowed;
+                background: var(--surface);
+            }
         </style>
     </head>
     <body>
@@ -314,7 +320,7 @@
                     <label title="Active pattern set (manifest.json)">set</label>
                     <button
                         id="btn-loadset"
-                        title="Load a built SD-bundle folder (manifest.json + patterns/) to pick patterns by name + preview. Defaults to the built-in library served with this tool."
+                        title="Point at a built SD-bundle FOLDER — the unzipped Export-ZIP from the Pattern Set builder (a folder with manifest.json + a patterns/ subfolder), or the SD card if you copied the whole bundle onto it. The arena's built-in library loads automatically; use this only for a custom set."
                     >
                         Load set…
                     </button>
@@ -483,7 +489,7 @@
             diagnose framing problems.
         </div>
 
-        <footer id="footer">Arena Console v2 | 2026-06-10 19:58 ET</footer>
+        <footer id="footer">Arena Console v3 | 2026-06-11 07:01 ET</footer>
 
         <!-- Milestone-A substrate — window-global dual-export path (no build, no ES import). -->
         <script src="js/arena-wire-g6.js"></script>
@@ -638,6 +644,13 @@
                         gain: parseInt($('tp-gain').value, 10),
                         initPos: parseInt($('tp-init').value, 10)
                     };
+                    if (p.frameRate < 0) {
+                        log(
+                            'Negative frame rate isn’t supported in open-loop (Mode 2) — the controller advances frames forward only. For reverse playback, use Mode 4 (closed-loop) with a negative gain.',
+                            'err'
+                        );
+                        return;
+                    }
                     try {
                         run(
                             `trial-params ${JSON.stringify(p)}`,
@@ -678,6 +691,17 @@
 
             const BUILTIN_BASE = './patterns/g6_2x10/'; // the served default library
 
+            // #tp-pat is the raw SD index. When a set is loaded the name dropdown drives
+            // it, so lock it (read-only) to avoid a confusing second entry point; unlock
+            // it when there's no set so the console still works as a raw index sender.
+            const PAT_RAW_TITLE = tpPat.title;
+            function lockPat(locked) {
+                tpPat.readOnly = locked;
+                tpPat.title = locked
+                    ? 'Driven by the pattern name above — the resolved 1-based SD index sent via trial_params. (Clear/replace the set to enter an index by hand.)'
+                    : PAT_RAW_TITLE;
+            }
+
             let activeManifest = null;
             let byteSource = null; // (sd_name) => Promise<ArrayBuffer>
             let previewCache = {};
@@ -707,6 +731,7 @@
                     o.textContent = '(empty set)';
                     nameSel.appendChild(o);
                     previewHost.innerHTML = '';
+                    lockPat(false); // no set to drive it → raw index entry stays editable
                     return;
                 }
                 names.sort((a, b) => (m.patterns[a].index || 0) - (m.patterns[b].index || 0));
@@ -719,6 +744,7 @@
                 }
                 nameSel.value = names[0];
                 applyPick(names[0]);
+                lockPat(true); // a set is active → the dropdown drives the SD index
             }
 
             async function renderPreview(name) {
@@ -802,6 +828,7 @@
                     populateDropdown(m);
                 } catch (e) {
                     setStatus('built-in library unavailable — use “Load set…”', 'l-err');
+                    lockPat(false);
                 }
             }
 
@@ -828,6 +855,7 @@
                     populateDropdown(m);
                 } catch (e) {
                     setStatus('load failed: ' + (e.message || e), 'l-err');
+                    lockPat(false);
                 }
             });
 

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -671,8 +671,12 @@
         }
         .wc-w { color: var(--accent); border: 1px solid var(--accent); background: rgba(0, 230, 118, 0.12); }
         .wc-c { color: #6cb1ff; border: 1px solid #3b6ea5; background: rgba(88, 166, 255, 0.12); }
-        /* LAB-96: animated pattern preview next to the picker dropdown. */
-        .pat-preview-host { margin-top: 0.35rem; }
+        /* LAB-96: animated pattern preview. It sits on its OWN full-width line BELOW the
+           picker controls — the pattern kv-line wraps (.kv-pattern) and the host takes
+           flex-basis:100%, so the thumbnail stays inside the inspector column instead of
+           overflowing off the right edge. */
+        .cmd-card .kv-line.kv-pattern { flex-wrap: wrap; }
+        .pat-preview-host { margin-top: 0.35rem; flex-basis: 100%; }
         .pat-preview { position: relative; display: inline-block; line-height: 0; }
         .pat-preview img {
             width: 96px; height: 96px; border-radius: 6px;
@@ -1492,7 +1496,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.28 | <span id="footerTimestamp">2026-06-10 20:35 ET</span>
+        v3 Experiment Designer v0.29 | <span id="footerTimestamp">2026-06-11 07:01 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -4210,6 +4214,7 @@
         // The dropdown's trailing "C · computer / MATLAB pattern…" option switches to C.
         // Only reached when activeSet() exists (gated at the renderCommandCard call site).
         function renderPatternPickerField(wrapper, path, value, bindBtn) {
+            wrapper.classList.add('kv-pattern'); // let the preview wrap onto its own line
             const items = activeSetValidItems();
             const COMP = '__computer__';
             window.PatternSet.assignIndices(activeSet());


### PR DESCRIPTION
Follow-up polish from live Pages testing of [#99](https://github.com/reiserlab/webDisplayTools/pull/99):

- **v3 designer (v0.29)** — the trialParams pattern **preview now wraps onto its own full-width line below the picker controls** (it was overflowing off the right edge of the inspector). Scoped via `.kv-pattern` flex-wrap.
- **Arena Console (v3)** — **`#tp-pat` (raw SD index) is locked read-only when a set is loaded** (the name dropdown drives it); editable again with no set. Clarified the **"Load set…"** tooltip. **Negative frame rate** now logs a clear message instead of a raw encode error.

**Negative frame rate / reverse playback (firmware finding):** confirmed against `LED-Display_G6_Firmware_Arena/src/CommandProcessor.cpp` that open-loop **Mode 2 is forward-only** — `frame_rate` is `uint16_t` and `serviceOpenLoop` advances `cur_frame_index_ = (… + steps) % frame_count_`. So a negative frame_rate is correctly rejected (it would be read as a large unsigned Hz). Reverse playback already works in **Mode 4** via a **negative `gain`** (signed int8). True open-loop reverse would need a firmware change (read `frame_rate` as `int16_t` + step backward).

Verified on a fresh load: `npm test` exit 0, browser-checked (preview below controls + in-column; console locked field + negative-rate message), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)