### PR TITLE
feat(g6): v3 full-sequence arena runner + controller-palette cleanup [LAB-97]

### DIFF
--- a/docs/development/v3-editor-handoff.md
+++ b/docs/development/v3-editor-handoff.md
@@ -90,7 +90,6 @@ Today `renderEditableField` only branches on `typeHint === 'number'`; `select`
 schema entries fall through to text input. Affects:
 
 - `log.level` (DEBUG / INFO / WARNING / ERROR)
-- `controller.command_name: setColorDepth` → `gs_val` (2 / 16)
 - `controller.command_name: trialParams` → `mode` (2 / 4)
 
 Path: lookup via `getV3CommandParams(experiment, type, pluginName, commandName)`,

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -1696,6 +1696,32 @@
             }
         }
 
+        // On protocol load: if rig_path matches a built-in rig (configs/rigs/index.json),
+        // auto-load it so the arena config resolves and the Pattern Set builder + W/C
+        // pattern resolution work without the user having to re-pick the (already
+        // pre-selected) rig in the dropdown. A non-built-in / local path is left for
+        // Browse… (the browser can't read an arbitrary local filesystem path). Never
+        // marks the doc dirty — onRigEdit is a no-op when the path is unchanged.
+        async function maybeAutoLoadBuiltinRig() {
+            if (!experiment || !experiment.rig_path) return;
+            const want = experiment.rig_path;
+            if (loadedRig && loadedRig.path === want) return; // already resolved
+            if (builtinRigs === null) {
+                try {
+                    const r = await fetch('./configs/rigs/index.json', { cache: 'no-store' });
+                    const j = r.ok ? await r.json() : null;
+                    builtinRigs = j && Array.isArray(j.rigs) ? j.rigs : [];
+                } catch (_) {
+                    builtinRigs = [];
+                }
+            }
+            const match = (builtinRigs || []).find((r) => r.path === want);
+            // The user may have loaded another protocol while we awaited — re-check.
+            if (!match || !experiment || experiment.rig_path !== want) return;
+            await loadBuiltinRig(match.path); // fetch + applyRigData (+ renderSettings)
+            renderAll(); // refresh W/C chips + timeline now that the arena resolves
+        }
+
         // date_created standardized to YYYY-MM-DD (local). toISODate coerces an existing
         // value (ISO with time, or anything Date can parse) to the date part, else ''.
         const pad2 = (n) => String(n).padStart(2, '0');
@@ -1874,6 +1900,10 @@
                 // undo stack (so the wipe is reversible); imports/demos clear it.
                 if (!opts.keepUndo) clearUndo();
                 renderAll();
+                // If the protocol's rig is a bundled one, resolve its arena config now
+                // (async, non-blocking) so the Pattern Set builder + W/C resolution work
+                // without re-picking the pre-selected rig. Local paths are left for Browse….
+                maybeAutoLoadBuiltinRig();
                 $('exportBtn').disabled = false;
                 $('resetBtn').disabled = false;
                 $('addCondBtn').disabled = false;

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -546,6 +546,10 @@
             cursor: not-allowed;
             opacity: 0.5;
         }
+        /* The full-sequence run trigger — emphasized green, mirrors the inspector's
+           "▶ Test on arena" (Test = one trial; Run = the whole sequence). */
+        .zone-head-btn.run-seq-btn { border-color: var(--accent); font-weight: 700; }
+        .zone-head-btn.run-seq-btn:disabled { border-color: var(--border); font-weight: 400; }
         .lib-row .lib-row-dup {
             background: transparent;
             border: 1px solid transparent;
@@ -619,6 +623,7 @@
             flex-shrink: 0;
         }
         .run-status #runStatusMsg { font-weight: 600; color: var(--text); }
+        .run-status-elapsed { font-size: 0.62rem; color: var(--text-dim); font-variant-numeric: tabular-nums; }
         .run-stop-btn:not(:disabled) { border-color: var(--accent); color: var(--accent); }
         .run-status-head { display: flex; align-items: center; gap: 0.5rem; }
         .run-status-dot {
@@ -1448,6 +1453,7 @@
                 <span class="count" id="seqCount">0</span>
                 <button id="addRefBtn" class="zone-head-btn" title="Append a bare reference to an existing condition" disabled>+ Ref</button>
                 <button id="addBlockBtn" class="zone-head-btn" title="Append a new block (group of trials with optional repetition / intertrial)" disabled>+ Block</button>
+                <button id="runSeqBtn" class="zone-head-btn run-seq-btn" title="Run the WHOLE sequence on the arena over Web Serial — conditions × repeats, client-side waits, ITI (controller commands only; plugins are skipped). Trial timing is host-side/best-effort (firmware duration not landed yet) — keep this tab focused; STOP is the primary control." disabled>▶ Run on arena</button>
             </div>
             <div class="zone-body">
                 <div id="sequenceList">
@@ -1472,6 +1478,7 @@
                 <div class="run-status-head">
                     <span class="run-status-dot" id="runStatusDot"></span>
                     <span id="runStatusMsg">Idle</span>
+                    <span id="runStatusElapsed" class="run-status-elapsed"></span>
                     <span class="run-status-spacer"></span>
                     <button id="runStopBtn" class="header-btn run-stop-btn" title="Stop the running pattern (STOP_DISPLAY 0x30) — best-effort; won't fire if the tab is closed" disabled>Stop</button>
                     <button id="runDisconnectBtn" class="header-btn" title="Close the serial connection to the arena" disabled>Disconnect</button>
@@ -1496,7 +1503,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.29 | <span id="footerTimestamp">2026-06-11 07:01 ET</span>
+        v3 Experiment Designer v0.30 | <span id="footerTimestamp">2026-06-11 10:31 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -1578,6 +1585,7 @@
             getV3PluginCommands,
             listV3PluginNames,
             getV3CommandParams,
+            isKnownControllerCommand,
             BUILTIN_PLUGINS,
             createPluginEntry,
             mapRigPluginToBuiltin,
@@ -3185,7 +3193,7 @@
         // Controls disabled while "yours" is locked (design fix #8 — lock at the
         // UI, not by suppressing pushUndo, since commit itself pushes one undo).
         const IMPORT_LOCKED_CONTROLS = [
-            'addCondBtn', 'addRefBtn', 'addBlockBtn', 'exportBtn', 'resetBtn',
+            'addCondBtn', 'addRefBtn', 'addBlockBtn', 'runSeqBtn', 'exportBtn', 'resetBtn',
             'undoBtn', 'redoBtn', 'newBtn', 'importBtn', 'importFromBtn', 'demoSelect',
             'settingsToggle', 'librarySearch'
         ];
@@ -4058,7 +4066,6 @@
             'frame_index': 'number',
             'frame_rate': 'number',
             'gain': 'number',
-            'gs_val': 'number',
             'posX': 'number',
             'command_name': 'string',
             'plugin_name': 'string'
@@ -4134,7 +4141,7 @@
                 }
                 select.addEventListener('change', () => {
                     // Match the picked string back to the option's original
-                    // value type (numeric for mode/gs_val, string for log.level)
+                    // value type (numeric for mode, string for log.level)
                     const picked = schema.options.find((o) => String(o.value) === select.value);
                     if (!picked) return;
                     if (picked.value === value) return;
@@ -5142,14 +5149,48 @@
                 msg.textContent = 'Disconnected';
                 dot.className = 'run-status-dot';
             } else if (phase === 'error') {
-                const m = s.error && (s.error.message || s.error);
-                msg.textContent = 'Error: ' + m;
-                dot.className = 'run-status-dot error';
+                // Shared by the single-trial path ({error}) and per-step sequence
+                // errors ({reason, step}). A step-scoped error is non-fatal
+                // (proceed-and-skip) — log it but keep the run's running indicator;
+                // a fatal/connection error (no step) sets the red dot + message.
+                const m = (s.error && (s.error.message || s.error)) || s.reason || 'unknown error';
                 runLog('error: ' + m, true);
+                if (!s.step) {
+                    msg.textContent = 'Error: ' + m;
+                    dot.className = 'run-status-dot error';
+                }
+            } else if (phase === 'sequence-start') {
+                msg.textContent = 'Running sequence — ' + (s.total || 0) + ' step' + (s.total === 1 ? '' : 's');
+                dot.className = 'run-status-dot running';
+                runLog('▶ sequence started: ' + (s.total || 0) + ' steps · host-side timing (best-effort) · STOP is primary');
+            } else if (phase === 'step-start') {
+                msg.textContent = seqMsg(s);
+                dot.className = 'run-status-dot running';
+            } else if (phase === 'trial-running') {
+                runLog(seqLine(s) + ' → trial running (' + (s.durationSec || 0) + 's host-side)');
+            } else if (phase === 'command') {
+                runLog(seqLine(s) + ' → ' + s.op + (s.value !== undefined ? ' ' + s.value : ''));
+            } else if (phase === 'skip') {
+                const what = s.plugin_name ? s.plugin_name + '.' + s.command_name : (s.step ? s.step.conditionName : '');
+                runLog('skipped ' + what + ' — ' + (s.reason || ''), true);
+            } else if (phase === 'step-done') {
+                // the message already reflects the current step; nothing to do
+            } else if (phase === 'sequence-complete') {
+                const sm = s.summary || {};
+                msg.textContent = 'Sequence complete — ' + (sm.steps || 0) + ' steps' +
+                    (sm.skipped ? ', ' + sm.skipped + ' skipped' : '') +
+                    (sm.errors ? ', ' + sm.errors + ' error' + (sm.errors === 1 ? '' : 's') : '');
+                dot.className = 'run-status-dot connected';
+                runLog('✓ sequence complete');
+            } else if (phase === 'aborted') {
+                msg.textContent = 'Sequence stopped (STOP)';
+                dot.className = 'run-status-dot connected';
+                runLog('■ sequence aborted by STOP');
             }
             // Button states reflect live link/runner state.
             $('runStopBtn').disabled = !(arenaRunner && arenaRunner.active);
             $('runDisconnectBtn').disabled = !(arenaLink && arenaLink.connected);
+            updateRunSeqBtn();
         }
 
         async function onRunConditionDryRun(condIdx) {
@@ -5307,6 +5348,237 @@
             if (arenaRunner && arenaRunner.active) return; // don't hide mid-run
             $('runStatus').style.display = 'none';
         });
