### PR TITLE
fix(v3): create variables: in canonical order — fixes editor freeze on variable bind

### DIFF
--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -1515,7 +1515,7 @@
     <!-- Footer -->
     <div class="app-footer">
         <a href="https://github.com/reiserlab/webDisplayTools" target="_blank">Reiser Lab</a> |
-        v3 Experiment Designer v0.32 | <span id="footerTimestamp">2026-06-11 16:24 ET</span>
+        v3 Experiment Designer v0.33 | <span id="footerTimestamp">2026-06-11 18:22 ET</span>
     </div>
 
     <!-- Error modal -->

--- a/js/protocol-yaml-v3.js
+++ b/js/protocol-yaml-v3.js
@@ -1651,14 +1651,16 @@ function docCreateVariable(experiment, name, value) {
         );
     }
 
-    // Find or create the variables: map. yaml@2's setIn replaces nodes
-    // wholesale, so we create a fresh YAMLMap only if absent.
-    let varsNode = experiment._doc.get('variables', true);
-    if (!varsNode || !Array.isArray(varsNode.items)) {
-        const newMap = experiment._doc.createNode({});
-        experiment._doc.set('variables', newMap);
-        varsNode = experiment._doc.get('variables', true);
-    }
+    // Find or create the variables: map AT THE CANONICAL POSITION (before the
+    // alias-bearing experiment:/conditions: sections). A plain doc.set('variables',…)
+    // APPENDS the section to the END of the root map — after conditions: — so a
+    // freshly-created anchor would sit AFTER any command field that binds to it.
+    // yaml@2 stringifies with verifyAliasOrder (default), so the alias would then
+    // precede its anchor and experiment._doc.toString() would throw "Unresolved
+    // alias" — which fires from snapshotState() on the NEXT pushUndo, breaking
+    // every subsequent mutation + undo (the editor appears frozen). ensureTopLevelSection
+    // splices variables: at the right spot (it's the same helper the D4 importer uses).
+    const varsNode = ensureTopLevelSection(experiment, 'variables', 'map');
 
     // Build the scalar with the anchor attached, then assemble the pair.
     const valueNode = experiment._doc.createNode(value);

--- a/tests/test-protocol-roundtrip-v3.js
+++ b/tests/test-protocol-roundtrip-v3.js
@@ -3483,6 +3483,60 @@ console.log('\n--- Suite N13: import canonical plugin binding (#89) ---');
     check('N13d: prefix change leaves canonical bind alone', stR.batch.pluginRegistry.get('specialCam').plannedName, 'specialCam');
 }
 
+// ─── Suite 31: variables-section ORDERING — the "frozen editor" bug ───────────
+// docCreateVariable must insert `variables:` BEFORE the alias-bearing sections
+// (experiment:/conditions:). When the section was appended at the end (old
+// doc.set), a freshly-created anchor sat AFTER the command alias bound to it, so
+// experiment._doc.toString() threw "Unresolved alias" — which fires from
+// snapshotState() on the NEXT pushUndo, freezing the editor.
+console.log('\n--- Suite 32: variables ordering (frozen-editor bugfix) ---');
+{
+    const yaml = [
+        'version: 3',
+        'experiment_info: {name: t}',
+        'rig: "/tmp/r.yaml"',
+        'experiment: [c1]',
+        'conditions:',
+        '  - name: c1',
+        '    commands:',
+        '      - type: wait',
+        '        duration: 5'
+    ].join('\n') + '\n';
+    const exp = parseV3Protocol(yaml); // NO variables: section
+    docCreateVariable(exp, 'pause_short', 1);
+    docBindToAnchor(exp, ['conditions', 0, 'commands', 0, 'duration'], 'pause_short');
+
+    let text = null;
+    let threw = null;
+    try {
+        text = exp._doc.toString();
+    } catch (e) {
+        threw = e.message;
+    }
+    checkTrue(
+        '31.1: toString() does not throw after binding on a no-variables doc',
+        threw === null,
+        threw || ''
+    );
+    if (text) {
+        const ai = text.indexOf('&pause_short');
+        const li = text.indexOf('*pause_short');
+        checkTrue(
+            '31.2: anchor &pause_short precedes alias *pause_short',
+            ai >= 0 && li >= 0 && ai < li,
+            'anchorIdx=' + ai + ' aliasIdx=' + li
+        );
+        checkTrue(
+            '31.3: variables: section sits before conditions:',
+            text.indexOf('\nvariables:') >= 0 &&
+                text.indexOf('\nvariables:') < text.indexOf('\nconditions:'),
+            text.slice(0, 90)
+        );
+        const re = parseV3Protocol(text);
+        check('31.4: rebound field resolves to the anchor value', re.conditions[0].commands[0].duration, 1);
+    }
+}
+
 // ─── Results ────────────────────────────────────────────────────────────────
 console.log('\n=== Results: ' + passedTests + '/' + totalTests + ' passed ===');
 if (failedTests.length > 0) {


### PR DESCRIPTION
## The bug
Binding/using a YAML-anchor **variable** froze the v3 Experiment Designer — buttons stopped responding and undo stopped working. Reproduced on any protocol with no pre-existing `variables:` section (＋New, or an existing YAML lacking variables), via either "+ Add a variable then bind" or "create & bind in place".

## Root cause
`docCreateVariable` created the `variables:` map with `doc.set('variables', …)`, which **appends it at the end** of the document — *after* `conditions:`. A freshly-created anchor then sat *after* the command field bound to it, so yaml@2 (`verifyAliasOrder`, default) made `experiment._doc.toString()` throw:

```
Unresolved alias (the anchor must be set before the alias): pause_short
  at Document.toString → snapshotState (1784) → pushUndo (1798) → onAddCommand
```

The bind itself returns fine (pushUndo snapshots *before* the mutation), but the **next** mutation/undo calls `snapshotState()` → `toString()` → throws uncaught, and since handlers call `pushUndo()` outside their try, every subsequent click silently aborts → frozen UI. (Not an infinite loop — a throw on every action.)

## Fix
One line in `docCreateVariable`: use the existing ordering-safe `ensureTopLevelSection(experiment, 'variables', 'map')` (the same helper the D4 importer uses) instead of `doc.set` — it splices `variables:` at the canonical position (before `experiment:`/`conditions:`). The helper's own doc comment describes exactly this failure mode; `docCreateVariable` just predated it.

## Verification
- **Node repro** (before: `toString` throws; after: clean, anchor precedes alias).
- **Regression test**: Suite 32 in `tests/test-protocol-roundtrip-v3.js` — bind on a no-variables doc, assert `toString()` doesn't throw + anchor precedes alias + value round-trips. `npm test` green (643/643 v3).
- **Browser**: loaded `v3_no_variables.yaml`, created+bound `pause_short`, then did the previously-fatal follow-up mutation — completes in 3ms, no error, responsive.
- **Independently root-caused by an adversarial Codex review** — identical cause + identical fix.

v0.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)