### PR TITLE
fix(g6): trial timing overlaps waits + timeline run-position highlight [LAB-97]

### DIFF
--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -1244,6 +1244,17 @@
         .step.iti { background: rgba(139, 148, 158, 0.05); border-color: var(--border); color: var(--text-dim); min-width: 40px; }
         .step .step-label { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
         .step .step-dur { color: var(--text-dim); margin-top: 0.1rem; }
+        /* Live run-position highlight — the step currently executing on the arena.
+           After the kind rules so it wins the border/background. */
+        .step.running {
+            border-color: #ff5252;
+            background: rgba(255, 82, 82, 0.18);
+            animation: stepRunPulse 1s ease-in-out infinite;
+        }
+        @keyframes stepRunPulse {
+            0%, 100% { box-shadow: 0 0 0 2px rgba(255, 82, 82, 0.4), 0 0 6px rgba(255, 82, 82, 0.35); }
+            50% { box-shadow: 0 0 0 2px rgba(255, 82, 82, 0.7), 0 0 12px rgba(255, 82, 82, 0.6); }
+        }
         .randomize-note {
             font-size: 0.7rem;
             color: var(--warn);
@@ -1504,7 +1515,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.30 | <span id="footerTimestamp">2026-06-11 10:31 ET</span>
+        v3 Experiment Designer v0.31 | <span id="footerTimestamp">2026-06-11 16:19 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -5145,6 +5156,21 @@
             logEl.scrollTop = logEl.scrollHeight;
         }
 
+        // Run-position highlight on the bottom timeline: mark the step currently
+        // executing on the arena (keys off data-step-idx set in renderTimeline).
+        // Nominal vs run order match for non-randomized sequences; for randomized
+        // blocks it tracks the right block — enough as a "you are here" cue.
+        function highlightTimelineStep(runIndex) {
+            document
+                .querySelectorAll('#timelineTrack .timeline-steps .step')
+                .forEach((c) => c.classList.toggle('running', Number(c.dataset.stepIdx) === runIndex));
+        }
+        function clearTimelineHighlight() {
+            document
+                .querySelectorAll('#timelineTrack .step.running')
+                .forEach((c) => c.classList.remove('running'));
+        }
+
         function updateRunStatus(s) {
             $('runStatus').style.display = 'block';
             const dot = $('runStatusDot');
@@ -5176,9 +5202,11 @@
             } else if (phase === 'stopped') {
                 msg.textContent = 'Stopped';
                 dot.className = 'run-status-dot connected';
+                clearTimelineHighlight();
             } else if (phase === 'disconnected') {
                 msg.textContent = 'Disconnected';
                 dot.className = 'run-status-dot';
+                clearTimelineHighlight();
             } else if (phase === 'error') {
                 // Shared by the single-trial path ({error}) and per-step sequence
                 // errors ({reason, step}). A step-scoped error is non-fatal
@@ -5189,6 +5217,7 @@
                 if (!s.step) {
                     msg.textContent = 'Error: ' + m;
                     dot.className = 'run-status-dot error';
+                    clearTimelineHighlight();
                 }
             } else if (phase === 'sequence-start') {
                 msg.textContent = 'Running sequence — ' + (s.total || 0) + ' step' + (s.total === 1 ? '' : 's');
@@ -5197,6 +5226,7 @@
             } else if (phase === 'step-start') {
                 msg.textContent = seqMsg(s);
                 dot.className = 'run-status-dot running';
+                highlightTimelineStep(s.index);
             } else if (phase === 'trial-running') {
                 runLog(seqLine(s) + ' → trial running (' + (s.durationSec || 0) + 's host-side)');
             } else if (phase === 'command') {
@@ -5213,10 +5243,12 @@
                     (sm.errors ? ', ' + sm.errors + ' error' + (sm.errors === 1 ? '' : 's') : '');
                 dot.className = 'run-status-dot connected';
                 runLog('✓ sequence complete');
+                clearTimelineHighlight();
             } else if (phase === 'aborted') {
                 msg.textContent = 'Sequence stopped (STOP)';
                 dot.className = 'run-status-dot connected';
                 runLog('■ sequence aborted by STOP');
+                clearTimelineHighlight();
             }
             // Button states reflect live link/runner state.
             $('runStopBtn').disabled = !(arenaRunner && arenaRunner.active);
@@ -6118,6 +6150,8 @@
                 const cell = el('div', {
                     class: 'step ' + step.kind + (isSelected ? ' selected' : ''),
                     style: 'width: ' + width + 'px;',
+                    // Run-progress highlight keys off this ordinal (see highlightTimelineStep).
+                    'data-step-idx': String(i),
                     title: 'Click to select ' + (step.kind === 'ref' ? '"' + step.label + '" ref' : 'block "' + (step.blockName || step.seqIdx) + '"'),
                     onClick: () => onTimelineStepClick(step)
                 },

--- a/js/arena-runner-g6.js
+++ b/js/arena-runner-g6.js
@@ -353,10 +353,15 @@ var ArenaRunnerG6 = (function () {
     /**
      * TIMING MODEL — interim, host-side (firmware issue
      * reiserlab/LED-Display_G6_Firmware_Arena#4). The controller-run trial
-     * `duration` is NOT in firmware yet, so the browser drives trial timing: after a
-     * trialParams send acks OK, sleep `durationSec`, then advance to the next
-     * command/step. This function is the ONE place that decides "when is a trial
-     * done".
+     * `duration` is NOT in firmware yet, so the browser holds the trial's display
+     * time. IMPORTANT: a trialParams display OVERLAPS the condition's `wait`
+     * commands (the controller loops the pattern autonomously while the host waits),
+     * so the trial duration is NOT added to the waits. runSequence sleeps the waits
+     * as they occur, then calls this ONCE per condition to "top up" only the
+     * remainder — `max(trialDuration, sum(waits)) - sum(waits)` — giving a
+     * wall-clock of `max(trialDuration, sum(waits))`, matching conditionDuration /
+     * the timeline. (Sleeping per trialParams AND per wait double-counted — the bug
+     * this model fixes.)
      *
      * SWAP POINT: once #4 lands (trial_params carries a controller-run duration and
      * the controller signals completion), replace this with a function that AWAITS
@@ -366,11 +371,11 @@ var ArenaRunnerG6 = (function () {
      * Best-effort: a slept/closed tab won't fire the timer, so STOP/abort is the
      * primary control.
      *
-     * @param {number} durationSec               trial duration in s (0 ⇒ no wait)
-     * @param {function(number):Promise} sleep    abort-aware sleep(ms)
+     * @param {number} remainderSec               trial time left after the waits (0 ⇒ none)
+     * @param {function(number):Promise} sleep     abort-aware sleep(ms)
      */
-    async function hostSideTrialEnd(durationSec, sleep) {
-        await sleep((Number(durationSec) || 0) * 1000);
+    async function hostSideTrialEnd(remainderSec, sleep) {
+        await sleep((Number(remainderSec) || 0) * 1000);
     }
 
     // ---- run-state machine ----------------------------------------------
@@ -619,11 +624,14 @@ var ArenaRunnerG6 = (function () {
                         emit({ phase: 'step-done', index: i, total: steps.length, step });
                         continue;
                     }
+                    // Per-condition timing accumulators: the max trialParams target
+                    // duration and the total time actually slept on wait commands.
+                    const acc = { trialTargetSec: 0, waitedSec: 0 };
                     for (const cmd of cond.commands) {
                         if (this._abort) break;
                         const ir = translateCommand(cmd, { patternId: resolvePatternId(cmd) });
                         try {
-                            await this._runIR(ir, { step, index: i, emit, timing, sleep, summary });
+                            await this._runIR(ir, { step, index: i, emit, sleep, summary, acc });
                         } catch (e) {
                             // A wire/link failure mid-command: surface it and abort
                             // the run (the finally sends STOP). Don't blindly continue
@@ -639,6 +647,15 @@ var ArenaRunnerG6 = (function () {
                             });
                             break;
                         }
+                    }
+                    // Condition-level host-side trial timing: hold so the trial gets
+                    // its full display duration OVERLAPPING the waits (not added to
+                    // them), making wall-clock == max(trialDuration, sum(waits)) — the
+                    // value conditionDuration / the timeline shows. When firmware #4
+                    // lands (controller enforces duration + signals done), this top-up
+                    // is what gets swapped for awaiting that signal.
+                    if (!this._abort && acc.trialTargetSec > acc.waitedSec) {
+                        await timing(acc.trialTargetSec - acc.waitedSec, sleep);
                     }
                     emit({ phase: 'step-done', index: i, total: steps.length, step });
                 }
@@ -668,7 +685,7 @@ var ArenaRunnerG6 = (function () {
          * Throws only on a link/send failure (the caller aborts the run).
          */
         async _runIR(ir, ctx) {
-            const { step, index, emit, timing, sleep, summary } = ctx;
+            const { step, index, emit, sleep, summary, acc } = ctx;
             const W = this._wire;
             switch (ir.op) {
                 case 'trialParams': {
@@ -693,8 +710,15 @@ var ArenaRunnerG6 = (function () {
                         response: resp,
                         durationSec: ir.durationSec
                     });
-                    // Host-side timing (interim — firmware #4). Abort-aware via sleep.
-                    await timing(ir.durationSec, sleep);
+                    // Trial timing is host-side (interim — firmware #4) but does NOT
+                    // block here: the controller displays the pattern autonomously
+                    // while the condition's wait commands run CONCURRENTLY. We only
+                    // record the trial's target duration; runSequence tops up at the
+                    // end of the condition if the waits didn't cover it, so the
+                    // condition's wall-clock == max(trialDuration, sum(waits)) — the
+                    // same value the timeline estimates. (Sleeping here AND on every
+                    // wait double-counted the time.)
+                    acc.trialTargetSec = Math.max(acc.trialTargetSec, Number(ir.durationSec) || 0);
                     return;
                 }
                 case 'allOn':
@@ -715,6 +739,7 @@ var ArenaRunnerG6 = (function () {
                     return;
                 case 'wait':
                     await sleep((Number(ir.durationSec) || 0) * 1000);
+                    acc.waitedSec += Number(ir.durationSec) || 0;
                     emit({ phase: 'command', index, step, op: ir.op, value: ir.durationSec });
                     return;
                 case 'skip':

--- a/tests/test-arena-runner-g6.js
+++ b/tests/test-arena-runner-g6.js
@@ -565,6 +565,55 @@ async function main() {
         checkBool('runner inactive after abort', runnerRef.active === false);
     }
 
+    console.log('\n=== runSequence: host-side timing — trial OVERLAPS waits (no double-count) ===');
+    {
+        // Inject a sleep that SUMS requested ms instead of waiting, so we can assert
+        // the total host time per condition == max(trialDuration, sum(waits)).
+        const totalSleptSec = async (commands) => {
+            const link = makeFakeLink();
+            const runner = new Runner.ArenaRunner(link, Wire);
+            let ms = 0;
+            await runner.runSequence({
+                steps: [{ kind: 'ref', conditionName: 'c', label: 'c', seqIdx: 0, dur: 0 }],
+                conditionsByName: new Map([['c', { name: 'c', commands }]]),
+                resolvePatternId: () => 1,
+                sleep: (n) => {
+                    ms += n;
+                    return Promise.resolve();
+                }
+            });
+            return ms / 1000;
+        };
+        const tp = (d) => ({
+            type: 'controller',
+            command_name: 'trialParams',
+            mode: 2,
+            frame_rate: 10,
+            gain: 0,
+            frame_index: 0,
+            duration: d
+        });
+        const w = (d) => ({ type: 'wait', duration: d });
+        const allOn = { type: 'controller', command_name: 'allOn' };
+        check(
+            'trialParams(5)+wait(5) = 5s (overlap, NOT 10)',
+            await totalSleptSec([tp(5), w(5)]),
+            5
+        );
+        check(
+            'trialParams(10)+wait(3) = 10s (waits + 7s top-up)',
+            await totalSleptSec([tp(10), w(3)]),
+            10
+        );
+        check('standalone trialParams(5) = 5s (full top-up)', await totalSleptSec([tp(5)]), 5);
+        check('no trialParams: allOn+wait(2) = 2s', await totalSleptSec([allOn, w(2)]), 2);
+        check(
+            'two waits sum: trialParams(2)+wait(3)+wait(4) = 7s',
+            await totalSleptSec([tp(2), w(3), w(4)]),
+            7
+        );
+    }
+
     console.log('\n=== Summary ===');
     console.log(`${totalChecks - failures} / ${totalChecks} checks passed`);
     process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Two follow-ups to the LAB-97 runner ([#101](https://github.com/reiserlab/webDisplayTools/pull/101)), both from bench testing.

## 1. Trial timing was double-counting (~2× the estimate)
`runSequence` slept `trialParams.duration` **and** each `wait` sequentially, so a condition like `trialParams(5) + wait(5)` ran 10s while the timeline estimated 5s. But the designer (and `computeLaneData`) model them as **overlapping**: `conditionDuration = max(trialParams.duration, sum(waits))` — the controller displays the pattern autonomously while the host's waits run concurrently.

**Fix:** `trialParams` records its target duration (no blocking sleep on the send), `wait`s drive the clock, and the condition **tops up only the remainder** at the end. Wall-clock is now `max(duration, sum(waits))`, matching the timeline. `hostSideTrialEnd` now realizes the per-condition top-up; the firmware-#4 swap point is unchanged.

+5 timing unit tests (inject a summing `sleep`): `trialParams(5)+wait(5)=5s` (not 10), `trialParams(10)+wait(3)=10s`, standalone `trialParams(5)=5s`, `allOn+wait(2)=2s`, two-waits sum.

## 2. Timeline run-position highlight
The bottom timeline now **red-highlights the step currently executing** on the arena (`data-step-idx` + `.step.running`, driven by the `step-start` progress event), cleared on complete / stop / abort / disconnect / fatal error. A "you are here" cue during a run.

## Verification
- `npm test` green (runner suite now 116 checks).
- Browser (preview, fake link): ran `g6_2x10_smoke` — the red highlight tracked the running cell (show_grating_sq → show_rotation → …) and the **elapsed clock matched the estimate** (0:15 at step 5 = arena_check 1 + 3 + 4 + 4 + ~3, i.e. no doubling); STOP cleared the highlight and re-enabled Run.

v0.31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)