+
+        // ── LAB-97: full-sequence runner (host-side timing, no plugins) ──────
+        $('runSeqBtn').addEventListener('click', onRunSequence);
+
+        let seqElapsedTimer = null; // live elapsed clock during a sequence run
+        let seqStartMs = 0;
+
+        // Enable "▶ Run on arena" only when a sequence can actually run. Called from
+        // renderAll (load/edit/import-exit) and updateRunStatus (run transitions);
+        // import mode is handled via IMPORT_LOCKED_CONTROLS too.
+        function updateRunSeqBtn() {
+            const btn = $('runSeqBtn');
+            if (!btn) return;
+            const empty =
+                !experiment || !Array.isArray(experiment.sequence) || experiment.sequence.length === 0;
+            btn.disabled =
+                !serialSupported || importMode || empty || !!(arenaRunner && arenaRunner.active);
+        }
+
+        // 1-based SD index for a trialParams command: prefer the active web set
+        // (LAB-95/96), fall back to the protocol's pattern_ID, else null (the runner
+        // surfaces an error + skips the step — the proceed-and-skip policy).
+        function resolvePatternIdForCmd(cmd) {
+            const id = activeSetIndexByName(cmd.pattern);
+            if (id != null) return id;
+            const pid = Number(cmd.pattern_ID);
+            return Number.isInteger(pid) && pid >= 1 ? pid : null;
+        }
+
+        // Fisher–Yates in place — randomized blocks at run time. The timeline preview
+        // passes NO shuffle, so it stays in nominal order.
+        function shuffleInPlace(arr) {
+            for (let i = arr.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                const tmp = arr[i];
+                arr[i] = arr[j];
+                arr[j] = tmp;
+            }
+            return arr;
+        }
+
+        function fmtDuration(sec) {
+            sec = Math.round(Number(sec) || 0);
+            if (sec < 60) return sec + 's';
+            const m = Math.floor(sec / 60);
+            const s = sec % 60;
+            return s === 0 ? m + 'm' : m + 'm ' + s + 's';
+        }
+
+        function fmtElapsed(ms) {
+            const total = Math.floor((Number(ms) || 0) / 1000);
+            const m = Math.floor(total / 60);
+            const s = total % 60;
+            return m + ':' + String(s).padStart(2, '0');
+        }
+
+        // Compact "(block · ITI · rep N/M)" suffix for a step.
+        function seqStepLabel(step) {
+            if (!step) return '';
+            const bits = [];
+            if (step.blockName) bits.push(step.blockName);
+            if (step.kind === 'iti') bits.push('ITI');
+            if (typeof step.rep === 'number' && step.repsTotal) {
+                bits.push('rep ' + (step.rep + 1) + '/' + step.repsTotal);
+            }
+            return bits.length ? ' (' + bits.join(' · ') + ')' : '';
+        }
+
+        // Main status line for a step (step i/total · condition · block/rep · next).
+        function seqMsg(s) {
+            const step = s.step || {};
+            const n = s.index != null ? s.index + 1 : '?';
+            const total = s.total || '?';
+            let m = 'step ' + n + '/' + total + ': ' + (step.conditionName || '') + seqStepLabel(step);
+            if (s.next && s.next.conditionName) m += '  → next: ' + s.next.conditionName;
+            return m;
+        }
+
+        // Short per-step log prefix.
+        function seqLine(s) {
+            const step = s.step || {};
+            const n = s.index != null ? s.index + 1 : '?';
+            return '[' + n + '] ' + (step.conditionName || '');
+        }
+
+        function seqRunStart() {
+            seqStartMs = Date.now();
+            if (seqElapsedTimer) clearInterval(seqElapsedTimer);
+            const tick = () => {
+                const e = $('runStatusElapsed');
+                if (e) e.textContent = '⏱ ' + fmtElapsed(Date.now() - seqStartMs);
+            };
+            tick();
+            seqElapsedTimer = setInterval(tick, 500);
+        }
+
+        function seqRunStop() {
+            if (seqElapsedTimer) {
+                clearInterval(seqElapsedTimer);
+                seqElapsedTimer = null;
+            }
+        }
+
+        // Pre-run check: flatten (nominal), classify every referenced condition, and
+        // show a confirm modal listing what will run / be skipped before connecting.
+        function preRunCheck() {
+            const { steps, hasRandom } = RunnerLib.flattenStructure(experiment);
+            const byName = new Map(experiment.conditions.map((c) => [c.name, c]));
+            const totalDur = steps.reduce((sum, x) => sum + (x.dur || 0), 0);
+            const names = [...new Set(steps.map((x) => x.conditionName))];
+            let wCount = 0;
+            let cCount = 0;
+            const unresolvable = [];
+            const missingConds = [];
+            const pluginSkips = [];
+            const unsupported = [];
+            for (const name of names) {
+                const cond = byName.get(name);
+                if (!cond || !Array.isArray(cond.commands)) {
+                    missingConds.push(name);
+                    continue;
+                }
+                const tp = RunnerLib.findTrialParams(cond);
+                if (tp) {
+                    if (activeSetIndexByName(tp.pattern) != null) wCount++;
+                    else {
+                        const pid = Number(tp.pattern_ID);
+                        if (Number.isInteger(pid) && pid >= 1) cCount++;
+                        else unresolvable.push(name + ' ("' + (tp.pattern || '') + '")');
+                    }
+                }
+                for (const c of cond.commands) {
+                    if (c.type === 'plugin') {
+                        pluginSkips.push(
+                            name + ': ' + (c.plugin_name || '?') + '.' + (c.command_name || '?')
+                        );
+                    }
+                    if (c.type === 'controller' && !isKnownControllerCommand(c.command_name)) {
+                        unsupported.push(name + ': ' + c.command_name);
+                    }
+                }
+            }
+            const list = [];
+            list.push(
+                steps.length + ' step' + (steps.length === 1 ? '' : 's') +
+                    ' · ~' + fmtDuration(totalDur) + ' total (host-side timing, best-effort)'
+            );
+            if (wCount || cCount) {
+                list.push(
+                    wCount + ' web pattern (W, active set) · ' + cCount + ' computer (C, protocol pattern_ID)'
+                );
+            }
+            if (hasRandom) list.push('Randomized block(s): trial order is shuffled at run time');
+            for (const u of unresolvable) list.push('⚠ pattern not resolvable — step SKIPPED: ' + u);
+            for (const m of missingConds) list.push('⚠ missing condition — step SKIPPED: ' + m);
+            if (pluginSkips.length) {
+                list.push(
+                    '⚠ ' + pluginSkips.length + ' plugin command' +
+                        (pluginSkips.length === 1 ? '' : 's') + ' SKIPPED: ' + pluginSkips.join(', ')
+                );
+            }
+            for (const u of unsupported) {
+                list.push('⚠ unsupported controller command (errors + skips): ' + u);
+            }
+            return confirmModal({
+                title: 'Run the whole sequence on the arena?',
+                body:
+                    'Walks the experiment_structure and replays each condition’s controller ' +
+                    'commands + client-side waits over Web Serial. Trial timing is host-side ' +
+                    '(best-effort) until the controller-run duration lands in firmware — keep this ' +
+                    'tab focused; STOP is the primary control. Plugins are skipped (the browser ' +
+                    'cannot drive them).',
+                list,
+                confirmLabel: 'Connect & run',
+                cancelLabel: 'Cancel'
+            });
+        }
+
+        // Entry point for the full-sequence run. Run-START is import-mode guarded and
+        // read-only (no pushUndo/setDirty); Stop/Disconnect stay usable.
+        async function onRunSequence() {
+            if (!experiment || importMode) return;
+            if (!serialSupported) {
+                showError(
+                    'Web Serial unavailable',
+                    'This browser cannot talk to the arena. Use Chrome, Edge, or another ' +
+                        'Chromium-based desktop browser to run the sequence over Web Serial.'
+                );
+                return;
+            }
+            if (!Array.isArray(experiment.sequence) || experiment.sequence.length === 0) {
+                showError('Empty sequence', 'Add conditions or blocks to the sequence before running.');
+                return;
+            }
+            const ok = await preRunCheck();
+            if (!ok) return;
+
+            // Connect-on-demand: the confirm-button click is a fresh user gesture, and
+            // connect() is the first await after it resolves, so requestPort() runs
+            // inside that activation.
+            const { link, runner } = ensureArena();
+            $('runStatus').style.display = 'block';
+            $('runStatusLog').innerHTML = '';
+            try {
+                if (!link.connected) {
+                    updateRunStatus({ phase: 'connecting' });
+                    await link.connect();
+                }
+            } catch (e) {
+                updateRunStatus({ phase: 'error', error: e });
+                return;
+            }
+
+            // Build the flattened steps WITH a per-rep shuffle for randomized blocks.
+            const { steps } = RunnerLib.flattenStructure(experiment, { shuffle: shuffleInPlace });
+            const conditionsByName = new Map(experiment.conditions.map((c) => [c.name, c]));
+            try {
+                if (runner.active) await runner.stop();
+                seqRunStart();
+                await runner.runSequence({
+                    steps,
+                    conditionsByName,
+                    resolvePatternId: resolvePatternIdForCmd,
+                    onProgress: updateRunStatus
+                });
+            } catch (e) {
+                updateRunStatus({ phase: 'error', error: e });
+            } finally {
+                seqRunStop();
+            }
+        }
 
         async function onDeleteCondition(condIdx) {
             if (!experiment || importMode) return;
@@ -5524,6 +5796,16 @@
                 head.appendChild(document.createTextNode('wait'));
             } else {
                 head.appendChild(document.createTextNode(cmd.command_name || ''));
+                // Flag controller commands that aren't in the G6 palette (e.g. a
+                // legacy setColorDepth → SWITCH_GRAYSCALE 0x06, dropped on G6). The
+                // command is preserved on export, but the arena runner will skip it
+                // with an error rather than emit a dropped/no-op opcode.
+                if (cmd.command_name && !isKnownControllerCommand(cmd.command_name)) {
+                    head.appendChild(el('span', {
+                        class: 'raw-badge',
+                        title: 'Unsupported controller command on G6 — preserved on export, but the arena runner will skip it with an error. (e.g. setColorDepth maps to SWITCH_GRAYSCALE 0x06, which was dropped on G6 — color depth is set in the .pat/SD header, not at runtime.)'
+                    }, '⚠ unsupported'));
+                }
             }
             card.appendChild(head);
 
