### PR TITLE
feat(g6): auto-center the running step in the timeline during a run [LAB-97]

### DIFF
--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -1515,7 +1515,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.31 | <span id="footerTimestamp">2026-06-11 16:19 ET</span>
+        v3 Experiment Designer v0.32 | <span id="footerTimestamp">2026-06-11 16:24 ET</span>
     </div>
 
     <!-- Error modal -->
@@ -5161,9 +5161,24 @@
         // Nominal vs run order match for non-randomized sequences; for randomized
         // blocks it tracks the right block — enough as a "you are here" cue.
         function highlightTimelineStep(runIndex) {
-            document
-                .querySelectorAll('#timelineTrack .timeline-steps .step')
-                .forEach((c) => c.classList.toggle('running', Number(c.dataset.stepIdx) === runIndex));
+            const track = $('timelineTrack');
+            if (!track) return;
+            let active = null;
+            track.querySelectorAll('.timeline-steps .step').forEach((c) => {
+                const on = Number(c.dataset.stepIdx) === runIndex;
+                c.classList.toggle('running', on);
+                if (on) active = c;
+            });
+            // Keep the active step centered in the horizontally-scrolling timeline.
+            // scrollTo clamps at the ends, so the first/last few steps sit as centered
+            // as the content allows. Scrolls ONLY the track, never the page (we set the
+            // track's scrollLeft directly rather than using scrollIntoView).
+            if (active) {
+                const cRect = track.getBoundingClientRect();
+                const aRect = active.getBoundingClientRect();
+                const delta = aRect.left - cRect.left - (track.clientWidth / 2 - aRect.width / 2);
+                track.scrollTo({ left: track.scrollLeft + delta, behavior: 'smooth' });
+            }
         }
         function clearTimelineHighlight() {
             document


### PR DESCRIPTION
Small follow-up to the run-position highlight ([#102](https://github.com/reiserlab/webDisplayTools/pull/102)): the timeline now keeps the **active step centered** in the horizontally-scrolling track as the run advances (sets the track's `scrollLeft` directly with smooth behavior — scrolls only the track, never the page). `scrollTo` clamps at the ends, so the first/last steps sit as centered as the content allows.

Verified deterministically in the preview: a mid-sequence cell (idx 10) centers to **0px residual** (scrollLeft 1089); an end cell (idx 13) **clamps at maxScroll** (can't center near the end — the "enough on either side" caveat). The highlight wiring (`step-start` → highlight) was already verified.

v0.32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)