### PR TITLE
Run-log module foundation (js/run-log.js)

### DIFF
--- a/js/run-log.js
+++ b/js/run-log.js
@@ -1,0 +1,283 @@
+/**
+ * run-log.js — structured experiment run-log builder (Arena Studio).
+ *
+ * A DOM-free accumulator that turns a recorded experiment run into a
+ * self-describing, exportable record: a metadata header + a timestamped event
+ * stream + a run summary. The browser feeds it the ArenaRunner's onProgress
+ * phases (no new instrumentation — those events already carry everything); this
+ * module stamps each one (the runner emits no timestamps) and serializes to
+ * BOTH runlog.json (canonical, for analysis) and runlog.txt (human transcript),
+ * generated from the same array so they can never drift.
+ *
+ * Provenance: the header records the protocol filename + sha256 the run actually
+ * used, so the saved .yaml on disk and this log are self-verifying as a pair
+ * (re-hash the file, compare). intent='test' runs are tagged and carry no hash.
+ *
+ * LOADING: classic <script src> (window-global + CommonJS dual-export, no ES
+ * `export`) — same pattern as arena-session.js / arena-runner-g6.js, so it loads
+ * before the module block and dodges the ES-import-cache gotcha. The core is
+ * DOM-free + clock-injectable so it is fully unit-testable under Node
+ * (tests/test-run-log.js); only `download()` touches the DOM and is guarded.
+ */
+(function (global) {
+    'use strict';
+
+    const SCHEMA = 'arena-studio-runlog/1';
+
+    function iso(ms) {
+        return new Date(ms).toISOString();
+    }
+    function round(n, d) {
+        const f = Math.pow(10, d);
+        return Math.round(n * f) / f;
+    }
+    // Filesystem-safe slug for filenames (experimenter etc.).
+    function slug(s) {
+        return (
+            String(s || '')
+                .trim()
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '-')
+                .replace(/^-+|-+$/g, '') || 'anon'
+        );
+    }
+    // Strip a YAML extension to a basename for the log filename.
+    function baseName(filename) {
+        return String(filename || 'untitled').replace(/\.ya?ml$/i, '');
+    }
+    // Derive a terminal outcome flag from the runner summary (+ optional override).
+    function deriveOutcome(summary, override) {
+        if (override) return override;
+        if (!summary) return 'UNKNOWN';
+        if (summary.aborted) return 'ABORTED_BY_USER';
+        if (summary.errors > 0) return 'ERRORED';
+        if (summary.completed) return 'COMPLETED';
+        return 'UNKNOWN';
+    }
+
+    // One readable transcript line per event. Known runner phases get friendly
+    // text; anything else falls back to a compact JSON dump so nothing is lost.
+    function formatLine(ev) {
+        const stamp = ev.t_iso.slice(11, 19) + '  ';
+        const step = ev.step || {};
+        const where =
+            ev.index != null ? '[' + (ev.index + 1) + (ev.total ? '/' + ev.total : '') + '] ' : '';
+        switch (ev.phase) {
+            case 'sequence-start':
+                return stamp + '▸ sequence start — ' + (ev.total || 0) + ' steps (host-timed)';
+            case 'step-start':
+                return (
+                    stamp +
+                    '▸ ' +
+                    where +
+                    (step.conditionName || step.label || '') +
+                    (step.kind ? ' · ' + step.kind : '')
+                );
+            case 'trial-running':
+                return (
+                    stamp +
+                    '   ' +
+                    where +
+                    'running ' +
+                    (step.conditionName || '') +
+                    (ev.durationSec != null ? ' (' + ev.durationSec + 's, host-timed)' : '')
+                );
+            case 'command':
+                return (
+                    stamp +
+                    '   ' +
+                    where +
+                    (ev.op || 'command') +
+                    (ev.value != null ? ' ' + ev.value : '')
+                );
+            case 'skip':
+                return (
+                    stamp +
+                    '   ' +
+                    where +
+                    'SKIP ' +
+                    (ev.plugin_name || '') +
+                    (ev.command_name ? '.' + ev.command_name : '') +
+                    (ev.reason ? ' (' + ev.reason + ')' : '')
+                );
+            case 'error':
+                return stamp + '   ' + where + 'ERROR ' + (ev.reason || '');
+            case 'step-done':
+                return stamp + '   ' + where + 'done';
+            case 'sequence-complete':
+            case 'aborted':
+                return stamp + '■ ' + ev.phase;
+            default:
+                return stamp + ev.phase + ' ' + compactPayload(ev);
+        }
+    }
+    function compactPayload(ev) {
+        const out = {};
+        for (const k in ev) {
+            if (k === 't_iso' || k === 't_offset_s' || k === 'phase' || k === 'step') continue;
+            out[k] = ev[k];
+        }
+        const keys = Object.keys(out);
+        return keys.length ? JSON.stringify(out) : '';
+    }
+
+    /**
+     * Create a run-log accumulator.
+     * @param {object} [opts]
+     * @param {object} [opts.meta]   per-run metadata: run_id, experimenter, genotype,
+     *     notes, protocol_filename, protocol_sha256, arena_config, rig, firmware, tool_version
+     * @param {string} [opts.intent] 'experiment' (default) | 'test'
+     * @param {Function} [opts.now]  () => ms-since-epoch (injectable for tests; default Date.now)
+     */
+    function createRunLog(opts) {
+        const o = opts || {};
+        const now = o.now || Date.now;
+        const intent = o.intent || 'experiment';
+        const startMs = now();
+        const meta = Object.assign({}, o.meta, { timestamp_start: iso(startMs) });
+        // A test run never carries a protocol hash — keep the two un-confusable.
+        if (intent === 'test') meta.protocol_sha256 = null;
+        const events = [];
+        let summary = null;
+
+        return {
+            get intent() {
+                return intent;
+            },
+            get meta() {
+                return meta;
+            },
+            get events() {
+                return events;
+            },
+            get summary() {
+                return summary;
+            },
+
+            /** Append a stamped event (phase + arbitrary payload). Returns it. */
+            event(phase, payload) {
+                const t = now();
+                const ev = Object.assign(
+                    { t_iso: iso(t), t_offset_s: round((t - startMs) / 1000, 3), phase: phase },
+                    payload || {}
+                );
+                events.push(ev);
+                return ev;
+            },
+
+            /**
+             * Close the log at a terminal event.
+             * @param {object} runnerSummary {completed,aborted,steps,errors,skipped}
+             * @param {string} [outcomeOverride] e.g. 'DISCONNECTED'
+             */
+            finish(runnerSummary, outcomeOverride) {
+                const endMs = now();
+                summary = Object.assign({}, runnerSummary, {
+                    timestamp_end: iso(endMs),
+                    duration_s: round((endMs - startMs) / 1000, 3),
+                    outcome: deriveOutcome(runnerSummary, outcomeOverride)
+                });
+                return summary;
+            },
+
+            /** Canonical machine record. */
+            toJSON() {
+                return {
+                    schema: SCHEMA,
+                    intent: intent,
+                    meta: meta,
+                    events: events,
+                    summary: summary
+                };
+            },
+
+            /** Human transcript (lab-notebook friendly), same content as toJSON. */
+            toText() {
+                const L = [];
+                L.push('# Arena Studio run log (' + intent + ')');
+                const order = [
+                    'run_id',
+                    'timestamp_start',
+                    'experimenter',
+                    'genotype',
+                    'notes',
+                    'protocol_filename',
+                    'protocol_sha256',
+                    'arena_config',
+                    'rig',
+                    'firmware',
+                    'tool_version'
+                ];
+                for (const k of order) {
+                    if (meta[k] != null && meta[k] !== '') L.push(k + ': ' + meta[k]);
+                }
+                L.push('');
+                for (const ev of events) L.push(formatLine(ev));
+                if (summary) {
+                    L.push('');
+                    L.push(
+                        '— ' +
+                            (summary.outcome || 'DONE') +
+                            ' — ' +
+                            (summary.steps != null ? summary.steps + ' steps · ' : '') +
+                            (summary.errors || 0) +
+                            ' errors · ' +
+                            (summary.skipped || 0) +
+                            ' skipped · ' +
+                            (summary.duration_s != null ? summary.duration_s + 's' : '')
+                    );
+                    L.push(
+                        '(durations are host-side estimates — firmware-confirmed timing pending FW #4)'
+                    );
+                }
+                return L.join('\n');
+            },
+
+            /** Filename convention: <protocol>__<experimenter>__<ISO-dashes>__<run_id>.runlog.<ext> */
+            filename(ext) {
+                const isoDash = meta.timestamp_start.replace(/[:.]/g, '-').slice(0, 19);
+                return (
+                    baseName(meta.protocol_filename) +
+                    '__' +
+                    slug(meta.experimenter) +
+                    '__' +
+                    isoDash +
+                    '__' +
+                    (meta.run_id || 'run') +
+                    '.runlog.' +
+                    (ext || 'json')
+                );
+            }
+        };
+    }
+
+    // Browser-only: trigger a download of the log as .json (+ .txt). Reuses the
+    // arena_console #btn-save Blob+anchor recipe. No-op (returns false) under Node.
+    function download(log, opts) {
+        if (typeof document === 'undefined') return false;
+        const both = !opts || opts.text !== false;
+        const drop = (text, ext, mime) => {
+            const blob = new Blob([text], { type: mime });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = log.filename(ext);
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        };
+        drop(JSON.stringify(log.toJSON(), null, 2), 'json', 'application/json');
+        if (both) drop(log.toText(), 'txt', 'text/plain');
+        return true;
+    }
+
+    const RunLog = { createRunLog, download, slug, baseName, deriveOutcome, SCHEMA };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = RunLog;
+    }
+    if (typeof global !== 'undefined') {
+        global.RunLog = RunLog;
+    }
+})(typeof window !== 'undefined' ? window : this);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.1",
     "description": "Web-based tools for configuring and editing display patterns for modular arena systems",
     "scripts": {
-        "test": "node tests/validate-arena-calculations.js && node tests/test-protocol-roundtrip.js && node tests/test-protocol-roundtrip-v3.js && node tests/test-arena-wire-g6.js && node tests/test-arena-link.js && node tests/test-arena-runner-g6.js && node tests/test-arena-session.js && node tests/test-bin-classifier.js && node tests/test-pattern-set.js && node tests/test-pat-preview.js",
+        "test": "node tests/validate-arena-calculations.js && node tests/test-protocol-roundtrip.js && node tests/test-protocol-roundtrip-v3.js && node tests/test-arena-wire-g6.js && node tests/test-arena-link.js && node tests/test-arena-runner-g6.js && node tests/test-arena-session.js && node tests/test-run-log.js && node tests/test-bin-classifier.js && node tests/test-pattern-set.js && node tests/test-pat-preview.js",
         "test:arena": "node tests/validate-arena-calculations.js",
         "test:protocol-v2": "node tests/test-protocol-roundtrip.js",
         "test:protocol-v3": "node tests/test-protocol-roundtrip-v3.js",
@@ -11,6 +11,7 @@
         "test:link": "node tests/test-arena-link.js",
         "test:runner": "node tests/test-arena-runner-g6.js",
         "test:session": "node tests/test-arena-session.js",
+        "test:run-log": "node tests/test-run-log.js",
         "test:bin-classifier": "node tests/test-bin-classifier.js",
         "test:pattern-set": "node tests/test-pattern-set.js",
         "test:pat-preview": "node tests/test-pat-preview.js",

--- a/tests/test-run-log.js
+++ b/tests/test-run-log.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Tests for js/run-log.js — the structured experiment run-log builder.
+ * Pure, DOM-free, with an injected clock for deterministic timestamps/offsets.
+ *
+ * Run: node tests/test-run-log.js   (wired into `npm test`)
+ * Exits 0 on PASS, 1 on any FAIL.
+ */
+
+'use strict';
+
+const RunLog = require('../js/run-log.js');
+
+let totalChecks = 0;
+let failures = 0;
+
+function check(name, got, expected) {
+    totalChecks++;
+    const ok = JSON.stringify(got) === JSON.stringify(expected);
+    console.log(
+        `  ${ok ? 'PASS' : 'FAIL'}  ${name}: got ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`
+    );
+    if (!ok) failures++;
+}
+function checkBool(name, ok, info) {
+    totalChecks++;
+    console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${info ? ' — ' + info : ''}`);
+    if (!ok) failures++;
+}
+
+// Deterministic clock: starts fixed, advances 1s per call.
+function fixedClock() {
+    let t = Date.parse('2026-06-17T14:32:05.000Z');
+    return () => {
+        const v = t;
+        t += 1000;
+        return v;
+    };
+}
+const META = {
+    run_id: 'a1b2',
+    experimenter: 'M Reiser',
+    genotype: 'w;UAS-CsChrimson',
+    notes: 'fly 3',
+    protocol_filename: 'looming_v3.yaml',
+    protocol_sha256: 'a1b2c3d4',
+    arena_config: 'G6_2x10',
+    rig: 'test_rig_1',
+    firmware: 'v1',
+    tool_version: 'Arena Studio v0'
+};
+
+// ── helpers ────────────────────────────────────────────────────────────────
+console.log('=== helpers ===');
+check('slug normalizes + lowercases', RunLog.slug('M Reiser'), 'm-reiser');
+check('slug empty → anon', RunLog.slug(''), 'anon');
+check('baseName strips .yaml', RunLog.baseName('looming_v3.yaml'), 'looming_v3');
+check('baseName strips .yml', RunLog.baseName('x.yml'), 'x');
+check('deriveOutcome aborted', RunLog.deriveOutcome({ aborted: true }), 'ABORTED_BY_USER');
+check('deriveOutcome errors', RunLog.deriveOutcome({ errors: 2 }), 'ERRORED');
+check('deriveOutcome completed', RunLog.deriveOutcome({ completed: true }), 'COMPLETED');
+check(
+    'deriveOutcome override',
+    RunLog.deriveOutcome({ completed: true }, 'DISCONNECTED'),
+    'DISCONNECTED'
+);
+
+// ── stamping + accumulation ──────────────────────────────────────────────────
+console.log('=== stamping ===');
+{
+    const log = RunLog.createRunLog({ meta: META, now: fixedClock() });
+    check('timestamp_start stamped', log.meta.timestamp_start, '2026-06-17T14:32:05.000Z');
+    check('intent defaults to experiment', log.intent, 'experiment');
+    const e1 = log.event('sequence-start', { total: 15 });
+    const e2 = log.event('step-start', {
+        index: 0,
+        total: 15,
+        step: { conditionName: 'baseline_off', kind: 'ref' }
+    });
+    check('event count', log.events.length, 2);
+    check('first offset = 1s (clock advanced once for start)', e1.t_offset_s, 1);
+    check('second offset = 2s', e2.t_offset_s, 2);
+    check('event carries phase + payload', [e1.phase, e1.total], ['sequence-start', 15]);
+    check('event iso stamped', e1.t_iso, '2026-06-17T14:32:06.000Z');
+}
+
+// ── intent=test nulls the protocol hash ──────────────────────────────────────
+console.log('=== intent=test ===');
+{
+    const log = RunLog.createRunLog({ meta: META, intent: 'test', now: fixedClock() });
+    check('test intent', log.intent, 'test');
+    check('test run nulls protocol_sha256', log.meta.protocol_sha256, null);
+}
+
+// ── finish / summary / outcome ───────────────────────────────────────────────
+console.log('=== finish ===');
+{
+    const log = RunLog.createRunLog({ meta: META, now: fixedClock() });
+    log.event('sequence-start', { total: 15 }); // clock now used twice (start + this)
+    const s = log.finish({ completed: true, aborted: false, steps: 15, errors: 0, skipped: 0 });
+    check('summary outcome', s.outcome, 'COMPLETED');
+    checkBool('summary has timestamp_end', !!s.timestamp_end);
+    check('duration_s = 2 (start@1 call, finish@3rd call)', s.duration_s, 2);
+    check('summary carried into toJSON', log.toJSON().summary.steps, 15);
+    const sAbort = RunLog.createRunLog({ meta: META, now: fixedClock() }).finish(
+        { aborted: true, steps: 4 },
+        'ABORTED_BY_USER'
+    );
+    check('aborted outcome', sAbort.outcome, 'ABORTED_BY_USER');
+}
+
+// ── toJSON shape ─────────────────────────────────────────────────────────────
+console.log('=== toJSON ===');
+{
+    const log = RunLog.createRunLog({ meta: META, now: fixedClock() });
+    log.event('command', { index: 1, op: 'allOff' });
+    log.finish({ completed: true, steps: 1, errors: 0, skipped: 0 });
+    const j = log.toJSON();
+    check('schema tag', j.schema, RunLog.SCHEMA);
+    check('top-level keys', Object.keys(j).sort(), [
+        'events',
+        'intent',
+        'meta',
+        'schema',
+        'summary'
+    ]);
+    check('meta round-trips run_id', j.meta.run_id, 'a1b2');
+    check('events present', j.events.length, 1);
+}
+
+// ── toText ───────────────────────────────────────────────────────────────────
+console.log('=== toText ===');
+{
+    const log = RunLog.createRunLog({ meta: META, now: fixedClock() });
+    log.event('sequence-start', { total: 2 });
+    log.event('step-start', {
+        index: 0,
+        total: 2,
+        step: { conditionName: 'grating_15px_cw', kind: 'block-trial' }
+    });
+    log.event('skip', {
+        index: 1,
+        plugin_name: 'camera',
+        command_name: 'getTimestamp',
+        reason: 'plugins not driven'
+    });
+    log.finish({ completed: true, steps: 2, errors: 0, skipped: 1 });
+    const txt = log.toText();
+    checkBool('header has experimenter', /experimenter: M Reiser/.test(txt));
+    checkBool('header has protocol hash', /protocol_sha256: a1b2c3d4/.test(txt));
+    checkBool('renders a step line by condition name', /grating_15px_cw/.test(txt));
+    checkBool('renders SKIP line', /SKIP camera\.getTimestamp/.test(txt));
+    checkBool('summary line shows outcome', /— COMPLETED —/.test(txt));
+    checkBool('flags host-side timing caveat', /host-side estimates/.test(txt));
+}
+
+// ── filename convention ──────────────────────────────────────────────────────
+console.log('=== filename ===');
+{
+    const log = RunLog.createRunLog({ meta: META, now: fixedClock() });
+    check(
+        'json filename',
+        log.filename('json'),
+        'looming_v3__m-reiser__2026-06-17T14-32-05__a1b2.runlog.json'
+    );
+    check(
+        'txt filename',
+        log.filename('txt'),
+        'looming_v3__m-reiser__2026-06-17T14-32-05__a1b2.runlog.txt'
+    );
+    checkBool('filename has no colons (fs-safe)', log.filename('json').indexOf(':') === -1);
+}
+
+// ── download is a no-op under Node ───────────────────────────────────────────
+console.log('=== download (Node) ===');
+{
+    const log = RunLog.createRunLog({ meta: META, now: fixedClock() });
+    check('download returns false without document', RunLog.download(log), false);
+}
+
+console.log('\n=== Summary ===');
+console.log(`${totalChecks - failures} / ${totalChecks} checks passed`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
UI-independent foundation for experiment-run logging. **Stacked on #112** (Stage A) — base is `stage-a-arena-session` so this diff shows only the run-log files; GitHub auto-retargets to `main` once #112 merges.

## What it is
**`js/run-log.js`** — a DOM-free builder that turns a recorded run into a self-describing record: metadata header (experimenter / genotype / notes / timestamp + **protocol filename & sha256**) → a host-stamped event stream fed from the runner's existing `onProgress` phases → a summary. Serializes **`runlog.json`** (canonical) + **`runlog.txt`** (transcript) from one array; filename `<protocol>__<experimenter>__<ISO>__<run_id>.runlog.<ext>`.

- `intent='test'` runs are tagged and carry **no protocol hash** (can't be confused with a real experiment record).
- Captures what can't be reconstructed afterward: the *actual* randomized run order, timestamps, skips, aborts.
- Clock-injectable core → fully unit-tested; `download()` is the only DOM-touching part (guarded).

## Notes
- **Not wired into any page** — zero deploy impact. It's the shared log format a runner (the existing v3 designer's run path, a future runner page, or the merged tool) will emit.
- Classic-script dual-export, same loading pattern as `arena-session.js`.
- **`tests/test-run-log.js`** (36 checks) wired into `npm test` + `npm run test:run-log`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)