@@ -5555,13 +5837,13 @@
             card.appendChild(actions);
 
             const detailKeys = {
-                controller: ['command_name', 'pattern', 'pattern_ID', 'duration', 'mode', 'frame_index', 'frame_rate', 'gain', 'gs_val', 'posX'],
+                controller: ['command_name', 'pattern', 'pattern_ID', 'duration', 'mode', 'frame_index', 'frame_rate', 'gain', 'posX'],
                 wait: ['duration'],
                 plugin: []
             }[cmd.type] || [];
 
             // Schema for this command's params (controller or plugin). Used so
-            // `mode` / `gs_val` / `level` render as <select> with type-correct
+            // `mode` / `level` render as <select> with type-correct
             // coercion. Falls back to the freeform FIELD_TYPES map.
             const paramsSchema =
                 cmd.type === 'controller'
@@ -5655,65 +5937,20 @@
         // Timeline preview (flattened)
         // ═══════════════════════════════════════════════════════════════
 
+        // Delegates to the shared, unit-tested duration math (js/arena-runner-g6.js)
+        // so the timeline preview and the arena runner agree on every condition's
+        // wall-clock length.
         function condDuration(cond) {
-            if (!cond) return 0;
-            let tp = 0, wait = 0;
-            for (const c of cond.commands) {
-                if (c.type === 'controller' && c.command_name === 'trialParams') tp = Math.max(tp, c.duration || 0);
-                if (c.type === 'wait') wait += (c.duration || 0);
-            }
-            return Math.max(tp, wait);
+            return RunnerLib.conditionDuration(cond);
         }
 
+        // Delegates to the shared, unit-tested flattener (LAB-97). NO shuffle here →
+        // the timeline preview shows the NOMINAL order; the run path
+        // (onRunSequence) passes a real shuffle for randomized blocks. The returned
+        // step shape is identical (kind/label/conditionName/seqIdx/dur/blockName/
+        // trialIdxInBlock/rep), plus repsTotal which the timeline ignores.
         function flattenSequence() {
-            if (!experiment) return { steps: [], hasRandom: false };
-            const byName = new Map(experiment.conditions.map(c => [c.name, c]));
-            const steps = [];
-            let hasRandom = false;
-            for (let seqIdx = 0; seqIdx < experiment.sequence.length; seqIdx++) {
-                const entry = experiment.sequence[seqIdx];
-                if (entry.kind === 'ref') {
-                    steps.push({
-                        kind: 'ref',
-                        label: entry.condition_name,
-                        conditionName: entry.condition_name,
-                        seqIdx,
-                        dur: condDuration(byName.get(entry.condition_name))
-                    });
-                } else if (entry.kind === 'block') {
-                    if (entry.randomize) hasRandom = true;
-                    const iti = entry.intertrial ? byName.get(entry.intertrial) : null;
-                    for (let r = 0; r < entry.repetitions; r++) {
-                        for (let t = 0; t < entry.trials.length; t++) {
-                            const condName = entry.trials[t];
-                            steps.push({
-                                kind: 'block-trial',
-                                label: condName,
-                                conditionName: condName,
-                                seqIdx,
-                                blockName: entry.name,
-                                trialIdxInBlock: t,
-                                dur: condDuration(byName.get(condName)),
-                                rep: r,
-                                randomize: entry.randomize
-                            });
-                            // Intertrial between consecutive trials within a rep (not after last)
-                            const isLastTrialOfFinalRep = (r === entry.repetitions - 1) && (t === entry.trials.length - 1);
-                            if (entry.intertrial && !isLastTrialOfFinalRep) {
-                                steps.push({
-                                    kind: 'iti',
-                                    label: 'iti: ' + entry.intertrial,
-                                    conditionName: entry.intertrial,
-                                    seqIdx,
-                                    blockName: entry.name,
-                                    dur: condDuration(iti)
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-            return { steps, hasRandom };
+            return RunnerLib.flattenStructure(experiment);
         }
 
         // Format seconds as "1m", "15m", "1h 5m" for ruler labels.
@@ -5867,6 +6104,7 @@
             renderInspector();
             renderTimeline();
             renderExportWarnings();
+            updateRunSeqBtn();
         }
 
         // Soft-warn validation banner. Listed in the yellow strip below the

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -5577,6 +5577,14 @@
                 updateRunStatus({ phase: 'error', error: e });
             } finally {
                 seqRunStop();
+                // The run has fully settled here (runSequence's finally already
+                // reset runner.active=false). The terminal 'sequence-complete' /
+                // 'aborted' event fired from INSIDE runSequence while active was
+                // still true, so re-sync the run-control buttons now: re-enable
+                // "▶ Run on arena" and disable Stop after a normal completion.
+                $('runStopBtn').disabled = !(arenaRunner && arenaRunner.active);
+                $('runDisconnectBtn').disabled = !(arenaLink && arenaLink.connected);
+                updateRunSeqBtn();
             }
         }
 

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -1346,6 +1346,7 @@
         <button id="settingsToggle" class="header-btn" title="Show/hide experiment metadata, rig, and plugins">Settings ▾</button>
         <select id="demoSelect" class="header-btn" title="Load a bundled demo YAML to explore">
             <option value="">Load demo ▾</option>
+            <option value="tests/fixtures/v3_g6_2x10_smoke.yaml">g6_2x10_smoke — all 4 patterns + every arena command (run on G6)</option>
             <option value="tests/fixtures/v3_canonical_a.yaml">canonical_a — 11 conds, 1 block, 4 anchors</option>
             <option value="tests/fixtures/v3_canonical_b.yaml">canonical_b — same shape (alt trials)</option>
             <option value="tests/fixtures/v3_full_experiment.yaml">full_experiment — 15 conds, 9 trials, 6 anchors</option>

--- a/js/arena-runner-g6.js
+++ b/js/arena-runner-g6.js
@@ -1,18 +1,22 @@
 /**
  * arena-runner-g6.js — condition → wire execution helpers + a small run-state
- * machine, shared by the Arena Console (LAB-93) and the v3 Experiment Designer
- * dry-run (LAB-94).
+ * machine, shared by the Arena Console (LAB-93), the v3 single-trial dry-run
+ * (LAB-94), and the v3 full-sequence runner (LAB-97).
  *
- * This is the ONE home for "take a v3 condition's controller trialParams
- * command and drive it on the arena". It sits between the pure wire protocol
+ * This is the ONE home for "take a v3 condition (or whole experiment_structure)
+ * and drive it on the arena". It sits between the pure wire protocol
  * (js/arena-wire-g6.js) and the I/O transport (js/arena-link.js) but contains
  * NO DOM — pages own their own UI. That keeps it Node-testable with a faked
  * link (see tests/test-arena-runner-g6.js).
  *
- * Scope (v0, per the LAB-94 DoD): only the `trialParams` controller command is
- * sent. Other controller commands (allOn/allOff/setPositionX/…), plugins, and
- * waits are NOT executed — this is a "test the pattern", not a full
- * behaviourally-faithful condition run.
+ * Two layers:
+ *   - PURE (no I/O): findTrialParams, buildTrialParams, conditionDuration,
+ *     flattenStructure (experiment_structure → ordered step list, respecting block
+ *     reps + randomize + ITI), translateCommand (one command → a wire-neutral IR).
+ *   - ASYNC executor: ArenaRunner.start (single trial) and ArenaRunner.runSequence
+ *     (walk the flattened steps, replay each condition's commands, host-side trial
+ *     timing). Plugin commands are skipped-with-warning; unsupported controller
+ *     commands (e.g. setColorDepth) error then skip.
  */
 'use strict';
 
@@ -22,8 +26,8 @@ var ArenaRunnerG6 = (function () {
     /**
      * Find the controller `trialParams` command in a condition's command list.
      * IMPORTANT: a condition's controller commands are a family (allOn, allOff,
-     * stopDisplay, setPositionX, setColorDepth, trialParams) — only trialParams
-     * maps to encodeTrialParams, so we must match on command_name, not just
+     * stopDisplay, setPositionX, trialParams) — only trialParams maps to
+     * encodeTrialParams, so we must match on command_name, not just
      * type === 'controller'.
      * @returns {object|null} the trialParams command, or null if none.
      */
@@ -142,15 +146,244 @@ var ArenaRunnerG6 = (function () {
         return { mode, patternId, frameRate, gain, initPos };
     }
 
+    // The controller commands the sequence runner can EMIT on G6, grounded in the
+    // firmware command set (commands.h): trialParams (0x08), allOn (0xFF),
+    // allOff (0x00), stopDisplay (0x30), setPositionX → SET_FRAME_POSITION (0x70).
+    // This mirrors plugin-registry's isKnownControllerCommand, duplicated on purpose
+    // because this module must stay import-free (no sibling imports). Anything else
+    // (e.g. a legacy setColorDepth → SWITCH_GRAYSCALE 0x06, dropped on G6) is an
+    // error, not a silent no-op.
+    const RUNNABLE_CONTROLLER_COMMANDS = [
+        'trialParams',
+        'allOn',
+        'allOff',
+        'stopDisplay',
+        'setPositionX'
+    ];
+
+    /**
+     * The wall-clock duration of a condition, in seconds: max(trialParams.duration,
+     * sum of wait durations). Mirrors the v3 designer's timeline math; pure so the
+     * runner and the timeline preview share ONE definition. Number()-coerces to
+     * defend against string YAML scalars.
+     */
+    function conditionDuration(cond) {
+        if (!cond || !Array.isArray(cond.commands)) return 0;
+        let tp = 0;
+        let wait = 0;
+        for (const c of cond.commands) {
+            if (c && c.type === 'controller' && c.command_name === 'trialParams') {
+                tp = Math.max(tp, Number(c.duration) || 0);
+            }
+            if (c && c.type === 'wait') wait += Number(c.duration) || 0;
+        }
+        return Math.max(tp, wait);
+    }
+
+    /**
+     * Flatten an experiment_structure into the ordered list of steps the runner
+     * (and the timeline preview) execute: refs, block trials × repetitions, and
+     * intertrial (ITI) conditions inserted BETWEEN consecutive trials but NOT after
+     * the final trial of the final rep.
+     *
+     * PURE — takes the parsed `experiment` object, returns { steps, hasRandom }.
+     * `opts.shuffle(arr)` (optional) is applied per-rep to a block's trial order
+     * when the block has `randomize: true`; the timeline preview passes NO shuffle
+     * (nominal order), the run path passes a real shuffle. `opts.conditionDuration`
+     * overrides the duration function (defaults to the module's).
+     *
+     * Step shapes (kind):
+     *   ref         { kind, label, conditionName, seqIdx, dur }
+     *   block-trial { kind, label, conditionName, seqIdx, blockName, trialIdxInBlock,
+     *                 dur, rep, repsTotal, randomize }
+     *   iti         { kind, label, conditionName, seqIdx, blockName, dur }
+     */
+    function flattenStructure(experiment, opts) {
+        opts = opts || {};
+        const durOf =
+            typeof opts.conditionDuration === 'function'
+                ? opts.conditionDuration
+                : conditionDuration;
+        const shuffle = typeof opts.shuffle === 'function' ? opts.shuffle : null;
+        const out = { steps: [], hasRandom: false };
+        if (
+            !experiment ||
+            !Array.isArray(experiment.sequence) ||
+            !Array.isArray(experiment.conditions)
+        ) {
+            return out;
+        }
+        const byName = new Map(experiment.conditions.map((c) => [c.name, c]));
+        const steps = out.steps;
+        for (let seqIdx = 0; seqIdx < experiment.sequence.length; seqIdx++) {
+            const entry = experiment.sequence[seqIdx];
+            if (!entry) continue;
+            if (entry.kind === 'ref') {
+                steps.push({
+                    kind: 'ref',
+                    label: entry.condition_name,
+                    conditionName: entry.condition_name,
+                    seqIdx,
+                    dur: durOf(byName.get(entry.condition_name))
+                });
+            } else if (entry.kind === 'block') {
+                if (entry.randomize) out.hasRandom = true;
+                const reps = entry.repetitions || 1;
+                const iti = entry.intertrial ? byName.get(entry.intertrial) : null;
+                const baseTrials = Array.isArray(entry.trials) ? entry.trials : [];
+                for (let r = 0; r < reps; r++) {
+                    // Randomize per-rep only when a shuffle is supplied (the run
+                    // path). slice() so the source array is never mutated.
+                    const trials =
+                        entry.randomize && shuffle ? shuffle(baseTrials.slice()) : baseTrials;
+                    for (let t = 0; t < trials.length; t++) {
+                        const condName = trials[t];
+                        steps.push({
+                            kind: 'block-trial',
+                            label: condName,
+                            conditionName: condName,
+                            seqIdx,
+                            blockName: entry.name,
+                            trialIdxInBlock: t,
+                            dur: durOf(byName.get(condName)),
+                            rep: r,
+                            repsTotal: reps,
+                            randomize: !!entry.randomize
+                        });
+                        const isLastTrialOfFinalRep = r === reps - 1 && t === trials.length - 1;
+                        if (entry.intertrial && !isLastTrialOfFinalRep) {
+                            steps.push({
+                                kind: 'iti',
+                                label: 'iti: ' + entry.intertrial,
+                                conditionName: entry.intertrial,
+                                seqIdx,
+                                blockName: entry.name,
+                                dur: durOf(iti)
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Translate ONE v3 command into a wire-neutral instruction descriptor (the
+     * "command IR"). PURE and wire-free so it is trivially unit-testable; the
+     * executor (ArenaRunner.runSequence) maps each `op` to an ArenaWireG6 encoder.
+     *
+     * @param {object} cmd  a v3 command ({type:'controller'|'wait'|'plugin', …})
+     * @param {{patternId:(number|null)}} [opts]  resolved 1-based SD index for a
+     *        trialParams command (null/undefined ⇒ unresolvable ⇒ {op:'error'}).
+     * @returns {object} one of:
+     *   { op:'trialParams', params, durationSec }
+     *   { op:'allOn' | 'allOff' | 'stopDisplay' }
+     *   { op:'setFramePosition', index }            // 0-based frame index (Mode 3)
+     *   { op:'wait', durationSec }
+     *   { op:'skip', reason, plugin_name, command_name }   // plugin → not driveable
+     *   { op:'error', reason }                              // unsupported / malformed
+     */
+    function translateCommand(cmd, opts) {
+        opts = opts || {};
+        if (!cmd || !cmd.type) {
+            return { op: 'error', reason: 'Malformed command (missing type).' };
+        }
+        if (cmd.type === 'wait') {
+            return { op: 'wait', durationSec: Number(cmd.duration) || 0 };
+        }
+        if (cmd.type === 'plugin') {
+            return {
+                op: 'skip',
+                reason: 'plugin command (the browser cannot drive plugins)',
+                plugin_name: cmd.plugin_name || '(unnamed)',
+                command_name: cmd.command_name || '(unnamed)'
+            };
+        }
+        if (cmd.type === 'controller') {
+            const name = cmd.command_name;
+            if (name === 'trialParams') {
+                if (opts.patternId === undefined || opts.patternId === null) {
+                    return {
+                        op: 'error',
+                        reason:
+                            'No SD pattern index for trialParams pattern "' +
+                            (cmd.pattern || '(empty)') +
+                            '" — not in the active set and no usable pattern_ID.'
+                    };
+                }
+                let params;
+                try {
+                    params = buildTrialParams(cmd, { patternId: opts.patternId });
+                } catch (e) {
+                    return { op: 'error', reason: e.message };
+                }
+                return {
+                    op: 'trialParams',
+                    params,
+                    durationSec: Number(cmd.duration) > 0 ? Number(cmd.duration) : 0
+                };
+            }
+            if (name === 'allOn') return { op: 'allOn' };
+            if (name === 'allOff') return { op: 'allOff' };
+            if (name === 'stopDisplay') return { op: 'stopDisplay' };
+            if (name === 'setPositionX') {
+                // Mode-3 frame jump: posX is a 0-based frame index → 0x70.
+                const index = Number(cmd.posX);
+                return { op: 'setFramePosition', index: Number.isFinite(index) ? index : 0 };
+            }
+            return {
+                op: 'error',
+                reason:
+                    'Unsupported controller command "' +
+                    (name || '(unnamed)') +
+                    '" — not in the G6 runner palette ' +
+                    '(trialParams/allOn/allOff/stopDisplay/setPositionX).' +
+                    (name === 'setColorDepth'
+                        ? ' setColorDepth maps to SWITCH_GRAYSCALE 0x06, which is dropped on G6 ' +
+                          '(color depth is a .pat/SD-header property, not a runtime command).'
+                        : '')
+            };
+        }
+        return { op: 'error', reason: 'Unknown command type "' + cmd.type + '".' };
+    }
+
+    // ---- timing model (interim host-side) -------------------------------
+
+    /**
+     * TIMING MODEL — interim, host-side (firmware issue
+     * reiserlab/LED-Display_G6_Firmware_Arena#4). The controller-run trial
+     * `duration` is NOT in firmware yet, so the browser drives trial timing: after a
+     * trialParams send acks OK, sleep `durationSec`, then advance to the next
+     * command/step. This function is the ONE place that decides "when is a trial
+     * done".
+     *
+     * SWAP POINT: once #4 lands (trial_params carries a controller-run duration and
+     * the controller signals completion), replace this with a function that AWAITS
+     * the controller's run-complete event instead of sleeping — or inject
+     * `opts.timing` into runSequence. Nothing else in the runner changes.
+     *
+     * Best-effort: a slept/closed tab won't fire the timer, so STOP/abort is the
+     * primary control.
+     *
+     * @param {number} durationSec               trial duration in s (0 ⇒ no wait)
+     * @param {function(number):Promise} sleep    abort-aware sleep(ms)
+     */
+    async function hostSideTrialEnd(durationSec, sleep) {
+        await sleep((Number(durationSec) || 0) * 1000);
+    }
+
     // ---- run-state machine ----------------------------------------------
 
     /**
-     * Owns one active run at a time: the send, the decoded status, and the
-     * best-effort auto-stop timer. A double-click can't queue two trial frames
-     * or two timers because start() rejects while active.
+     * Owns one active run at a time — either a single-trial dry-run (start) or a
+     * whole flattened sequence (runSequence). A double-click can't queue two runs
+     * because both reject while active.
      *
-     * STOP is best-effort: a closed/slept tab won't fire the timer, so manual
-     * stop() is the primary mechanism and the timer is a convenience.
+     * STOP is best-effort: a closed/slept tab won't fire the auto-stop timer or the
+     * host-side trial timing, so manual stop() is the primary mechanism. stop() sets
+     * an abort flag the sequence loop checks before every step and every command,
+     * and resolves any in-progress host-side wait immediately so STOP halts promptly.
      */
     class ArenaRunner {
         /**
@@ -164,9 +397,12 @@ var ArenaRunnerG6 = (function () {
                 throw new Error('ArenaRunner: ArenaWireG6 is not available.');
             }
             this._active = false;
-            this._timer = null;
+            this._timer = null; // single-trial auto-stop timer
             this._conditionName = null;
             this._lastResponse = null;
+            this._abort = false; // sequence abort flag (set by stop()/_clear())
+            this._sleepTimer = null; // in-progress host-side wait timer
+            this._sleepResolve = null; // resolver for the in-progress wait
         }
 
         get active() {
@@ -241,12 +477,16 @@ var ArenaRunnerG6 = (function () {
         }
 
         /**
-         * Stop the active run: clear the timer, mark inactive, and send STOP if
+         * Stop the active run: raise the abort flag, resolve any in-progress
+         * host-side wait, clear the auto-stop timer, mark inactive, and send STOP if
          * the link is connected. Idempotent and NOT import-mode-guarded by the
-         * UI — a run must remain stoppable.
+         * UI — a run must remain stoppable. The sequence loop, if running, observes
+         * the abort flag and unwinds (its own finally also sends STOP — harmless).
          * @returns {Promise<object|null>} the STOP response (or null if offline)
          */
         async stop() {
+            this._abort = true;
+            this._resolveSleep();
             if (this._timer) {
                 clearTimeout(this._timer);
                 this._timer = null;
@@ -259,14 +499,241 @@ var ArenaRunnerG6 = (function () {
             return null;
         }
 
-        /** Clear run-state + timer without sending STOP (used on disconnect/error). */
+        /** Clear run-state without sending STOP (used on disconnect/error). Also
+         *  aborts a running sequence and unblocks its current wait. */
         _clear() {
+            this._abort = true;
+            this._resolveSleep();
             if (this._timer) {
                 clearTimeout(this._timer);
                 this._timer = null;
             }
             this._active = false;
             this._conditionName = null;
+        }
+
+        /** Resolve + clear any in-progress host-side wait (makes STOP prompt). */
+        _resolveSleep() {
+            if (this._sleepTimer) {
+                clearTimeout(this._sleepTimer);
+                this._sleepTimer = null;
+            }
+            if (this._sleepResolve) {
+                const r = this._sleepResolve;
+                this._sleepResolve = null;
+                r();
+            }
+        }
+
+        /**
+         * Abort-aware sleep: resolves after `ms`, OR immediately if already aborted
+         * or stop() fires mid-wait. Only one wait is outstanding at a time (the
+         * sequence loop awaits each in turn).
+         */
+        _sleep(ms) {
+            return new Promise((resolve) => {
+                if (this._abort || !(ms > 0)) {
+                    resolve();
+                    return;
+                }
+                this._sleepResolve = resolve;
+                this._sleepTimer = setTimeout(() => {
+                    this._sleepTimer = null;
+                    this._sleepResolve = null;
+                    resolve();
+                }, ms);
+            });
+        }
+
+        /**
+         * Run a whole flattened sequence on the arena. Walks each step's condition
+         * and replays its command list in order (trialParams / allOn / allOff /
+         * stopDisplay / setPositionX + client-side waits). Plugin commands are
+         * skipped-with-warning; unsupported controller commands (e.g. setColorDepth)
+         * and unresolvable patterns are surfaced as errors then skipped (the
+         * proceed-and-skip policy). Trial timing is host-side (see hostSideTrialEnd).
+         * The abort flag is checked before every step AND every command, so STOP
+         * halts promptly. On completion or abort the finally sends a best-effort STOP.
+         *
+         * @param {object} a
+         * @param {Array}    a.steps             flattenStructure(...).steps
+         * @param {Map}      a.conditionsByName  conditionName → condition object
+         * @param {function} a.resolvePatternId  (trialParamsCmd) ⇒ 1-based SD index | null
+         * @param {function} [a.onProgress]      progress/event callback (see phases below)
+         * @param {function} [a.timing]          async (durationSec, sleep) ⇒ trial end
+         *                                        (defaults to host-side; firmware #4 swap)
+         * @param {function} [a.sleep]           async (ms) ⇒ void (defaults to the
+         *                                        abort-aware _sleep; tests inject instant)
+         * @returns {Promise<{completed:boolean, aborted:boolean, steps:number, errors:number, skipped:number}>}
+         */
+        async runSequence(a) {
+            a = a || {};
+            if (this._active) {
+                throw new Error('A run is already active — stop it first.');
+            }
+            const steps = Array.isArray(a.steps) ? a.steps : [];
+            const conditionsByName = a.conditionsByName || new Map();
+            const resolvePatternId =
+                typeof a.resolvePatternId === 'function' ? a.resolvePatternId : () => null;
+            const timing = typeof a.timing === 'function' ? a.timing : hostSideTrialEnd;
+            const sleep = typeof a.sleep === 'function' ? a.sleep : (ms) => this._sleep(ms);
+            const emit = (s) => {
+                if (typeof a.onProgress === 'function') a.onProgress(s);
+            };
+
+            this._active = true;
+            this._abort = false;
+            const summary = {
+                completed: false,
+                aborted: false,
+                steps: steps.length,
+                errors: 0,
+                skipped: 0
+            };
+
+            try {
+                emit({ phase: 'sequence-start', total: steps.length });
+                for (let i = 0; i < steps.length; i++) {
+                    if (this._abort) break;
+                    const step = steps[i];
+                    const cond = conditionsByName.get(step.conditionName) || null;
+                    this._conditionName = step.conditionName || null;
+                    emit({
+                        phase: 'step-start',
+                        index: i,
+                        total: steps.length,
+                        step,
+                        next: i + 1 < steps.length ? steps[i + 1] : null
+                    });
+                    if (!cond || !Array.isArray(cond.commands)) {
+                        summary.errors++;
+                        emit({
+                            phase: 'error',
+                            index: i,
+                            step,
+                            reason:
+                                'Condition "' +
+                                step.conditionName +
+                                '" not found or has no commands — skipped.'
+                        });
+                        emit({ phase: 'step-done', index: i, total: steps.length, step });
+                        continue;
+                    }
+                    for (const cmd of cond.commands) {
+                        if (this._abort) break;
+                        const ir = translateCommand(cmd, { patternId: resolvePatternId(cmd) });
+                        try {
+                            await this._runIR(ir, { step, index: i, emit, timing, sleep, summary });
+                        } catch (e) {
+                            // A wire/link failure mid-command: surface it and abort
+                            // the run (the finally sends STOP). Don't blindly continue
+                            // past a possible protocol desync.
+                            summary.errors++;
+                            this._abort = true;
+                            emit({
+                                phase: 'error',
+                                index: i,
+                                step,
+                                error: e,
+                                reason: 'send failed: ' + (e && (e.message || e))
+                            });
+                            break;
+                        }
+                    }
+                    emit({ phase: 'step-done', index: i, total: steps.length, step });
+                }
+                summary.aborted = this._abort;
+                summary.completed = !this._abort;
+                emit({ phase: this._abort ? 'aborted' : 'sequence-complete', summary });
+                return summary;
+            } finally {
+                // Best-effort STOP at the end / on abort, then reset run-state.
+                this._active = false;
+                this._conditionName = null;
+                this._resolveSleep();
+                try {
+                    if (this._link && this._link.connected) {
+                        await this._link.send(this._wire.encodeStop());
+                    }
+                } catch (_) {
+                    /* best-effort */
+                }
+            }
+        }
+
+        /**
+         * Execute one command IR over the link: send the matching wire frame and,
+         * for trialParams, apply the host-side trial timing. Skips/errors are
+         * surfaced via emit and do NOT abort the run. Mutates `ctx.summary`.
+         * Throws only on a link/send failure (the caller aborts the run).
+         */
+        async _runIR(ir, ctx) {
+            const { step, index, emit, timing, sleep, summary } = ctx;
+            const W = this._wire;
+            switch (ir.op) {
+                case 'trialParams': {
+                    const frame = await this._link.send(W.encodeTrialParams(ir.params));
+                    const resp = W.decodeResponse(frame);
+                    this._lastResponse = resp;
+                    if (!resp || !resp.ok) {
+                        summary.errors++;
+                        emit({
+                            phase: 'error',
+                            index,
+                            step,
+                            response: resp,
+                            reason: 'controller rejected trialParams'
+                        });
+                        return;
+                    }
+                    emit({
+                        phase: 'trial-running',
+                        index,
+                        step,
+                        response: resp,
+                        durationSec: ir.durationSec
+                    });
+                    // Host-side timing (interim — firmware #4). Abort-aware via sleep.
+                    await timing(ir.durationSec, sleep);
+                    return;
+                }
+                case 'allOn':
+                    await this._link.send(W.encodeAllOn());
+                    emit({ phase: 'command', index, step, op: ir.op });
+                    return;
+                case 'allOff':
+                    await this._link.send(W.encodeAllOff());
+                    emit({ phase: 'command', index, step, op: ir.op });
+                    return;
+                case 'stopDisplay':
+                    await this._link.send(W.encodeStop());
+                    emit({ phase: 'command', index, step, op: ir.op });
+                    return;
+                case 'setFramePosition':
+                    await this._link.send(W.encodeSetFramePosition(ir.index));
+                    emit({ phase: 'command', index, step, op: ir.op, value: ir.index });
+                    return;
+                case 'wait':
+                    await sleep((Number(ir.durationSec) || 0) * 1000);
+                    emit({ phase: 'command', index, step, op: ir.op, value: ir.durationSec });
+                    return;
+                case 'skip':
+                    summary.skipped++;
+                    emit({
+                        phase: 'skip',
+                        index,
+                        step,
+                        reason: ir.reason,
+                        plugin_name: ir.plugin_name,
+                        command_name: ir.command_name
+                    });
+                    return;
+                case 'error':
+                default:
+                    summary.errors++;
+                    emit({ phase: 'error', index, step, reason: ir.reason || 'unknown command' });
+                    return;
+            }
         }
     }
 
@@ -276,6 +743,11 @@ var ArenaRunnerG6 = (function () {
         isDryRunEligible,
         frameIndexToInitPos,
         buildTrialParams,
+        conditionDuration,
+        flattenStructure,
+        translateCommand,
+        hostSideTrialEnd,
+        RUNNABLE_CONTROLLER_COMMANDS,
         ArenaRunner
     };
 })();

--- a/js/plugin-registry.js
+++ b/js/plugin-registry.js
@@ -83,35 +83,39 @@ var CONTROLLER_COMMANDS = {
         label: 'Stop Display',
         description: 'Stop displaying the current pattern'
     },
+    // setPositionX is the Mode-3 FRAME JUMP: it maps to SET_FRAME_POSITION (0x70),
+    // and its `posX` param is a 0-based frame index (NOT a pixel/position offset).
+    // The historical key `posX` is kept for YAML compatibility — only the labels
+    // describe the real behaviour. (setColorDepth was dropped: it mapped to
+    // SWITCH_GRAYSCALE 0x06, which is dropped on G6 — color depth is a property of
+    // the .pat/SD-card header, not a runtime command. A YAML carrying setColorDepth
+    // now has no schema here and is flagged as unsupported by the editor + runner.)
     setPositionX: {
-        label: 'Set Position X',
-        description: 'Set the starting frame for pattern display',
+        label: 'Set Frame (Mode 3)',
+        description:
+            'Mode-3 frame jump — show a specific 0-based frame (SET_FRAME_POSITION 0x70). ' +
+            'Load the pattern first with a trialParams command (frame_rate 0). ' +
+            'Full Mode-3 closed-loop streaming is out of scope.',
         params: {
             posX: {
                 type: 'number',
                 required: true,
-                default: 1,
-                label: 'Position X'
-            }
-        }
-    },
-    setColorDepth: {
-        label: 'Set Color Depth',
-        description: 'Change the arena grayscale value',
-        params: {
-            gs_val: {
-                type: 'select',
-                required: true,
-                default: 2,
-                options: [
-                    { value: 2, label: 'GS2 (binary)' },
-                    { value: 16, label: 'GS16 (4-bit)' }
-                ],
-                label: 'Grayscale'
+                default: 0,
+                label: 'Frame index (0-based)'
             }
         }
     }
 };
+
+/**
+ * Is `name` a known/supported G6 controller command? Used by the editor to flag
+ * unsupported controller commands (e.g. a legacy `setColorDepth`) on the command
+ * card. The arena runner keeps its OWN copy of this set (it must stay import-free),
+ * so this is the authoring-side mirror of the runner's emit list.
+ */
+function isKnownControllerCommand(name) {
+    return Object.prototype.hasOwnProperty.call(CONTROLLER_COMMANDS, name);
+}
 
 // ════════════════════════════════════════════════════
 // Built-in Plugin Definitions
@@ -814,6 +818,7 @@ var PluginRegistry = {
     WELL_KNOWN_RIG_PLUGIN_NAMES: WELL_KNOWN_RIG_PLUGIN_NAMES,
     getPluginCommands: getPluginCommands,
     getCommandParams: getCommandParams,
+    isKnownControllerCommand: isKnownControllerCommand,
     getAllCommandOptions: getAllCommandOptions,
     createPluginEntry: createPluginEntry,
     findPluginDefByClass: findPluginDefByClass,
@@ -844,6 +849,7 @@ export {
     WELL_KNOWN_RIG_PLUGIN_NAMES,
     getPluginCommands,
     getCommandParams,
+    isKnownControllerCommand,
     getAllCommandOptions,
     createPluginEntry,
     findPluginDefByClass,

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -65,7 +65,6 @@ const KNOWN_COMMAND_KEYS_BY_TYPE = {
         'frame_index',
         'frame_rate',
         'gain',
-        'gs_val',
         'posX'
     ],
     wait: ['type', 'duration'],

--- a/tests/fixtures/v2_all_possible_plugins.yaml
+++ b/tests/fixtures/v2_all_possible_plugins.yaml
@@ -438,9 +438,10 @@ posttrial:
 #
 # setPositionX - set the starting frame when displaying a pattern (default 1)
 #   Parameters: posX: integer between 1 and number of frames in pattern
+#   (NOTE: on G6 this is the Mode-3 frame jump → SET_FRAME_POSITION 0x70, 0-based.)
 #
-# setColorDepth - change the arena's accepted grayscale value 
-#   Parameters: gs_val: 2 or 16
+# (setColorDepth was dropped: SWITCH_GRAYSCALE 0x06 is not a runtime command on G6;
+#  grayscale is a property of the .pat / SD-card header.)
 #
 # trialParams - start displaying a trial on the G4.1 system
 #   Parameters: mode: integer 2-4 

--- a/tests/fixtures/v3_g6_2x10_smoke.yaml
+++ b/tests/fixtures/v3_g6_2x10_smoke.yaml
@@ -1,0 +1,164 @@
+version: 3
+
+# ============================================================================
+# G6 2x10 arena smoke test (LAB-97) — exercises ALL FOUR built-in g6_2x10
+# patterns by name and EVERY legal G6 controller command the web runner emits:
+#   trialParams (mode 2 open-loop + mode 4 closed-loop), allOn, allOff,
+#   stopDisplay, setPositionX (Mode-3 frame jump -> SET_FRAME_POSITION 0x70),
+#   plus client-side waits, a block with repetitions, and an ITI.
+#
+# Patterns are referenced BY NAME so they resolve as W (web / in active set) when
+# the built-in `g6_2x10` pattern set is the active set (Pattern Set… → load the
+# built-in set first). The pattern_ID fallbacks match the built-in manifest
+# indices, so it still runs by SD index (C) if no set is built:
+#   1 all_on · 2 grating_sq · 3 grating_sine · 4 frame2_h_ccw_200f
+#
+# No plugins → nothing is skipped; the whole sequence runs on the arena.
+# Total ~50 s; STOP halts anywhere.
+# ============================================================================
+
+experiment_info:
+  name: "G6 2x10 arena smoke test"
+  author: "webDisplayTools"
+
+rig: "./configs/rigs/cshl_g6_2x10.yaml"
+
+experiment:
+  - "arena_check"
+  - "show_all_on"
+  - "show_grating_sq"
+  - "show_grating_sine"
+  - "show_rotation"
+  - "frame_jump"
+  - "closed_loop"
+  - name: "repeat_block"
+    trials:
+      - "show_grating_sq"
+      - "show_grating_sine"
+    repetitions: 2
+    intertrial: "blank"
+  - "shutdown"
+
+conditions:
+  # allOn then allOff — the simplest panel commands.
+  - name: "arena_check"
+    commands:
+      - type: "controller"
+        command_name: "allOn"
+      - type: "wait"
+        duration: 2
+      - type: "controller"
+        command_name: "allOff"
+      - type: "wait"
+        duration: 1
+
+  - name: "show_all_on"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "all_on"
+        pattern_ID: 1
+        duration: 3
+        mode: 2
+        frame_index: 0
+        frame_rate: 1
+        gain: 0
+      - type: "wait"
+        duration: 3
+
+  - name: "show_grating_sq"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "grating_sq"
+        pattern_ID: 2
+        duration: 4
+        mode: 2
+        frame_index: 0
+        frame_rate: 5
+        gain: 0
+      - type: "wait"
+        duration: 4
+
+  - name: "show_grating_sine"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "grating_sine"
+        pattern_ID: 3
+        duration: 4
+        mode: 2
+        frame_index: 0
+        frame_rate: 5
+        gain: 0
+      - type: "wait"
+        duration: 4
+
+  # 200-frame rotation, advanced fast (open-loop, mode 2).
+  - name: "show_rotation"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "frame2_h_ccw_200f"
+        pattern_ID: 4
+        duration: 5
+        mode: 2
+        frame_index: 0
+        frame_rate: 30
+        gain: 0
+      - type: "wait"
+        duration: 5
+
+  # Mode-3 FRAME JUMP: load the pattern static (frame_rate 0), then address a
+  # specific 0-based frame with setPositionX (SET_FRAME_POSITION 0x70), then stop.
+  - name: "frame_jump"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "frame2_h_ccw_200f"
+        pattern_ID: 4
+        duration: 0
+        mode: 2
+        frame_index: 0
+        frame_rate: 0
+        gain: 0
+      - type: "controller"
+        command_name: "setPositionX"
+        posX: 100
+      - type: "wait"
+        duration: 3
+      - type: "controller"
+        command_name: "stopDisplay"
+
+  # Mode 4 closed-loop: the controller runs the analog loop (frame_rate 0, gain set).
+  # Static on a bench with no analog input — exercises the mode-4 + gain wire path.
+  - name: "closed_loop"
+    commands:
+      - type: "controller"
+        command_name: "trialParams"
+        pattern: "grating_sine"
+        pattern_ID: 3
+        duration: 5
+        mode: 4
+        frame_index: 0
+        frame_rate: 0
+        gain: 10
+      - type: "wait"
+        duration: 5
+
+  # ITI between the block's trials.
+  - name: "blank"
+    commands:
+      - type: "controller"
+        command_name: "allOff"
+      - type: "wait"
+        duration: 2
+
+  - name: "shutdown"
+    commands:
+      - type: "controller"
+        command_name: "stopDisplay"
+      - type: "controller"
+        command_name: "allOff"
+      - type: "wait"
+        duration: 1

--- a/tests/test-arena-runner-g6.js
+++ b/tests/test-arena-runner-g6.js
@@ -277,6 +277,294 @@ async function main() {
         checkBytes('auto-stop sent STOP (0x30)', link.sent[link.sent.length - 1], '01 30');
     }
 
+    // ════════════════════════════════════════════════════════════════════
+    // LAB-97: full-sequence runner — pure helpers + executor
+    // ════════════════════════════════════════════════════════════════════
+
+    console.log('\n=== conditionDuration (max(trialParams.duration, sum waits)) ===');
+    check(
+        'trialParams 5s dominates a 3s wait',
+        Runner.conditionDuration({
+            commands: [trialCmd, { type: 'wait', duration: 3 }]
+        }),
+        5
+    );
+    check(
+        'summed waits (3+4) exceed a 2s trialParams',
+        Runner.conditionDuration({
+            commands: [
+                { type: 'controller', command_name: 'trialParams', duration: 2 },
+                { type: 'wait', duration: 3 },
+                { type: 'wait', duration: 4 }
+            ]
+        }),
+        7
+    );
+    check('waits-only condition', Runner.conditionDuration(intertrialCond), 2);
+    check('null condition -> 0', Runner.conditionDuration(null), 0);
+    check(
+        'string durations coerce',
+        Runner.conditionDuration({
+            commands: [{ type: 'controller', command_name: 'trialParams', duration: '5' }]
+        }),
+        5
+    );
+
+    console.log('\n=== flattenStructure (reps × trials, ITI between-not-after) ===');
+    const flattenFixture = {
+        conditions: [
+            { name: 'a', commands: [trialCmd, { type: 'wait', duration: 3 }] }, // dur 5
+            { name: 'b', commands: [{ type: 'wait', duration: 2 }] }, // dur 2
+            { name: 'iti', commands: [{ type: 'wait', duration: 1 }] } // dur 1
+        ],
+        sequence: [
+            { kind: 'ref', condition_name: 'a' },
+            {
+                kind: 'block',
+                name: 'blk',
+                trials: ['a', 'b'],
+                repetitions: 2,
+                randomize: false,
+                intertrial: 'iti'
+            }
+        ]
+    };
+    const flat = Runner.flattenStructure(flattenFixture);
+    // ref a + [a, iti, b, iti, a, iti, b] = 8 steps (4 trials + 3 itis)
+    check('total step count', flat.steps.length, 8);
+    check('step0 is the ref', flat.steps[0].kind, 'ref');
+    check('step0 dur = max(trialParams 5, wait 3)', flat.steps[0].dur, 5);
+    check('step1 is a block-trial', flat.steps[1].kind, 'block-trial');
+    check('step1 conditionName', flat.steps[1].conditionName, 'a');
+    check('step1 rep index', flat.steps[1].rep, 0);
+    check('step1 repsTotal', flat.steps[1].repsTotal, 2);
+    check('step2 is an ITI', flat.steps[2].kind, 'iti');
+    check('step2 ITI conditionName', flat.steps[2].conditionName, 'iti');
+    check('step2 ITI dur', flat.steps[2].dur, 1);
+    check('last step is the final trial (no trailing ITI)', flat.steps[7].kind, 'block-trial');
+    check('last step conditionName', flat.steps[7].conditionName, 'b');
+    check('last step rep index', flat.steps[7].rep, 1);
+    checkBool('hasRandom false for a non-randomized block', flat.hasRandom === false);
+    check('empty/no experiment -> 0 steps', Runner.flattenStructure(null).steps.length, 0);
+
+    console.log('\n=== flattenStructure: randomize honors an injected shuffle (pure) ===');
+    const randFixture = {
+        conditions: [
+            { name: 'x', commands: [] },
+            { name: 'y', commands: [] }
+        ],
+        sequence: [
+            { kind: 'block', name: 'b', trials: ['x', 'y'], repetitions: 1, randomize: true }
+        ]
+    };
+    const nominal = Runner.flattenStructure(randFixture);
+    check('no shuffle -> nominal order [x, y] (0)', nominal.steps[0].conditionName, 'x');
+    check('no shuffle -> nominal order [x, y] (1)', nominal.steps[1].conditionName, 'y');
+    checkBool('hasRandom flagged even without a shuffle', nominal.hasRandom === true);
+    const reversed = Runner.flattenStructure(randFixture, { shuffle: (arr) => arr.reverse() });
+    check('injected reverse shuffle reorders (0)', reversed.steps[0].conditionName, 'y');
+    check('injected reverse shuffle reorders (1)', reversed.steps[1].conditionName, 'x');
+    check(
+        'source trials array NOT mutated by the shuffle',
+        randFixture.sequence[0].trials.join(','),
+        'x,y'
+    );
+
+    console.log('\n=== translateCommand (command → wire-neutral IR) ===');
+    const trTrial = Runner.translateCommand(trialCmd, { patternId: 1 });
+    check('trialParams -> op trialParams', trTrial.op, 'trialParams');
+    check('trialParams -> durationSec carried', trTrial.durationSec, 5);
+    check('trialParams -> params.patternId', trTrial.params.patternId, 1);
+    check('trialParams -> params.mode', trTrial.params.mode, 2);
+    check(
+        'trialParams with null patternId -> error',
+        Runner.translateCommand(trialCmd, { patternId: null }).op,
+        'error'
+    );
+    check(
+        'trialParams with bad mode -> error',
+        Runner.translateCommand(
+            { type: 'controller', command_name: 'trialParams', mode: 5 },
+            {
+                patternId: 1
+            }
+        ).op,
+        'error'
+    );
+    check(
+        'allOn -> op allOn',
+        Runner.translateCommand({ type: 'controller', command_name: 'allOn' }).op,
+        'allOn'
+    );
+    check(
+        'allOff -> op allOff',
+        Runner.translateCommand({ type: 'controller', command_name: 'allOff' }).op,
+        'allOff'
+    );
+    check(
+        'stopDisplay -> op stopDisplay',
+        Runner.translateCommand({ type: 'controller', command_name: 'stopDisplay' }).op,
+        'stopDisplay'
+    );
+    const trPos = Runner.translateCommand({
+        type: 'controller',
+        command_name: 'setPositionX',
+        posX: 3
+    });
+    check('setPositionX -> op setFramePosition', trPos.op, 'setFramePosition');
+    check('setPositionX -> 0-based index passthrough', trPos.index, 3);
+    check(
+        'setPositionX missing posX -> index 0',
+        Runner.translateCommand({ type: 'controller', command_name: 'setPositionX' }).index,
+        0
+    );
+    const trColor = Runner.translateCommand({
+        type: 'controller',
+        command_name: 'setColorDepth',
+        gs_val: 16
+    });
+    check('setColorDepth -> op error (dropped on G6)', trColor.op, 'error');
+    checkBool(
+        'setColorDepth error mentions SWITCH_GRAYSCALE',
+        /SWITCH_GRAYSCALE/.test(trColor.reason)
+    );
+    check(
+        'unknown controller command -> op error',
+        Runner.translateCommand({ type: 'controller', command_name: 'frobnicate' }).op,
+        'error'
+    );
+    const trWait = Runner.translateCommand({ type: 'wait', duration: 3 });
+    check('wait -> op wait', trWait.op, 'wait');
+    check('wait -> durationSec', trWait.durationSec, 3);
+    const trPlugin = Runner.translateCommand({
+        type: 'plugin',
+        plugin_name: 'camera',
+        command_name: 'getTimestamp'
+    });
+    check('plugin -> op skip', trPlugin.op, 'skip');
+    check('plugin skip carries plugin_name', trPlugin.plugin_name, 'camera');
+
+    console.log('\n=== runSequence: happy path (fake link, instant sleep) ===');
+    {
+        const link = makeFakeLink();
+        const runner = new Runner.ArenaRunner(link, Wire);
+        const steps = [
+            { kind: 'ref', conditionName: 'check', label: 'check', seqIdx: 0, dur: 1 },
+            { kind: 'ref', conditionName: 'show', label: 'show', seqIdx: 1, dur: 5 }
+        ];
+        const conditionsByName = new Map([
+            [
+                'check',
+                {
+                    name: 'check',
+                    commands: [
+                        { type: 'controller', command_name: 'allOn' },
+                        { type: 'wait', duration: 1 }
+                    ]
+                }
+            ],
+            ['show', { name: 'show', commands: [trialCmd, { type: 'wait', duration: 2 }] }]
+        ]);
+        const phases = [];
+        const summary = await runner.runSequence({
+            steps,
+            conditionsByName,
+            resolvePatternId: () => 1,
+            sleep: () => Promise.resolve(),
+            onProgress: (s) => phases.push(s.phase)
+        });
+        check('sent exactly 3 frames (allOn, trialParams, final STOP)', link.sent.length, 3);
+        checkBytes('1st send: allOn', link.sent[0], '01 ff');
+        checkBytes('2nd send: trialParams', link.sent[1], '0c 08 02 01 00 0a 00 00 01 00 00 00 00');
+        checkBytes('3rd send: final STOP', link.sent[2], '01 30');
+        checkBool('summary.completed true', summary.completed === true);
+        checkBool('summary.aborted false', summary.aborted === false);
+        check('summary.errors 0', summary.errors, 0);
+        check('summary.skipped 0', summary.skipped, 0);
+        checkBool('emitted sequence-start', phases.includes('sequence-start'));
+        checkBool('emitted trial-running', phases.includes('trial-running'));
+        checkBool('emitted sequence-complete', phases.includes('sequence-complete'));
+        checkBool('runner inactive after a completed run', runner.active === false);
+    }
+
+    console.log(
+        '\n=== runSequence: plugin skipped + unsupported errored, arena cmds still run ==='
+    );
+    {
+        const link = makeFakeLink();
+        const runner = new Runner.ArenaRunner(link, Wire);
+        const steps = [{ kind: 'ref', conditionName: 'mixed', label: 'mixed', seqIdx: 0, dur: 0 }];
+        const conditionsByName = new Map([
+            [
+                'mixed',
+                {
+                    name: 'mixed',
+                    commands: [
+                        { type: 'plugin', plugin_name: 'camera', command_name: 'getTimestamp' },
+                        { type: 'controller', command_name: 'setColorDepth', gs_val: 16 },
+                        { type: 'controller', command_name: 'allOff' }
+                    ]
+                }
+            ]
+        ]);
+        const phases = [];
+        const summary = await runner.runSequence({
+            steps,
+            conditionsByName,
+            resolvePatternId: () => 1,
+            sleep: () => Promise.resolve(),
+            onProgress: (s) => phases.push(s.phase)
+        });
+        check('plugin counted as skipped', summary.skipped, 1);
+        check('setColorDepth counted as error', summary.errors, 1);
+        // allOff (01 00) sent, then the final STOP (01 30). The plugin + setColorDepth
+        // emit NO wire frame.
+        checkBytes('arena allOff still sent', link.sent[0], '01 00');
+        checkBytes('final STOP sent', link.sent[link.sent.length - 1], '01 30');
+        checkBool('emitted a skip phase', phases.includes('skip'));
+        checkBool('emitted an error phase', phases.includes('error'));
+        checkBool('run still completed (proceed-and-skip)', summary.completed === true);
+    }
+
+    console.log('\n=== runSequence: STOP mid-run aborts (no later steps sent) ===');
+    {
+        // A fake link that calls runner.stop() on the first allOn send, so the abort
+        // flag is set before the loop reaches step 1 (cond b's allOff).
+        let triggered = false;
+        let runnerRef = null;
+        const link = {
+            connected: true,
+            sent: [],
+            async send(bytes) {
+                this.sent.push(Array.from(bytes));
+                if (!triggered && bytes[1] === 0xff) {
+                    triggered = true;
+                    runnerRef.stop(); // fire-and-forget; sets _abort synchronously
+                }
+                return new Uint8Array([0x02, 0x00, bytes[1]]);
+            }
+        };
+        runnerRef = new Runner.ArenaRunner(link, Wire);
+        const steps = [
+            { kind: 'ref', conditionName: 'a', label: 'a', seqIdx: 0, dur: 0 },
+            { kind: 'ref', conditionName: 'b', label: 'b', seqIdx: 1, dur: 0 }
+        ];
+        const conditionsByName = new Map([
+            ['a', { name: 'a', commands: [{ type: 'controller', command_name: 'allOn' }] }],
+            ['b', { name: 'b', commands: [{ type: 'controller', command_name: 'allOff' }] }]
+        ]);
+        const summary = await runnerRef.runSequence({
+            steps,
+            conditionsByName,
+            resolvePatternId: () => 1,
+            sleep: () => Promise.resolve()
+        });
+        checkBool('cond b allOff (01 00) never sent', !link.sent.some((f) => f[1] === 0x00));
+        checkBool('summary.aborted true', summary.aborted === true);
+        checkBool('summary.completed false', summary.completed === false);
+        checkBool('runner inactive after abort', runnerRef.active === false);
+    }
+
     console.log('\n=== Summary ===');
     console.log(`${totalChecks - failures} / ${totalChecks} checks passed`);
     process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -1019,9 +1019,6 @@ console.log('\n--- Suite 12: select-typed schema field type preservation ---');
         '        frame_index: 1',
         '        frame_rate: 60',
         '        gain: 0',
-        '      - type: controller',
-        '        command_name: setColorDepth',
-        '        gs_val: 16',
         '      - type: plugin',
         '        plugin_name: log',
         '        command_name: log',
@@ -1035,10 +1032,8 @@ console.log('\n--- Suite 12: select-typed schema field type preservation ---');
     // 1. Initial types preserved through parse
     check('select: trialParams.mode is number', typeof cmds[0].mode, 'number');
     check('select: trialParams.mode value', cmds[0].mode, 2);
-    check('select: setColorDepth.gs_val is number', typeof cmds[1].gs_val, 'number');
-    check('select: setColorDepth.gs_val value', cmds[1].gs_val, 16);
-    check('select: log.level is string', typeof cmds[2].params.level, 'string');
-    check('select: log.level value', cmds[2].params.level, 'DEBUG');
+    check('select: log.level is string', typeof cmds[1].params.level, 'string');
+    check('select: log.level value', cmds[1].params.level, 'DEBUG');
 
     // 2. Schema lookup returns the right type info
     const trialParamsSchema = getV3CommandParams(exp, 'controller', null, 'trialParams');
@@ -1046,10 +1041,10 @@ console.log('\n--- Suite 12: select-typed schema field type preservation ---');
     check('select: trialParams.mode schema.options[0].value type',
         typeof trialParamsSchema.mode.options[0].value, 'number');
 
-    const setColorDepthSchema = getV3CommandParams(exp, 'controller', null, 'setColorDepth');
-    check('select: setColorDepth.gs_val schema.type', setColorDepthSchema.gs_val.type, 'select');
-    check('select: setColorDepth.gs_val schema.options[0].value type',
-        typeof setColorDepthSchema.gs_val.options[0].value, 'number');
+    // setColorDepth was dropped (SWITCH_GRAYSCALE 0x06 is unsupported on G6) — it no
+    // longer has a controller schema, which is how the editor flags it as unsupported.
+    check('dropped: setColorDepth has no controller schema',
+        getV3CommandParams(exp, 'controller', null, 'setColorDepth'), null);
 
     const logSchema = getV3CommandParams(exp, 'plugin', 'log', 'log');
     check('select: log.level schema.type', logSchema.level.type, 'select');
@@ -1058,27 +1053,20 @@ console.log('\n--- Suite 12: select-typed schema field type preservation ---');
 
     // 3. docSet with the right type preserves it through round-trip
     docSet(exp, ['conditions', 0, 'commands', 0, 'mode'], 4);
-    docSet(exp, ['conditions', 0, 'commands', 1, 'gs_val'], 2);
-    docSet(exp, ['conditions', 0, 'commands', 2, 'params', 'level'], 'WARNING');
+    docSet(exp, ['conditions', 0, 'commands', 1, 'params', 'level'], 'WARNING');
 
     const reparsed = parseV3Protocol(generateV3Protocol(exp));
     const r = reparsed.conditions[0].commands;
     check('select: round-trip mode stays number', typeof r[0].mode, 'number');
     check('select: round-trip mode value', r[0].mode, 4);
-    check('select: round-trip gs_val stays number', typeof r[1].gs_val, 'number');
-    check('select: round-trip gs_val value', r[1].gs_val, 2);
-    check('select: round-trip level stays string', typeof r[2].params.level, 'string');
-    check('select: round-trip level value', r[2].params.level, 'WARNING');
+    check('select: round-trip level stays string', typeof r[1].params.level, 'string');
+    check('select: round-trip level value', r[1].params.level, 'WARNING');
 
     // 4. The exported YAML should NOT quote the numeric selects
     const regen = generateV3Protocol(exp);
     checkTrue(
         'select: regen YAML has unquoted numeric mode',
         /mode:\s*4\b/.test(regen)
-    );
-    checkTrue(
-        'select: regen YAML has unquoted numeric gs_val',
-        /gs_val:\s*2\b/.test(regen)
     );
 }
 


### PR DESCRIPTION
Closes [LAB-97](https://linear.app/reiser-lab/issue/LAB-97). Generalizes the single-trial dry-run (LAB-94) into a **full-sequence runner**: the browser walks a whole v3 `experiment_structure` over Web Serial — conditions × repeats, client-side `wait`, ITI — emitting controller commands only (plugins skipped-with-warning). Builds on LAB-95/96 pattern resolution.

## What's new

**`js/arena-runner-g6.js`** (pure, dual-export, Node-tested — no sibling imports):
- `flattenStructure(experiment, {shuffle})` — `experiment_structure` → ordered step list (block reps + per-rep `randomize` via an **injected** shuffle + ITI between-not-after-final). The timeline preview now delegates to it (one tested definition for preview *and* run).
- `translateCommand(cmd, {patternId})` — one command → a wire-neutral IR (`trialParams`/`allOn`/`allOff`/`stopDisplay`/`setFramePosition`/`wait`/`skip`/`error`).
- `ArenaRunner.runSequence()` — async executor: replays each condition's commands in order, abort-aware host-side trial timing, **STOP checked before every step and every command**.
- `conditionDuration()` — shared `max(trialParams.duration, sum waits)`.

**Timing model — interim, host-side.** The controller-run trial `duration` isn't in firmware yet ([reiserlab/LED-Display_G6_Firmware_Arena#4](https://github.com/reiserlab/LED-Display_G6_Firmware_Arena/issues/4)). The browser drives trial timing with a best-effort JS timer, isolated in `hostSideTrialEnd()` — swapping to the controller duration later is a one-function change. A slept/closed tab won't keep time → **STOP/abort is primary** (marked in code + UI).

**`experiment_designer_v3.html` (v0.30):** "▶ Run on arena" button, pre-run check modal (steps / est. duration / W-C source / plugin + pattern skips), `onRunSequence` (importMode-guarded start, connect-on-demand), generalized run-status progress UI (block · condition · rep N/M · step i/total · next) + live elapsed clock.

## Palette cleanup (verified vs G6 firmware `commands.h`)
- **DROP `setColorDepth`** — maps to SWITCH_GRAYSCALE `0x06`, dropped on G6 (color depth is a `.pat`/SD-header property). Now schema-less, flagged "⚠ unsupported" on the command card, and errored-then-skipped by the runner. MATLAB still implements it → filing a maDisplayTools issue to drop it there too.
- **KEEP `setPositionX`**, redefined as the Mode-3 frame jump → `SET_FRAME_POSITION` (0x70); `posX` is a 0-based frame index (key kept for YAML compat, labels updated).

## Test plan
- `npm test` green. New `test-arena-runner-g6.js` suites (111 checks) cover flatten (reps/ITI/rep-indices/durations/injected shuffle), translate (every op incl. `setColorDepth`→error, plugin→skip, `setPositionX`→0-based jump, null-patternId→error), and a `runSequence` integration (fake link + injected instant sleep) asserting the exact byte order (`allOn`→`trialParams`→STOP), skip/error accounting, and mid-run abort. Suite 12 of `test-protocol-roundtrip-v3.js` de-`setColorDepth`'d (numeric-select still covered by `trialParams.mode`).
- **Browser (no hardware):** loaded `v3_multi_block.yaml` via the preview — module loads with no console errors, timeline renders 19 steps via the delegated flatten, pre-run modal shows the right summary, the run loop sends correct frames in order with resolved pattern IDs, progress UI + elapsed update, and **STOP aborts cleanly** (no further frames). _(Real serial connect needs hardware — bench step.)_
- **Hardware (bench):** pending — a multi-condition protocol runs start→finish on the real G6 2×10; STOP mid-run.

## Notes
- `js/protocol-yaml-v3.js`, `js/plugin-registry.js`, and `test-protocol-roundtrip-v3.js` were already not prettier-clean on `main` (CI doesn't run `format:check`). To keep this PR scoped, those files carry **only the logical edits** (no whole-file reformat); the already-clean runner files keep prettier formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)