### PR TITLE
Demonstrate SD card file management: upload, download, rename, delete (related to LAB-79)

### DIFF
--- a/arena_console.html
+++ b/arena_console.html
@@ -390,6 +390,17 @@
                 border-radius: 3px;
                 font-family: 'JetBrains Mono', monospace;
             }
+            .pat-preview-spinner {
+                width: 20px;
+                height: 20px;
+                border: 2px solid var(--border);
+                border-top-color: var(--accent);
+                border-radius: 50%;
+                animation: spin-preview 0.8s linear infinite;
+            }
+            @keyframes spin-preview {
+                to { transform: rotate(360deg); }
+            }
             #tp-pat[readonly] {
                 opacity: 0.55;
                 cursor: not-allowed;
@@ -398,8 +409,8 @@
 
             /* ── white device-memory boxes ────────────────────────────── */
             .mem-grid {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
+                display: flex;
+                flex-direction: column;
                 gap: 8px;
             }
             .mem-box {
@@ -434,15 +445,109 @@
             #sd-count-badge.loaded:hover {
                 color: var(--mem-text);
             }
-            .mem-body {
-                max-height: 92px;
-                overflow-y: auto;
+            #sd-upload-btn {
+                font-size: 14px;
+                line-height: 1;
+                padding: 0 5px;
+                background: none;
+                border: 1px solid var(--mem-dim);
+                border-radius: 3px;
+                color: var(--mem-dim);
+                cursor: pointer;
             }
-            .sd-row {
-                padding: 1px 0;
+            #sd-upload-btn:hover:not(:disabled) {
+                border-color: var(--mem-text);
+                color: var(--mem-text);
+            }
+            #sd-upload-btn:disabled {
+                opacity: 0.35;
+                cursor: default;
+            }
+            #sd-purge-btn {
+                font-size: 9px;
+                line-height: 1;
+                padding: 1px 4px;
+                background: none;
+                border: 1px solid var(--mem-dim);
+                border-radius: 3px;
+                color: var(--mem-dim);
+                cursor: pointer;
+                letter-spacing: 0.5px;
+            }
+            #sd-purge-btn:hover:not(:disabled) {
+                border-color: #e05c5c;
+                color: #e05c5c;
+            }
+            #sd-purge-btn:disabled {
+                opacity: 0.35;
+                cursor: default;
+            }
+            .sd-upload-row {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                padding: 4px 0 2px;
+            }
+            .sd-upload-status {
+                font-size: 10px;
+                color: var(--mem-dim);
+            }
+            .sd-table-wrap {
+                max-height: 270px;
+                overflow-y: auto;
+                margin-bottom: 2px;
+            }
+            .sd-table {
+                width: 100%;
+                border-collapse: collapse;
+                table-layout: fixed;
+                font-size: 11px;
+            }
+            .sd-table th {
+                text-align: left;
+                color: var(--mem-dim);
+                font-weight: 600;
+                border-bottom: 1px solid var(--mem-border);
+                padding: 2px 4px;
+                position: sticky;
+                top: 0;
+                background: var(--mem-bg);
+                font-size: 10px;
+            }
+            .sd-table td {
+                padding: 2px 4px;
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
+            }
+            .sd-col-idx {
+                width: 2.5em;
+                color: var(--mem-dim);
+                text-align: right;
+                padding-right: 6px;
+            }
+            .sd-col-del {
+                width: 22px;
+                text-align: center;
+            }
+            .sd-del-btn, .sd-down-btn {
+                background: none;
+                border: none;
+                color: var(--mem-dim);
+                cursor: pointer;
+                font-size: 11px;
+                padding: 0 2px;
+                line-height: 1;
+            }
+            .sd-del-btn:hover:not(:disabled) {
+                color: #e05c5c;
+            }
+            .sd-down-btn:hover:not(:disabled) {
+                color: #4fc3f7;
+            }
+            .sd-del-btn:disabled, .sd-down-btn:disabled {
+                opacity: 0.3;
+                cursor: default;
             }
             .mem-empty {
                 color: #a6b0bc;
@@ -1006,13 +1111,36 @@
                             title="Patterns in the loaded set (assumed on the SD card)"
                         >
                             SD card
+                            <button id="sd-purge-btn" disabled
+                                title="Delete ALL patterns from SD card (DELETE_ALL_PATTERNS 0x8F)">xXx</button>
                             <span
                                 id="sd-count-badge"
                                 title="Pattern files on SD card (GET_FILE_COUNT 0x80). Click to refresh."
                             >—</span>
                         </div>
-                        <div id="sd-list" class="mem-body">
-                            <div class="mem-empty">loading…</div>
+                        <div class="sd-table-wrap">
+                            <table id="sd-table" class="sd-table">
+                                <colgroup>
+                                    <col style="width:2.5em">
+                                    <col>
+                                    <col style="width:42px">
+                                </colgroup>
+                                <thead>
+                                    <tr>
+                                        <th class="sd-col-idx">#</th>
+                                        <th>filename</th>
+                                        <th class="sd-col-del"></th>
+                                    </tr>
+                                </thead>
+                                <tbody id="sd-tbody">
+                                    <tr><td colspan="3" class="mem-empty">loading…</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="sd-upload-row">
+                            <button id="sd-upload-btn" disabled title="Upload a .pat file to the SD card">+</button>
+                            <span id="sd-upload-status" class="sd-upload-status"></span>
+                            <input type="file" id="pat-file-input" accept=".pat" style="display:none">
                         </div>
                     </div>
                     <div class="mem-box">
@@ -1069,7 +1197,7 @@
                 <div id="log"></div>
             </div>
 
-            <footer id="footer">Arena Console v5 | 2026-06-17 20:00 ET</footer>
+            <footer id="footer">Arena Console v5 | 2026-06-18 12:10 ET</footer>
         </div>
 
         <!-- Paste-a-frame modal -->
@@ -1175,6 +1303,14 @@
                 }
             });
 
+            // Bridge for the ES-module preview code: fetch a pattern file from the
+            // controller via 0x84. Returns a Uint8Array of the raw .pat bytes.
+            window.__fetchSdPatternBytes = async function (sdIdx) {
+                return link.sendBulkRead(Wire.encodeGetPatternFile(sdIdx), {
+                    timeoutMs: 60000
+                });
+            };
+
             const cmdButtons = () => Array.from(document.querySelectorAll('.cmd'));
             function setConnected(on) {
                 $('btn-connect').disabled = on;
@@ -1184,6 +1320,8 @@
                 s.textContent = on ? 'connected' : 'disconnected';
                 $('conn').classList.toggle('on', on);
                 $('dot').classList.toggle('on', on);
+                $('sd-upload-btn').disabled = !on;
+                $('sd-purge-btn').disabled = !on;
                 if (on) {
                     refreshSdCount();
                 } else {
@@ -1795,6 +1933,10 @@
             function resetSdCount() {
                 sdCountBadge.textContent = '—';
                 sdCountBadge.classList.remove('loaded');
+                const tbody = $('sd-tbody');
+                if (tbody) tbody.innerHTML = '<tr><td colspan="3" class="mem-empty">—</td></tr>';
+                if (typeof window.__populateFromSdCard === 'function')
+                    window.__populateFromSdCard([]);
             }
             async function refreshSdCount() {
                 const resp = await run(
@@ -1815,63 +1957,192 @@
                 }
             }
 
-            // Fetch filenames from the controller (0x82) and render them in the SD list.
-            // Shows first 10 files; if count > 10, adds an ellipsis then the last 3
-            // (starting from max(11, count-2) to avoid duplicates).
+            // Fetch all filenames from the controller (0x82) and render as a
+            // scrollable table. Each row has a delete button wired to 0x86.
             async function refreshSdList(count) {
-                const host = $('sd-list');
-                if (!host) return;
+                const tbody = $('sd-tbody');
+                if (!tbody) return;
                 if (count === 0) {
-                    host.innerHTML = '<div class="mem-empty">(no patterns on SD)</div>';
+                    tbody.innerHTML = '<tr><td colspan="3" class="mem-empty">(no patterns on SD)</td></tr>';
                     return;
                 }
 
-                // Indices to fetch (1-based)
-                const indices = [];
-                for (let i = 1; i <= Math.min(10, count); i++) indices.push(i);
-                let ellipsisAfter = -1;
-                if (count > 10) {
-                    ellipsisAfter = indices.length;
-                    const lastStart = Math.max(11, count - 2);
-                    for (let i = lastStart; i <= count; i++) indices.push(i);
-                }
-
-                host.innerHTML = '<div class="mem-empty">fetching…</div>';
+                tbody.innerHTML = '<tr><td colspan="3" class="mem-empty">fetching…</td></tr>';
 
                 // Fetch each filename silently (no console log per file)
                 const names = [];
-                for (const idx of indices) {
+                for (let idx = 1; idx <= count; idx++) {
                     try {
                         const raw = await link.send(Wire.encodeGetPatternFilename(idx));
                         const parsed = Wire.decodeResponse(raw);
-                        names.push(
-                            parsed && parsed.ok ? Wire.decodePatternFilename(parsed) : null
-                        );
+                        names.push(parsed && parsed.ok ? Wire.decodePatternFilename(parsed) : null);
                     } catch (_) {
                         names.push(null);
                     }
                 }
 
-                // Render
-                host.innerHTML = '';
-                for (let i = 0; i < indices.length; i++) {
-                    if (ellipsisAfter >= 0 && i === ellipsisAfter) {
-                        const d = document.createElement('div');
-                        d.className = 'sd-row dim';
-                        d.textContent = '…';
-                        host.appendChild(d);
-                    }
-                    const d = document.createElement('div');
-                    d.className = 'sd-row';
-                    const n = names[i];
-                    d.textContent = indices[i] + (n ? ' · ' + n : ' · (error)');
-                    d.title = n || '';
-                    host.appendChild(d);
+                tbody.innerHTML = '';
+                for (let i = 0; i < count; i++) {
+                    const idx = i + 1;
+                    const name = names[i];
+                    const tr = document.createElement('tr');
+                    tr.dataset.idx = idx;
+                    tr.dataset.name = name || '';
+                    const tdIdx = document.createElement('td');
+                    tdIdx.className = 'sd-col-idx';
+                    tdIdx.textContent = idx;
+                    const tdName = document.createElement('td');
+                    tdName.textContent = name || '(error)';
+                    tdName.title = name || '';
+                    const tdBtns = document.createElement('td');
+                    tdBtns.className = 'sd-col-del';
+                    const dBtn = document.createElement('button');
+                    dBtn.className = 'sd-down-btn';
+                    dBtn.title = 'Download ' + (name || 'pattern ' + idx);
+                    dBtn.textContent = 'D';
+                    const delBtn = document.createElement('button');
+                    delBtn.className = 'sd-del-btn';
+                    delBtn.title = 'Delete pattern ' + idx + (name ? ': ' + name : '');
+                    delBtn.textContent = '×';
+                    tdBtns.appendChild(dBtn);
+                    tdBtns.appendChild(delBtn);
+                    tr.appendChild(tdIdx);
+                    tr.appendChild(tdName);
+                    tr.appendChild(tdBtns);
+                    tbody.appendChild(tr);
+                }
+
+                // Mirror the live SD list into the tp-pat-name picker (when no manifest loaded).
+                if (typeof window.__populateFromSdCard === 'function') {
+                    window.__populateFromSdCard(
+                        names
+                            .map((name, i) => ({ idx: i + 1, name: name || '' }))
+                            .filter((e) => e.name)
+                    );
                 }
             }
 
             sdCountBadge.addEventListener('click', () => {
                 if (link.connected) refreshSdCount();
+            });
+
+            $('sd-purge-btn').addEventListener('click', async () => {
+                if (!link.connected) return;
+                if (!confirm('Delete ALL patterns from SD card? This cannot be undone.')) return;
+                const resp = await run(
+                    'delete-all-patterns',
+                    Wire.encodeDeleteAllPatterns(),
+                    (r) => (r && r.ok ? 'done' : null)
+                );
+                if (resp && resp.ok) await refreshSdCount();
+            });
+
+            $('sd-table').addEventListener('click', async (e) => {
+                if (!link.connected) return;
+                const tr = e.target.closest('tr[data-idx]');
+                if (!tr) return;
+                const idx = parseInt(tr.dataset.idx, 10);
+                if (!Number.isFinite(idx)) return;
+
+                if (e.target.classList.contains('sd-del-btn')) {
+                    const btn = e.target;
+                    if (btn.disabled) return;
+                    btn.disabled = true;
+                    const resp = await run(
+                        'delete-pattern-file ' + idx,
+                        Wire.encodeDeletePatternFile(idx),
+                        (r) => (r && r.ok ? 'deleted' : null)
+                    );
+                    if (resp && resp.ok) {
+                        await refreshSdCount();
+                    } else {
+                        btn.disabled = false;
+                    }
+                    return;
+                }
+
+                if (e.target.classList.contains('sd-down-btn')) {
+                    const btn = e.target;
+                    if (btn.disabled) return;
+                    const name = tr.dataset.name || ('pattern_' + idx + '.pat');
+                    btn.disabled = true;
+                    log('download ' + idx + ' (' + name + ')…', 'dim');
+                    try {
+                        const data = await link.sendBulkRead(
+                            Wire.encodeGetPatternFile(idx),
+                            { timeoutMs: 60000 }
+                        );
+                        log('download complete: ' + data.length + ' bytes → ' + name, 'info');
+                        const blob = new Blob([data], { type: 'application/octet-stream' });
+                        const url = URL.createObjectURL(blob);
+                        const a = document.createElement('a');
+                        a.href = url;
+                        a.download = name;
+                        a.click();
+                        URL.revokeObjectURL(url);
+                    } catch (err) {
+                        log('download failed: ' + err.message, 'err');
+                    } finally {
+                        btn.disabled = false;
+                    }
+                }
+            });
+
+            const patFileInput = $('pat-file-input');
+            const sdUploadStatus = $('sd-upload-status');
+
+            $('sd-upload-btn').addEventListener('click', () => {
+                if (!link.connected) return;
+                patFileInput.click();
+            });
+
+            patFileInput.addEventListener('change', async () => {
+                const file = patFileInput.files[0];
+                patFileInput.value = '';
+                if (!file || !link.connected) return;
+
+                const filename = file.name;
+                sdUploadStatus.textContent = 'uploading…';
+                $('sd-upload-btn').disabled = true;
+
+                try {
+                    const data = new Uint8Array(await file.arrayBuffer());
+
+                    // Step 1: upload file to /patterns/pattern.temp (idx=0)
+                    const uploadResp = await run(
+                        'upload ' + filename + ' → pattern.temp',
+                        Wire.encodeSetPatternFile(0, data),
+                        (r) => r && r.ok ? 'ok (' + data.length + ' bytes)' : null,
+                        { timeoutMs: 120000, expectedCmd: Wire.OPCODES.SET_PATTERN_FILE }
+                    );
+                    if (!uploadResp || !uploadResp.ok) {
+                        sdUploadStatus.textContent = 'upload failed';
+                        return;
+                    }
+
+                    // Step 2: rename pattern.temp to the original filename (idx=0).
+                    // Allow up to 10 s — SD rescan after rename can be slow with many files.
+                    const renameResp = await run(
+                        'rename → ' + filename,
+                        Wire.encodeSetPatternFilename(0, filename),
+                        (r) => {
+                            const idx = Wire.decodeSetPatternFilenameResponse(r);
+                            return idx == null ? null : 'new index: ' + idx;
+                        },
+                        { timeoutMs: 10000, expectedCmd: Wire.OPCODES.SET_PATTERN_FILENAME }
+                    );
+                    if (!renameResp || !renameResp.ok) {
+                        sdUploadStatus.textContent = 'rename failed';
+                        return;
+                    }
+
+                    sdUploadStatus.textContent = '';
+                    await refreshSdCount();
+                } catch (e) {
+                    sdUploadStatus.textContent = 'error: ' + e.message;
+                } finally {
+                    if (link.connected) $('sd-upload-btn').disabled = false;
+                }
             });
 
             // ── command dispatch ────────────────────────────────────────────
@@ -2068,6 +2339,8 @@
             let activeManifest = null;
             let byteSource = null; // (sd_name) => Promise<ArrayBuffer>
             let previewCache = {};
+            let sdPreviewCache = {}; // sdIdx → sampled preview frames (cleared on SD refresh)
+            let sdPreviewNonce = 0;  // incremented on each render call to discard stale fetches
 
             const setStatus = (text, cls) => {
                 statusEl.textContent = text;
@@ -2143,22 +2416,30 @@
             }
 
             function renderSdList(m) {
-                const host = $('sd-list');
-                if (!host) return;
+                const tbody = $('sd-tbody');
+                if (!tbody) return;
                 const names = Object.keys((m && m.patterns) || {});
                 if (!names.length) {
-                    host.innerHTML = '<div class="mem-empty">(empty set)</div>';
+                    tbody.innerHTML = '<tr><td colspan="3" class="mem-empty">(empty set)</td></tr>';
                     return;
                 }
                 names.sort((a, b) => (m.patterns[a].index || 0) - (m.patterns[b].index || 0));
-                host.innerHTML = '';
+                tbody.innerHTML = '';
                 for (const n of names) {
                     const p = m.patterns[n];
-                    const d = document.createElement('div');
-                    d.className = 'sd-row';
-                    d.textContent = (p.index != null ? p.index + ' · ' : '') + n;
-                    d.title = n;
-                    host.appendChild(d);
+                    const tr = document.createElement('tr');
+                    const tdIdx = document.createElement('td');
+                    tdIdx.className = 'sd-col-idx';
+                    tdIdx.textContent = p.index != null ? p.index : '';
+                    const tdName = document.createElement('td');
+                    tdName.textContent = n;
+                    tdName.title = n;
+                    const tdDel = document.createElement('td');
+                    tdDel.className = 'sd-col-del';
+                    tr.appendChild(tdIdx);
+                    tr.appendChild(tdName);
+                    tr.appendChild(tdDel);
+                    tbody.appendChild(tr);
                 }
             }
 
@@ -2263,6 +2544,87 @@
                 }
             }
 
+            // Render a preview for an SD card pattern fetched live via 0x84.
+            // Uses the same icon pipeline as renderPreview. Nonce-guarded so fast
+            // dropdown changes discard stale fetches without flicker.
+            async function renderSdPreview(sdIdx) {
+                const nonce = ++sdPreviewNonce;
+                previewHost.innerHTML = '<span class="pat-preview-spinner"></span>';
+                try {
+                    let sampled = sdPreviewCache[sdIdx];
+                    if (!sampled) {
+                        if (typeof window.__fetchSdPatternBytes !== 'function') {
+                            previewHost.innerHTML = '';
+                            return;
+                        }
+                        const bytes = await window.__fetchSdPatternBytes(sdIdx);
+                        if (sdPreviewNonce !== nonce) return; // selection changed while fetching
+                        const arena =
+                            arenaForManifest(activeManifest) || (getConfig('G6_2x10') || {}).arena;
+                        const parsed = PatParser.parsePatFile(bytes.buffer);
+                        sampled = PP.samplePreviewFrames(parsed, arena, {
+                            renderIcon: generatePatternIcon,
+                            iconOpts: {
+                                width: 56,
+                                height: 56,
+                                backgroundColor: '#1a1f26',
+                                innerRadiusRatio: 0.4,
+                                padding: 2,
+                                showGaps: false,
+                                showOutlines: false
+                            }
+                        });
+                        // Attach metadata for the tooltip.
+                        sampled._numFrames = parsed.numFrames || (parsed.frames && parsed.frames.length) || 1;
+                        sampled._gsVal = parsed.gs_val || '?';
+                        sdPreviewCache[sdIdx] = sampled;
+                    }
+                    if (sdPreviewNonce !== nonce) return;
+                    previewHost.innerHTML = '';
+                    if (!sampled.frames.length) return;
+                    const container = document.createElement('div');
+                    container.className = 'pat-preview';
+                    const img = document.createElement('img');
+                    img.src = sampled.frames[sampled.staticIndex];
+                    img.alt = 'pattern ' + sdIdx;
+                    img.title =
+                        'SD index ' +
+                        sdIdx +
+                        ' — ' +
+                        sampled._numFrames +
+                        ' frame' +
+                        (sampled._numFrames === 1 ? '' : 's') +
+                        ' · GS' +
+                        sampled._gsVal +
+                        (sampled.frames.length > 1 ? ' · hover to animate' : '');
+                    container.appendChild(img);
+                    if (sampled._numFrames > 1) {
+                        const b = document.createElement('span');
+                        b.className = 'pat-preview-badge';
+                        b.textContent = sampled._numFrames + 'f';
+                        container.appendChild(b);
+                    }
+                    if (sampled.frames.length > 1) {
+                        let iv = null;
+                        let k = 0;
+                        container.addEventListener('mouseenter', () => {
+                            k = 0;
+                            iv = setInterval(() => {
+                                k = (k + 1) % sampled.frames.length;
+                                img.src = sampled.frames[k];
+                            }, 150);
+                        });
+                        container.addEventListener('mouseleave', () => {
+                            if (iv) { clearInterval(iv); iv = null; }
+                            img.src = sampled.frames[sampled.staticIndex];
+                        });
+                    }
+                    previewHost.appendChild(container);
+                } catch (e) {
+                    if (sdPreviewNonce === nonce) previewHost.innerHTML = '';
+                }
+            }
+
             function metaSpan(meta) {
                 const s = document.createElement('span');
                 s.className = 'dim small';
@@ -2278,7 +2640,50 @@
                 return s;
             }
 
-            nameSel.addEventListener('change', () => applyPick(nameSel.value));
+            // Live SD card name→index map; populated by the classic script via
+            // window.__populateFromSdCard when no manifest is active.
+            let sdNameToIndex = {};
+
+            // Called by the classic script after refreshSdList. Fills the tp-pat-name
+            // dropdown from live controller data only when no manifest is loaded.
+            window.__populateFromSdCard = function(entries) {
+                sdNameToIndex = {};
+                sdPreviewCache = {};   // pattern bytes may have changed on the SD card
+                previewHost.innerHTML = '';
+                nameSel.innerHTML = '';
+                if (!entries.length) {
+                    const o = document.createElement('option');
+                    o.value = '';
+                    o.textContent = '(no patterns)';
+                    nameSel.appendChild(o);
+                    lockPat(false);
+                    return;
+                }
+                for (const e of entries) {
+                    sdNameToIndex[e.name] = e.idx;
+                    const o = document.createElement('option');
+                    o.value = e.name;
+                    o.textContent = e.idx + ' · ' + e.name;
+                    nameSel.appendChild(o);
+                }
+                nameSel.value = entries[0].name;
+                tpPat.value = entries[0].idx;
+                lockPat(false);
+                renderSdPreview(entries[0].idx); // auto-preview first pattern after SD refresh
+            };
+
+            nameSel.addEventListener('change', () => {
+                const name = nameSel.value;
+                const sdIdx = sdNameToIndex[name];
+                if (sdIdx != null) {
+                    // SD card mode: set the pattern index directly and fetch a live preview.
+                    tpPat.value = sdIdx;
+                    renderSdPreview(sdIdx);
+                } else if (activeManifest) {
+                    // Manifest mode: resolve name → index + preview via manifest.
+                    applyPick(name);
+                }
+            });
 
             async function loadBuiltin() {
                 try {

--- a/arena_console.html
+++ b/arena_console.html
@@ -604,7 +604,7 @@
                                 class="cmd menu-item"
                                 data-cmd="info"
                                 disabled
-                                title="GET_CONTROLLER_INFO (0xC1) — firmware version + capability bitmap. The canonical round-trip check."
+                                title="GET_CONTROLLER_INFO (0xC2) — firmware version + capability bitmap. The canonical round-trip check."
                             >
                                 Get info
                             </button>
@@ -612,7 +612,7 @@
                                 class="cmd menu-item"
                                 data-cmd="ip"
                                 disabled
-                                title="GET_ETHERNET_IP (0xC0) — DHCP-resolved address (meaningful only with an Ethernet link)"
+                                title="GET_ETHERNET_IP (0xC1) — DHCP-resolved address (meaningful only with an Ethernet link)"
                             >
                                 Get IP
                             </button>
@@ -620,7 +620,7 @@
                                 class="cmd menu-item"
                                 data-cmd="frames"
                                 disabled
-                                title="GET_FRAMES_SENT (0x19) — master-side count of frames pushed to panels"
+                                title="GET_FRAMES_SENT (0x33) — master-side count of frames pushed to panels"
                             >
                                 Get frames sent
                             </button>
@@ -628,7 +628,7 @@
                                 class="cmd menu-item"
                                 data-cmd="resetframes"
                                 disabled
-                                title="RESET_FRAMES_SENT (0x1A) — zero the frames-sent counter"
+                                title="RESET_FRAMES_SENT (0x34) — zero the frames-sent counter"
                             >
                                 Reset frames sent
                             </button>
@@ -653,7 +653,7 @@
                                     data-cmd="setspi"
                                     disabled
                                     style="width: auto"
-                                    title="SET_SPI_CLOCK (0x17) — set the panel SPI master clock (echoes the applied MHz)"
+                                    title="SET_SPI_CLOCK (0xC5) — set the panel SPI master clock (echoes the applied MHz)"
                                 >
                                     Set
                                 </button>
@@ -662,7 +662,7 @@
                                     data-cmd="getspi"
                                     disabled
                                     style="width: auto"
-                                    title="GET_SPI_CLOCK (0x18) — read the current panel SPI master clock"
+                                    title="GET_SPI_CLOCK (0xC6) — read the current panel SPI master clock"
                                 >
                                     Get
                                 </button>
@@ -685,6 +685,15 @@
                                     title="SET_REFRESH_RATE (0x16) — set the panel re-transmit rate (Hz)"
                                 >
                                     Set
+                                </button>
+                                <button
+                                    class="cmd menu-item"
+                                    data-cmd="getrate"
+                                    disabled
+                                    style="width: auto"
+                                    title="GET_REFRESH_RATE (0x17) — read the current panel re-transmit rate (Hz)"
+                                >
+                                    Get
                                 </button>
                             </div>
                             <div class="menu-sep">Firmware-gated (planned)</div>
@@ -1206,6 +1215,10 @@
                 spi: (r) => {
                     const m = Wire.decodeSpiClock(r);
                     return m == null ? null : m + ' MHz';
+                },
+                refreshRate: (r) => {
+                    const hz = Wire.decodeRefreshRate(r);
+                    return hz == null ? null : hz + ' Hz';
                 },
                 frames: (r) => {
                     const c = Wire.decodeFramesSent(r);
@@ -1789,6 +1802,7 @@
                         log('set-refresh-rate (encode rejected): ' + e.message, 'err');
                     }
                 },
+                getrate: () => run('get-refresh-rate', Wire.encodeGetRefreshRate(), DECODE.refreshRate),
                 setframe: () => {
                     const i = parseInt($('sf-idx').value, 10);
                     if (Number.isNaN(i)) {

--- a/arena_console.html
+++ b/arena_console.html
@@ -416,6 +416,23 @@
                 font-weight: 600;
                 margin-bottom: 5px;
                 font-size: 11px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+            }
+            #sd-count-badge {
+                font-family: 'JetBrains Mono', monospace;
+                font-size: 10px;
+                color: #a6b0bc;
+                cursor: default;
+            }
+            #sd-count-badge.loaded {
+                color: var(--mem-dim);
+                cursor: pointer;
+                text-decoration: underline dotted;
+            }
+            #sd-count-badge.loaded:hover {
+                color: var(--mem-text);
             }
             .mem-body {
                 max-height: 92px;
@@ -989,6 +1006,10 @@
                             title="Patterns in the loaded set (assumed on the SD card)"
                         >
                             SD card
+                            <span
+                                id="sd-count-badge"
+                                title="Pattern files on SD card (GET_FILE_COUNT 0x80). Click to refresh."
+                            >—</span>
                         </div>
                         <div id="sd-list" class="mem-body">
                             <div class="mem-empty">loading…</div>
@@ -1048,7 +1069,7 @@
                 <div id="log"></div>
             </div>
 
-            <footer id="footer">Arena Console v5 | 2026-06-15 12:37 ET</footer>
+            <footer id="footer">Arena Console v5 | 2026-06-17 20:00 ET</footer>
         </div>
 
         <!-- Paste-a-frame modal -->
@@ -1163,10 +1184,13 @@
                 s.textContent = on ? 'connected' : 'disconnected';
                 $('conn').classList.toggle('on', on);
                 $('dot').classList.toggle('on', on);
-                if (!on) {
+                if (on) {
+                    refreshSdCount();
+                } else {
                     stepper.loaded = false;
                     clearAutoStop();
                     stopFilePlay('disconnected');
+                    resetSdCount();
                 }
                 updateStepperUI();
                 updateStreamUI();
@@ -1765,6 +1789,90 @@
                 doStream(pasteParsed.grid, pasteParsed.gs, 'stream pasted frame');
                 closePasteModal();
             };
+
+            // ── SD file count (GET_FILE_COUNT 0x80) ─────────────────────────
+            const sdCountBadge = $('sd-count-badge');
+            function resetSdCount() {
+                sdCountBadge.textContent = '—';
+                sdCountBadge.classList.remove('loaded');
+            }
+            async function refreshSdCount() {
+                const resp = await run(
+                    'get-file-count',
+                    Wire.encodeGetFileCount(),
+                    (r) => {
+                        const n = Wire.decodeFileCount(r);
+                        return n == null ? null : n + ' files';
+                    }
+                );
+                if (resp && resp.ok) {
+                    const n = Wire.decodeFileCount(resp);
+                    if (n != null) {
+                        sdCountBadge.textContent = String(n);
+                        sdCountBadge.classList.add('loaded');
+                        await refreshSdList(n);
+                    }
+                }
+            }
+
+            // Fetch filenames from the controller (0x82) and render them in the SD list.
+            // Shows first 10 files; if count > 10, adds an ellipsis then the last 3
+            // (starting from max(11, count-2) to avoid duplicates).
+            async function refreshSdList(count) {
+                const host = $('sd-list');
+                if (!host) return;
+                if (count === 0) {
+                    host.innerHTML = '<div class="mem-empty">(no patterns on SD)</div>';
+                    return;
+                }
+
+                // Indices to fetch (1-based)
+                const indices = [];
+                for (let i = 1; i <= Math.min(10, count); i++) indices.push(i);
+                let ellipsisAfter = -1;
+                if (count > 10) {
+                    ellipsisAfter = indices.length;
+                    const lastStart = Math.max(11, count - 2);
+                    for (let i = lastStart; i <= count; i++) indices.push(i);
+                }
+
+                host.innerHTML = '<div class="mem-empty">fetching…</div>';
+
+                // Fetch each filename silently (no console log per file)
+                const names = [];
+                for (const idx of indices) {
+                    try {
+                        const raw = await link.send(Wire.encodeGetPatternFilename(idx));
+                        const parsed = Wire.decodeResponse(raw);
+                        names.push(
+                            parsed && parsed.ok ? Wire.decodePatternFilename(parsed) : null
+                        );
+                    } catch (_) {
+                        names.push(null);
+                    }
+                }
+
+                // Render
+                host.innerHTML = '';
+                for (let i = 0; i < indices.length; i++) {
+                    if (ellipsisAfter >= 0 && i === ellipsisAfter) {
+                        const d = document.createElement('div');
+                        d.className = 'sd-row dim';
+                        d.textContent = '…';
+                        host.appendChild(d);
+                    }
+                    const d = document.createElement('div');
+                    d.className = 'sd-row';
+                    const n = names[i];
+                    d.textContent = indices[i] + (n ? ' · ' + n : ' · (error)');
+                    d.title = n || '';
+                    host.appendChild(d);
+                }
+            }
+
+            sdCountBadge.addEventListener('click', () => {
+                if (link.connected) refreshSdCount();
+            });
 
             // ── command dispatch ────────────────────────────────────────────
             const HANDLERS = {

--- a/arena_console.html
+++ b/arena_console.html
@@ -859,6 +859,14 @@
                     >
                         Disconnect
                     </button>
+                    <button
+                        id="btn-reset"
+                        class="danger"
+                        title="SYSTEM_RESET (0x01) — ack then reboot the controller firmware"
+                        disabled
+                    >
+                        Reset
+                    </button>
                 </div>
             </nav>
 
@@ -1200,7 +1208,7 @@
                 <div id="log"></div>
             </div>
 
-            <footer id="footer">Arena Console v5 | 2026-06-18 12:10 ET</footer>
+            <footer id="footer">Arena Console v5 | 2026-06-18 18:09 ET</footer>
         </div>
 
         <!-- Paste-a-frame modal -->
@@ -1318,6 +1326,7 @@
             function setConnected(on) {
                 $('btn-connect').disabled = on;
                 $('btn-disconnect').disabled = !on;
+                $('btn-reset').disabled = !on;
                 cmdButtons().forEach((b) => (b.disabled = !on));
                 const s = $('status');
                 s.textContent = on ? 'connected' : 'disconnected';
@@ -1410,6 +1419,12 @@
                 }
             };
             $('btn-disconnect').onclick = async () => {
+                await link.close();
+                setConnected(false);
+            };
+            $('btn-reset').onclick = async () => {
+                if (!confirm('Reboot the controller? The USB/TCP link will drop.')) return;
+                await run('system-reset', Wire.encodeSystemReset(), DECODE.ascii);
                 await link.close();
                 setConnected(false);
             };
@@ -2221,7 +2236,7 @@
                 $('sd-archive-btn').disabled = true;
                 status.textContent = 'downloading…';
                 try {
-                    const zipBytes = await link.sendBulkRead(Wire.encodeGetSdArchive());
+                    const zipBytes = await link.sendBulkRead(Wire.encodeGetSdArchive(), { timeoutMs: 300000 });
                     const blob = new Blob([zipBytes], { type: 'application/zip' });
                     const url = URL.createObjectURL(blob);
                     const a = document.createElement('a');

--- a/arena_console.html
+++ b/arena_console.html
@@ -604,7 +604,7 @@
                                 class="cmd menu-item"
                                 data-cmd="info"
                                 disabled
-                                title="GET_CONTROLLER_INFO (0x67) — firmware version + capability bitmap. The canonical round-trip check."
+                                title="GET_CONTROLLER_INFO (0xC1) — firmware version + capability bitmap. The canonical round-trip check."
                             >
                                 Get info
                             </button>
@@ -612,7 +612,7 @@
                                 class="cmd menu-item"
                                 data-cmd="ip"
                                 disabled
-                                title="GET_ETHERNET_IP (0x66) — DHCP-resolved address (meaningful only with an Ethernet link)"
+                                title="GET_ETHERNET_IP (0xC0) — DHCP-resolved address (meaningful only with an Ethernet link)"
                             >
                                 Get IP
                             </button>

--- a/arena_console.html
+++ b/arena_console.html
@@ -445,7 +445,7 @@
             #sd-count-badge.loaded:hover {
                 color: var(--mem-text);
             }
-            #sd-upload-btn {
+            #sd-upload-btn, #sd-folder-btn, #sd-archive-btn {
                 font-size: 14px;
                 line-height: 1;
                 padding: 0 5px;
@@ -455,11 +455,11 @@
                 color: var(--mem-dim);
                 cursor: pointer;
             }
-            #sd-upload-btn:hover:not(:disabled) {
+            #sd-upload-btn:hover:not(:disabled), #sd-folder-btn:hover:not(:disabled), #sd-archive-btn:hover:not(:disabled) {
                 border-color: var(--mem-text);
                 color: var(--mem-text);
             }
-            #sd-upload-btn:disabled {
+            #sd-upload-btn:disabled, #sd-folder-btn:disabled, #sd-archive-btn:disabled {
                 opacity: 0.35;
                 cursor: default;
             }
@@ -822,7 +822,7 @@
                             <button
                                 class="stub"
                                 disabled
-                                title="Planned — needs a controller report-card command (LAB-100). The console currently shows the loaded manifest.json in the SD-card box."
+                                title="Planned — needs a controller report-card command (LAB-100)."
                             >
                                 SD card report
                             </button>
@@ -901,7 +901,7 @@
                         <button
                             id="btn-loadset"
                             class="mini"
-                            title="Point at a built SD-bundle FOLDER — the unzipped Export-ZIP from the Pattern Set builder (manifest.json + a patterns/ subfolder). The arena's built-in library loads automatically; use this only for a custom set."
+                            title="Point at a built SD-bundle FOLDER — the unzipped Export-ZIP from the Pattern Set builder (MANIFEST.txt + a patterns/ subfolder). The arena's built-in library loads automatically; use this only for a custom set."
                         >
                             Load set…
                         </button>
@@ -1138,9 +1138,12 @@
                             </table>
                         </div>
                         <div class="sd-upload-row">
-                            <button id="sd-upload-btn" disabled title="Upload a .pat file to the SD card">+</button>
+                            <button id="sd-upload-btn" disabled title="Upload a single .pat file to the SD card">+</button>
+                            <button id="sd-folder-btn" disabled title="Upload all .pat files from a folder to the SD card">[+]</button>
+                            <button id="sd-archive-btn" disabled title="Download entire SD card content (MANIFEST + patterns) as a ZIP archive">&#x2913;</button>
                             <span id="sd-upload-status" class="sd-upload-status"></span>
                             <input type="file" id="pat-file-input" accept=".pat" style="display:none">
+                            <input type="file" id="pat-folder-input" webkitdirectory multiple style="display:none">
                         </div>
                     </div>
                     <div class="mem-box">
@@ -1321,6 +1324,8 @@
                 $('conn').classList.toggle('on', on);
                 $('dot').classList.toggle('on', on);
                 $('sd-upload-btn').disabled = !on;
+                $('sd-folder-btn').disabled = !on;
+                $('sd-archive-btn').disabled = !on;
                 $('sd-purge-btn').disabled = !on;
                 if (on) {
                     refreshSdCount();
@@ -2145,6 +2150,93 @@
                 }
             });
 
+            // ── folder upload ([+] button) ──────────────────────────────────
+            const patFolderInput = $('pat-folder-input');
+
+            $('sd-folder-btn').addEventListener('click', () => {
+                if (!link.connected) return;
+                patFolderInput.click();
+            });
+
+            patFolderInput.addEventListener('change', async () => {
+                const allFiles = Array.from(patFolderInput.files || []);
+                patFolderInput.value = '';
+                if (!allFiles.length || !link.connected) return;
+
+                const patFiles = allFiles.filter((f) => /\.pat$/i.test(f.name));
+                if (!patFiles.length) {
+                    sdUploadStatus.textContent = 'no .pat files found';
+                    return;
+                }
+
+                $('sd-upload-btn').disabled = true;
+                $('sd-folder-btn').disabled = true;
+                $('sd-purge-btn').disabled = true;
+
+                let done = 0, failed = 0;
+                for (const file of patFiles) {
+                    const filename = file.name;
+                    sdUploadStatus.textContent =
+                        'uploading ' + (done + failed + 1) + '/' + patFiles.length +
+                        ' — ' + filename + '…';
+                    try {
+                        const data = new Uint8Array(await file.arrayBuffer());
+
+                        const uploadResp = await run(
+                            'upload ' + filename + ' → pattern.temp',
+                            Wire.encodeSetPatternFile(0, data),
+                            (r) => r && r.ok ? 'ok' : null,
+                            { timeoutMs: 120000, expectedCmd: Wire.OPCODES.SET_PATTERN_FILE }
+                        );
+                        if (!uploadResp || !uploadResp.ok) { failed++; continue; }
+
+                        const renameResp = await run(
+                            'rename → ' + filename,
+                            Wire.encodeSetPatternFilename(0, filename),
+                            (r) => Wire.decodeSetPatternFilenameResponse(r) != null ? 'ok' : null,
+                            { timeoutMs: 10000, expectedCmd: Wire.OPCODES.SET_PATTERN_FILENAME }
+                        );
+                        if (!renameResp || !renameResp.ok) { failed++; continue; }
+
+                        done++;
+                    } catch (e) {
+                        failed++;
+                    }
+                }
+
+                sdUploadStatus.textContent =
+                    done + '/' + patFiles.length + ' uploaded' +
+                    (failed ? ', ' + failed + ' failed' : '');
+                await refreshSdCount();
+                if (link.connected) {
+                    $('sd-upload-btn').disabled = false;
+                    $('sd-folder-btn').disabled = false;
+                    $('sd-purge-btn').disabled = false;
+                }
+            });
+
+            // ── SD archive download ─────────────────────────────────────────
+            $('sd-archive-btn').addEventListener('click', async () => {
+                const status = $('sd-upload-status');
+                $('sd-archive-btn').disabled = true;
+                status.textContent = 'downloading…';
+                try {
+                    const zipBytes = await link.sendBulkRead(Wire.encodeGetSdArchive());
+                    const blob = new Blob([zipBytes], { type: 'application/zip' });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'sd_card.zip';
+                    a.click();
+                    URL.revokeObjectURL(url);
+                    status.textContent = 'downloaded ' + (zipBytes.length / 1024).toFixed(1) + ' KB';
+                } catch (e) {
+                    status.textContent = 'archive failed: ' + e.message;
+                } finally {
+                    if (link.connected) $('sd-archive-btn').disabled = false;
+                }
+            });
+
             // ── command dispatch ────────────────────────────────────────────
             const HANDLERS = {
                 info: () => run('get-controller-info', Wire.encodeGetControllerInfo(), DECODE.info),
@@ -2685,11 +2777,19 @@
                 }
             });
 
+            function manifestFromParsedTxt(parsed) {
+                const m = { arenaConfig: null, set_id: parsed.pattern_set_id || null, patterns: {} };
+                for (const p of parsed.patterns) {
+                    m.patterns[p.name] = { index: p.index, sd_name: p.sd_name, preview: null, arenaConfig: null };
+                }
+                return m;
+            }
+
             async function loadBuiltin() {
                 try {
-                    const resp = await fetch(BUILTIN_BASE + 'manifest.json', { cache: 'no-store' });
+                    const resp = await fetch(BUILTIN_BASE + 'MANIFEST.txt', { cache: 'no-store' });
                     if (!resp.ok) throw new Error('HTTP ' + resp.status);
-                    const m = PS.loadManifestJson(await resp.json());
+                    const m = manifestFromParsedTxt(PS.parseManifestTxt(await resp.text()));
                     activeManifest = m;
                     byteSource = async (sd) => {
                         const r = await fetch(BUILTIN_BASE + 'patterns/' + sd, {
@@ -2699,11 +2799,8 @@
                         return r.arrayBuffer();
                     };
                     previewCache = {};
-                    const cfg = getConfig(m.arenaConfig);
                     setStatus(
                         'built-in · ' +
-                            ((cfg && cfg.label) || m.arenaConfig) +
-                            ' · ' +
                             Object.keys(m.patterns || {}).length +
                             ' patterns' +
                             (m.set_id ? ' · ' + m.set_id : '')
@@ -2722,13 +2819,13 @@
                 const files = Array.from(folderInput.files || []);
                 folderInput.value = '';
                 if (!files.length) return;
-                const manifestFile = files.find((f) => f.name === 'manifest.json');
+                const manifestFile = files.find((f) => f.name === 'MANIFEST.txt');
                 if (!manifestFile) {
-                    setStatus('no manifest.json in that folder', 'err-msg');
+                    setStatus('no MANIFEST.txt in that folder', 'err-msg');
                     return;
                 }
                 try {
-                    const m = PS.loadManifestJson(JSON.parse(await manifestFile.text()));
+                    const m = manifestFromParsedTxt(PS.parseManifestTxt(await manifestFile.text()));
                     const map = {};
                     for (const f of files) map[f.name] = f; // sd_name === base filename
                     activeManifest = m;
@@ -2737,11 +2834,8 @@
                         return f ? f.arrayBuffer() : Promise.reject(new Error('missing ' + sd));
                     };
                     previewCache = {};
-                    const cfg = getConfig(m.arenaConfig);
                     setStatus(
                         'loaded · ' +
-                            ((cfg && cfg.label) || m.arenaConfig || '(unknown arena)') +
-                            ' · ' +
                             Object.keys(m.patterns || {}).length +
                             ' patterns' +
                             (m.set_id ? ' · ' + m.set_id : '')

--- a/docs/development/g6-web-pattern-pipeline-handoff.md
+++ b/docs/development/g6-web-pattern-pipeline-handoff.md
@@ -120,9 +120,8 @@ assist shows **no spurious plugins**.
    geometry check; **reject mismatches** with a clear message (a 3×16 pattern on a 2×10
    arena → reject; that's the firmware's `status=8` ARENA_MISMATCH, caught client-side).
 5. **Export a ZIP**: `/patterns/NNN_*.pat` + `README.txt` (copy-to-SD) + a timestamped
-   **`manifest.json`** (`set_id` + timestamp; `name → { index, arenaConfig, preview,
-   matlabPath? }`) + a **marker file** in `/patterns` for the later provenance check
-   (LAB-100).
+   **`MANIFEST.txt`** (`Pattern Count`, `Pattern Set ID` FNV-1a hash of SD filenames,
+   and `Mapping: sd_name <- human_name`) + **`MANIFEST.bin`** (uint16 count + uint32 timestamp LE).
 6. Ship a **pre-built default bundle in-repo** (the start of LAB-90's library).
 
 **Critical tie-ins from this session:**
@@ -130,9 +129,9 @@ assist shows **no spurious plugins**.
   defaults the G6 `duty_cycle` byte to `0x80` — so builder output **renders correctly on
   hardware**. The hand-patch `~/Desktop/g6_sd_card/patch_duty.js` is a **stopgap the
   builder retires**. (Do **not** touch G4/G4.1 "stretch" — see #97.)
-- The **manifest is the single source of truth for name → SD index** — it **retires the
-  dry-run's confirm-once dialog** (`onRunConditionDryRun` currently prompts/guesses
-  because `pattern_ID` ≠ SD index). LAB-95/96 consume `manifest.json` via `js/pattern-set.js`.
+- The **MANIFEST.txt** is the human-readable source of truth for SD state — `Pattern Set ID`
+  (FNV-1a hash over sorted filenames) lets the host detect SD card changes without a full
+  directory listing. Pattern name → SD index lookup uses 0x80/0x82 controller commands.
 - ZIP: pull a zip lib via **CDN** (e.g. JSZip) — consistent with the "dependencies via
   CDN only" rule (CLAUDE.md).
 

--- a/docs/development/pattern-set-builder-testing.md
+++ b/docs/development/pattern-set-builder-testing.md
@@ -32,9 +32,9 @@ fetched).
 - [ ] **▲ / ▼** reorder → indices and `pat000N` filenames update live.
 - [ ] Edit a Selected name → it's what the manifest mapping uses.
 - [ ] Footer: **"N selected · all valid"**, **Export ZIP** enabled → click → downloads `<set_id>.zip`.
-- [ ] Unzip: contains `MANIFEST.bin`, `MANIFEST.txt`, `manifest.json`, `README.txt`,
-      `patterns/pat0001.pat …`. `MANIFEST.txt` maps `patNNNN.pat <- <name>`;
-      `manifest.json` carries `set_id` (`yyyymmdd_HHMMSS`) + name→index.
+- [ ] Unzip: contains `MANIFEST.bin`, `MANIFEST.txt`, `README.txt`, `patterns/NNN_<name>.pat …`.
+      `MANIFEST.txt` contains `Pattern Count`, `Pattern Set ID` (FNV-1a hash of SD filenames),
+      and `Mapping: NNN_<name>.pat <- <name>`.
 
 ## 5. Validation (reject wrong arena)
 - [ ] Source → **Local files** (confirm the clear) → **Choose .pat files…** → pick a
@@ -43,17 +43,17 @@ fetched).
 
 ## 6. Another repo (optional)
 - [ ] Source → **Another repo** → enter a GitHub **raw** base URL of a webDisplayTools-style
-      repo that has `patterns/g6_2x10/manifest.json` → **Load** → Available populates.
+      repo that has `patterns/g6_2x10/MANIFEST.txt` → **Load** → Available populates.
       (CORS: `raw.githubusercontent.com` works; arbitrary Pages sites may not.)
 
 ## 7. Grow the default set (the "add a pattern" workflow)
 - [ ] Drop a new G6 2×10 `.pat` into `patterns/g6_2x10/_sources/`.
 - [ ] `node tests/generate-default-pattern-set.js` → it's ingested (duty → 128),
-      shipped as the next `patNNNN.pat`, listed in `manifest.json`.
+      shipped as the next `NNN_<name>.pat`, listed in `MANIFEST.txt`.
 - [ ] Reopen the builder → it's in **Available**.
 
 ## 8. Hardware SD round-trip (optional — needs a G6 controller)
-- [ ] Copy `MANIFEST.bin`, `MANIFEST.txt`, `manifest.json` + the `patterns/` folder to the
+- [ ] Copy `MANIFEST.bin`, `MANIFEST.txt` + the `patterns/` folder to the
       **SD card root** (from an exported ZIP, or `patterns/g6_2x10/`). **Seat the card before
       powering on** (firmware mounts SD only at boot).
 - [ ] Connect via `arena_console.html` (or the v3 per-condition dry-run). Send trial-params

--- a/experiment_designer_v3.html
+++ b/experiment_designer_v3.html
@@ -6545,31 +6545,27 @@
             else psRenderAvailable();
         }
 
-        // Load the Available list from a manifest.json (built-in or remote).
+        // Load the Available list from a MANIFEST.txt (built-in or remote).
         async function psLoadLibrary() {
             if (psState.source === 'local') { psRenderAvailable(); return; }
             const folder = psArenaFolder(psState.arenaConfig);
-            const url = psBaseUrl() + '/patterns/' + folder + '/manifest.json';
+            const url = psBaseUrl() + '/patterns/' + folder + '/MANIFEST.txt';
             psEl.availList.innerHTML = '';
             psEl.availList.appendChild(el('div', { class: 'ps-empty' }, 'Loading ' + url + ' …'));
             try {
                 const resp = await fetch(url, { cache: 'no-store' });
                 if (!resp.ok) throw new Error('HTTP ' + resp.status);
-                const manifest = await resp.json();
+                const parsed = window.PatternSet.parseManifestTxt(await resp.text());
                 const base = psBaseUrl() + '/patterns/' + folder + '/patterns/';
-                const arenaOk = !manifest.arenaConfig || manifest.arenaConfig === psState.arenaConfig;
-                psState.available = Object.keys(manifest.patterns || {}).map((name) => {
-                    const p = manifest.patterns[name];
-                    return {
-                        name,
-                        sourceName: name + '.pat',
-                        meta: p.preview || null,
-                        valid: arenaOk,
-                        reason: arenaOk ? null : 'library is for ' + manifest.arenaConfig,
-                        url: base + p.sd_name,
-                        bytes: null
-                    };
-                });
+                psState.available = parsed.patterns.map((p) => ({
+                    name: p.name,
+                    sourceName: p.name + '.pat',
+                    meta: null,
+                    valid: true,
+                    reason: null,
+                    url: base + p.sd_name,
+                    bytes: null
+                }));
             } catch (err) {
                 psState.available = [];
                 psEl.availList.innerHTML = '';
@@ -6726,7 +6722,6 @@
                 const zip = new JSZip();
                 zip.file('MANIFEST.bin', bundle.manifestBin);
                 zip.file('MANIFEST.txt', bundle.manifestTxt);
-                zip.file('manifest.json', JSON.stringify(bundle.manifestJson, null, 2) + '\n');
                 zip.file('README.txt', bundle.readme);
                 const pf = zip.folder('patterns');
                 for (const p of bundle.patterns) pf.file(p.name, p.bytes);

--- a/js/arena-link.js
+++ b/js/arena-link.js
@@ -95,9 +95,13 @@ const ArenaLink = (function () {
             // pulled off the front as they arrive.
             this._rxBuf = new Uint8Array(0);
             // The single outstanding request, or null. Shape:
-            // { expectedCmd, resolve, reject, timer }. Single-flight: there is
+            // { expectedCmd, resolve, reject, timer, bulkInit? }. Single-flight: there is
             // never more than one.
             this._inflight = null;
+            // Active bulk-read state (set while receiving raw bytes for 0x84). When
+            // non-null, _consumeIncoming routes bytes here instead of frame-parsing.
+            // Shape: { remaining, chunks, resolve, reject, timer }
+            this._bulkRead = null;
             // Serializes concurrent send() callers into one-at-a-time requests.
             this._sendQueue = Promise.resolve();
 
@@ -218,6 +222,106 @@ const ArenaLink = (function () {
             return result;
         }
 
+        /**
+         * Send a request and receive the raw bulk data that the firmware streams
+         * after its standard response header. Designed for 0x84 get-pattern-file:
+         * the firmware sends [length, 0, echo, size_b0..b7] as a normal response
+         * frame, then writes `size` raw bytes directly to the transport without
+         * framing. This method handles both the framed header and the raw bytes,
+         * returning a Promise<Uint8Array> that resolves to the complete file data.
+         *
+         * @param {Uint8Array|number[]} bytes request frame
+         * @param {object} [opts]
+         * @param {number} [opts.timeoutMs=30000] applies to both header and data phases
+         * @returns {Promise<Uint8Array>}
+         */
+        sendBulkRead(bytes, opts) {
+            const run = () => this._sendOneBulkRead(bytes, opts);
+            const result = this._sendQueue.then(run, run);
+            this._sendQueue = result.then(() => {}, () => {});
+            return result;
+        }
+
+        async _sendOneBulkRead(bytes, opts) {
+            if (!this._writer) throw new Error('ArenaLink.sendBulkRead: not connected');
+            const timeoutMs = (opts && opts.timeoutMs) || 30000;
+            const payload = bytes instanceof Uint8Array ? bytes : Uint8Array.from(bytes);
+            const expectedCmd =
+                opts && opts.expectedCmd != null ? opts.expectedCmd : payload[1];
+
+            // Create the data promise now so bulkInit can hold its resolve/reject.
+            let dataResolve, dataReject;
+            const dataPromise = new Promise((res, rej) => {
+                dataResolve = res;
+                dataReject = rej;
+            });
+
+            // Wait for the header frame. The inflight entry carries bulkInit so
+            // _consumeIncoming switches to bulk-drain mode atomically when the
+            // header arrives, before any file bytes can be misread as frames.
+            const headerPromise = new Promise((resolve, reject) => {
+                const entry = {
+                    expectedCmd,
+                    resolve,
+                    reject,
+                    timer: null,
+                    bulkInit: { timeoutMs, dataResolve, dataReject },
+                };
+                entry.timer = setTimeout(() => {
+                    if (this._inflight !== entry) return;
+                    this._inflight = null;
+                    this._rxBuf = new Uint8Array(0);
+                    dataReject(new Error('bulk-read header timeout after ' + timeoutMs + ' ms'));
+                    reject(new Error('bulk-read header timeout after ' + timeoutMs + ' ms'));
+                }, timeoutMs);
+                this._inflight = entry;
+            });
+
+            this._log('->', hexDump(payload));
+            try {
+                await this._writer.write(payload);
+            } catch (err) {
+                if (this._inflight) {
+                    clearTimeout(this._inflight.timer);
+                    this._inflight = null;
+                }
+                dataReject(err);
+                throw err;
+            }
+
+            // Wait for _consumeIncoming to resolve the header and set up _bulkRead.
+            await headerPromise;
+
+            // Return the data promise — resolves with Uint8Array when all file bytes
+            // arrive, or rejects on timeout/error. The send queue stays occupied
+            // until the download finishes.
+            return dataPromise;
+        }
+
+        // Drain `chunk` into the active _bulkRead accumulator. Returns the number of
+        // bytes consumed. If remaining reaches 0, resolves the data promise.
+        _drainToBulk(chunk) {
+            const br = this._bulkRead;
+            if (!br || br.remaining <= 0) return 0;
+            const take = Math.min(chunk.length, br.remaining);
+            if (take > 0) br.chunks.push(chunk.slice(0, take));
+            br.remaining -= take;
+            if (br.remaining <= 0) {
+                clearTimeout(br.timer);
+                this._bulkRead = null;
+                let total = 0;
+                for (const c of br.chunks) total += c.length;
+                const out = new Uint8Array(total);
+                let off = 0;
+                for (const c of br.chunks) {
+                    out.set(c, off);
+                    off += c.length;
+                }
+                br.resolve(out);
+            }
+            return take;
+        }
+
         async _sendOne(bytes, opts) {
             if (!this._writer) throw new Error('ArenaLink.send: not connected');
             const timeoutMs = (opts && opts.timeoutMs) || DEFAULT_TIMEOUT_MS;
@@ -319,7 +423,24 @@ const ArenaLink = (function () {
         // outstanding request — but only if its echo_cmd matches. Same framing as
         // the firmware's SerialManager / NetworkManager: first byte = count of
         // bytes that follow.
+        //
+        // When _bulkRead is active (after a 0x84 response header), bytes are
+        // routed directly to the bulk accumulator without frame parsing.
         _consumeIncoming(chunk) {
+            // Fast path: bulk-read mode — drain raw bytes without frame parsing.
+            if (this._bulkRead) {
+                const taken = this._drainToBulk(chunk);
+                if (taken < chunk.length) {
+                    // More bytes than expected (shouldn't happen in practice).
+                    const leftover = chunk.slice(taken);
+                    const merged = new Uint8Array(this._rxBuf.length + leftover.length);
+                    merged.set(this._rxBuf, 0);
+                    merged.set(leftover, this._rxBuf.length);
+                    this._rxBuf = merged;
+                }
+                return;
+            }
+
             const merged = new Uint8Array(this._rxBuf.length + chunk.length);
             merged.set(this._rxBuf, 0);
             merged.set(chunk, this._rxBuf.length);
@@ -356,6 +477,9 @@ const ArenaLink = (function () {
                     // host/firmware desync. Surface it rather than hide it.
                     clearTimeout(entry.timer);
                     this._inflight = null;
+                    if (entry.bulkInit) {
+                        entry.bulkInit.dataReject(new Error('desync during bulk-read header'));
+                    }
                     entry.reject(
                         new Error(
                             'response echo 0x' +
@@ -372,6 +496,55 @@ const ArenaLink = (function () {
 
                 clearTimeout(entry.timer);
                 this._inflight = null;
+
+                // For bulk-read requests: atomically switch to bulk-drain mode
+                // before resolving so no file bytes can be misread as frames.
+                if (entry.bulkInit) {
+                    const status = frame[1];
+                    if (status !== 0 || frame.length < 11) {
+                        entry.bulkInit.dataReject(
+                            new Error('get-pattern-file error: status=' + status)
+                        );
+                        entry.resolve(frame);
+                        continue;
+                    }
+                    // Extract lower 32 bits of the uint64 LE file size (upper 4 = 0 for <4 GB files).
+                    const sz =
+                        ((frame[3] | (frame[4] << 8) | (frame[5] << 16) | (frame[6] << 24)) >>>
+                            0);
+                    if (sz === 0) {
+                        entry.bulkInit.dataResolve(new Uint8Array(0));
+                        entry.resolve(frame);
+                        continue;
+                    }
+                    // Set up bulk drain.
+                    const bi = entry.bulkInit;
+                    const bulkTimer = setTimeout(() => {
+                        if (this._bulkRead) {
+                            const got = sz - this._bulkRead.remaining;
+                            this._bulkRead = null;
+                            bi.dataReject(
+                                new Error(
+                                    'bulk-read data timeout: got ' + got + '/' + sz + ' bytes'
+                                )
+                            );
+                        }
+                    }, bi.timeoutMs);
+                    this._bulkRead = {
+                        remaining: sz,
+                        chunks: [],
+                        resolve: bi.dataResolve,
+                        reject: bi.dataReject,
+                        timer: bulkTimer,
+                    };
+                    // Drain any file bytes that already arrived with the header frame.
+                    const leftover = this._rxBuf;
+                    this._rxBuf = new Uint8Array(0);
+                    entry.resolve(frame);
+                    if (leftover.length > 0) this._drainToBulk(leftover);
+                    return; // bulk mode active — stop frame parsing
+                }
+
                 entry.resolve(frame);
             }
         }
@@ -396,7 +569,14 @@ const ArenaLink = (function () {
                 clearTimeout(this._inflight.timer);
                 const entry = this._inflight;
                 this._inflight = null;
+                if (entry.bulkInit) entry.bulkInit.dataReject(err);
                 entry.reject(err);
+            }
+            if (this._bulkRead) {
+                clearTimeout(this._bulkRead.timer);
+                const br = this._bulkRead;
+                this._bulkRead = null;
+                br.reject(err);
             }
         }
 

--- a/js/arena-wire-g6.js
+++ b/js/arena-wire-g6.js
@@ -40,6 +40,7 @@ const ArenaWireG6 = (function () {
     // not the single leading length byte the `frame()` helper emits.
     const OPCODES = {
         ALL_OFF: 0x00,
+        SYSTEM_RESET: 0x01, // software reset — acks then reboots (SCB_AIRCR SYSRESETREQ)
         TRIAL_PARAMS: 0x08, // selects mode + pattern (Modes 2/3/4)
         SET_REFRESH_RATE: 0x16,
         GET_REFRESH_RATE: 0x17, // returns current refresh rate as uint16 LE Hz
@@ -165,6 +166,10 @@ const ArenaWireG6 = (function () {
 
     function encodeStop() {
         return frame(OPCODES.STOP_DISPLAY); // 01 30
+    }
+
+    function encodeSystemReset() {
+        return frame(OPCODES.SYSTEM_RESET); // 01 01
     }
 
     /**
@@ -496,6 +501,7 @@ const ArenaWireG6 = (function () {
         encodeAllOn,
         encodeAllOff,
         encodeStop,
+        encodeSystemReset,
         encodeTrialParams,
         encodeSetFramePosition,
         encodeStreamFrame,

--- a/js/arena-wire-g6.js
+++ b/js/arena-wire-g6.js
@@ -42,14 +42,18 @@ const ArenaWireG6 = (function () {
         ALL_OFF: 0x00,
         TRIAL_PARAMS: 0x08, // selects mode + pattern (Modes 2/3/4)
         SET_REFRESH_RATE: 0x16,
-        SET_SPI_CLOCK: 0x17, // uint16 LE MHz (1..30); echoes applied MHz
-        GET_SPI_CLOCK: 0x18, // returns uint16 LE current MHz
-        GET_FRAMES_SENT: 0x19, // returns uint32 LE frames pushed to panels
-        RESET_FRAMES_SENT: 0x1a, // zeroes the frames-sent counter
+        GET_REFRESH_RATE: 0x17, // returns current refresh rate as uint16 LE Hz
+        SET_SPI_CLOCK: 0xC5, // uint16 LE MHz (1..30); echoes applied MHz
+        GET_SPI_CLOCK: 0xC6, // returns uint16 LE current MHz
+        GET_FRAMES_SENT: 0x33, // returns uint32 LE frames pushed to panels
+        RESET_FRAMES_SENT: 0x34, // zeroes the frames-sent counter
         STOP_DISPLAY: 0x30,
         STREAM_FRAME: 0x32, // host-streamed full frame ("FR"+blocks; see encodeStreamFrame)
-        GET_ETHERNET_IP: 0xC0,
-        GET_CONTROLLER_INFO: 0xC1, // returns {version, capability_bitmap}
+        SET_ETHERNET_IP: 0xC0, // reserved — not yet implemented
+        GET_ETHERNET_IP: 0xC1,
+        GET_CONTROLLER_INFO: 0xC2, // returns {version, capability_bitmap}
+        SET_DIAG_OUTPUT: 0xC3, // [len=2,0xC3,on] mute/unmute DEBUG_SERIAL diagnostics
+        GET_DIAG_OUTPUT: 0xC4, // returns current g_dbg_on state (0/1)
         SET_FRAME_POSITION: 0x70, // Mode 3: host-commanded frame index
         ALL_ON: 0xff
     };
@@ -69,7 +73,7 @@ const ArenaWireG6 = (function () {
         CLOSED_LOOP: 4 // analog-in × gain, computed on the controller
     };
 
-    // Capability bitmap bits in the get-controller-info (0xC1) reply
+    // Capability bitmap bits in the get-controller-info (0xC2) reply
     // (controller_info.py / main.js, g6_03-controller.md § 5).
     const CAPABILITY_BITS = [
         [0, 'g6_mode'],
@@ -243,26 +247,38 @@ const ArenaWireG6 = (function () {
         return frame(OPCODES.SET_REFRESH_RATE, u16le(hz, 'hz')); // 03 16 lo hi
     }
 
-    // set-spi-clock (0x17) — panel SPI master clock in whole MHz (u16 LE); echoes
+    // get-refresh-rate (0x17) — read the current re-transmit rate.
+    function encodeGetRefreshRate() {
+        return frame(OPCODES.GET_REFRESH_RATE); // 01 17
+    }
+
+    // get-refresh-rate / set-refresh-rate reply carries the rate as uint16 LE Hz.
+    function decodeRefreshRate(resp) {
+        const r = asResponse(resp);
+        if (!r || !r.ok || r.payload.length < 2) return null;
+        return r.payload[0] | (r.payload[1] << 8);
+    }
+
+    // set-spi-clock (0xC5) — panel SPI master clock in whole MHz (u16 LE); echoes
     // applied MHz. The firmware clamps to 1..30 MHz, so reject out-of-range here.
     function encodeSetSpiClock(mhz) {
         requireInt(mhz, 'mhz');
         if (mhz < 1 || mhz > 30) {
             throw new RangeError('mhz must be 1..30, got ' + mhz);
         }
-        return frame(OPCODES.SET_SPI_CLOCK, u16le(mhz, 'mhz')); // 03 17 lo hi
+        return frame(OPCODES.SET_SPI_CLOCK, u16le(mhz, 'mhz')); // 03 C5 lo hi
     }
 
     function encodeGetSpiClock() {
-        return frame(OPCODES.GET_SPI_CLOCK); // 01 18
+        return frame(OPCODES.GET_SPI_CLOCK); // 01 C6
     }
 
     function encodeGetFramesSent() {
-        return frame(OPCODES.GET_FRAMES_SENT); // 01 19
+        return frame(OPCODES.GET_FRAMES_SENT); // 01 33
     }
 
     function encodeResetFramesSent() {
-        return frame(OPCODES.RESET_FRAMES_SENT); // 01 1A
+        return frame(OPCODES.RESET_FRAMES_SENT); // 01 34
     }
 
     function encodeGetIp() {
@@ -309,7 +325,7 @@ const ArenaWireG6 = (function () {
     }
 
     /**
-     * get-controller-info (0xC1) reply -> {version, capability, capabilities[]}.
+     * get-controller-info (0xC2) reply -> {version, capability, capabilities[]}.
      * Payload is {version_byte, capability_bitmap}.
      */
     function decodeControllerInfo(resp) {
@@ -323,14 +339,14 @@ const ArenaWireG6 = (function () {
         return { version, capability, capabilities };
     }
 
-    // set/get-spi-clock (0x17/0x18) reply carries the clock as uint16 LE MHz.
+    // set/get-spi-clock (0xC5/0xC6) reply carries the clock as uint16 LE MHz.
     function decodeSpiClock(resp) {
         const r = asResponse(resp);
         if (!r || !r.ok || r.payload.length < 2) return null;
         return r.payload[0] | (r.payload[1] << 8);
     }
 
-    // get-frames-sent (0x19) reply carries the master-sent count as uint32 LE.
+    // get-frames-sent (0x33) reply carries the master-sent count as uint32 LE.
     function decodeFramesSent(resp) {
         const r = asResponse(resp);
         if (!r || !r.ok || r.payload.length < 4) return null;
@@ -338,7 +354,7 @@ const ArenaWireG6 = (function () {
         return (m[0] | (m[1] << 8) | (m[2] << 16) | (m[3] << 24)) >>> 0;
     }
 
-    // get-ip (0xC0) reply carries the dotted-quad address as ASCII bytes.
+    // get-ip (0xC1) reply carries the dotted-quad address as ASCII bytes.
     function decodeIp(resp) {
         const r = asResponse(resp);
         if (!r || !r.ok || r.payload.length === 0) return null;

--- a/js/arena-wire-g6.js
+++ b/js/arena-wire-g6.js
@@ -47,6 +47,8 @@ const ArenaWireG6 = (function () {
         GET_SPI_CLOCK: 0xC6, // returns uint16 LE current MHz
         GET_FRAMES_SENT: 0x33, // returns uint32 LE frames pushed to panels
         RESET_FRAMES_SENT: 0x34, // zeroes the frames-sent counter
+        GET_FILE_COUNT: 0x80, // returns pattern file count on SD as uint16 LE
+        GET_PATTERN_FILENAME: 0x82, // [03 82 idx_lo idx_hi] 1-based; returns 1-byte-len + filename
         STOP_DISPLAY: 0x30,
         STREAM_FRAME: 0x32, // host-streamed full frame ("FR"+blocks; see encodeStreamFrame)
         SET_ETHERNET_IP: 0xC0, // reserved — not yet implemented
@@ -289,6 +291,20 @@ const ArenaWireG6 = (function () {
         return frame(OPCODES.GET_CONTROLLER_INFO); // 01 C1
     }
 
+    // get-file-count (0x80) — number of *.pat files in /patterns on the SD card.
+    function encodeGetFileCount() {
+        return frame(OPCODES.GET_FILE_COUNT); // 01 80
+    }
+
+    // get-pattern-filename (0x82) — filename for the 1-based pattern index on SD.
+    function encodeGetPatternFilename(index) {
+        requireInt(index, 'index');
+        if (index < 1) {
+            throw new RangeError('index must be >= 1 (1-based), got ' + index);
+        }
+        return frame(OPCODES.GET_PATTERN_FILENAME, u16le(index, 'index')); // 03 82 lo hi
+    }
+
     // ───────────────────────────── decoders ───────────────────────────────
 
     /**
@@ -354,6 +370,24 @@ const ArenaWireG6 = (function () {
         return (m[0] | (m[1] << 8) | (m[2] << 16) | (m[3] << 24)) >>> 0;
     }
 
+    // get-file-count (0x80) reply carries the count as uint16 LE.
+    function decodeFileCount(resp) {
+        const r = asResponse(resp);
+        if (!r || !r.ok || r.payload.length < 2) return null;
+        return r.payload[0] | (r.payload[1] << 8);
+    }
+
+    // get-pattern-filename (0x82) reply: 1-byte length prefix + ASCII filename chars.
+    function decodePatternFilename(resp) {
+        const r = asResponse(resp);
+        if (!r || !r.ok || r.payload.length < 1) return null;
+        const len = r.payload[0];
+        if (r.payload.length < 1 + len) return null;
+        let s = '';
+        for (let i = 1; i <= len; i++) s += String.fromCharCode(r.payload[i]);
+        return s;
+    }
+
     // get-ip (0xC1) reply carries the dotted-quad address as ASCII bytes.
     function decodeIp(resp) {
         const r = asResponse(resp);
@@ -389,13 +423,17 @@ const ArenaWireG6 = (function () {
         encodeGetControllerInfo,
         // Alias under the name the handoff lists for the get-info request.
         getControllerInfo: encodeGetControllerInfo,
+        encodeGetFileCount,
+        encodeGetPatternFilename,
 
         // Decoders
         decodeResponse,
         decodeControllerInfo,
         decodeSpiClock,
         decodeFramesSent,
-        decodeIp
+        decodeIp,
+        decodeFileCount,
+        decodePatternFilename
     };
 })();
 

--- a/js/arena-wire-g6.js
+++ b/js/arena-wire-g6.js
@@ -49,6 +49,11 @@ const ArenaWireG6 = (function () {
         RESET_FRAMES_SENT: 0x34, // zeroes the frames-sent counter
         GET_FILE_COUNT: 0x80, // returns pattern file count on SD as uint16 LE
         GET_PATTERN_FILENAME: 0x82, // [03 82 idx_lo idx_hi] 1-based; returns 1-byte-len + filename
+        SET_PATTERN_FILENAME: 0x83, // [0x83, idx_lo, idx_hi, len, chars…] rename; returns new uint16 LE index
+        GET_PATTERN_FILE: 0x84,     // [03 84 idx_lo idx_hi] 1-based; response: uint64 LE size, then raw bytes
+        SET_PATTERN_FILE: 0x85,     // [0x85, idx_lo, idx_hi, len64 LE, data…] upload file (bulk stream)
+        DELETE_PATTERN_FILE: 0x86,  // [03 86 idx_lo idx_hi] delete 1-based pattern; idx=0 deletes pattern.temp
+        DELETE_ALL_PATTERNS: 0x8F,  // [01 8F] delete all files in /patterns
         STOP_DISPLAY: 0x30,
         STREAM_FRAME: 0x32, // host-streamed full frame ("FR"+blocks; see encodeStreamFrame)
         SET_ETHERNET_IP: 0xC0, // reserved — not yet implemented
@@ -296,6 +301,50 @@ const ArenaWireG6 = (function () {
         return frame(OPCODES.GET_FILE_COUNT); // 01 80
     }
 
+    // set-pattern-filename (0x83) — rename pattern at 1-based idx (0 = pattern.temp).
+    // Returns new 1-based uint16 index after re-sort via decodeSetPatternFilenameResponse.
+    // Uses opcode-first framing (same as 0x85): [0x83, idx_lo, idx_hi, name_len, chars…]
+    // NOT frame() — the standard length-prefixed framing overflows for filenames > 45 chars
+    // because the length byte would equal or exceed STREAM_FRAME_CMD (0x32 = 50).
+    function encodeSetPatternFilename(index, name) {
+        requireInt(index, 'index');
+        if (index < 0 || index > 0xffff) {
+            throw new RangeError('index must be 0..65535, got ' + index);
+        }
+        const nameBytes = [];
+        for (let i = 0; i < name.length; i++) nameBytes.push(name.charCodeAt(i) & 0xff);
+        if (nameBytes.length === 0 || nameBytes.length > 63) {
+            throw new RangeError('filename must be 1..63 chars, got ' + nameBytes.length);
+        }
+        const idx = u16le(index, 'index');
+        return new Uint8Array([OPCODES.SET_PATTERN_FILENAME, ...idx, nameBytes.length, ...nameBytes]);
+    }
+
+    // set-pattern-file (0x85) — upload a .pat file. Opcode-first framing (NOT
+    // the standard frame() helper): [0x85, idx_lo, idx_hi, len_b0..b7, data…]
+    // idx = 0 writes to /patterns/pattern.temp; idx >= 1 overwrites that pattern.
+    function encodeSetPatternFile(index, data) {
+        requireInt(index, 'index');
+        if (index < 0 || index > 0xffff) {
+            throw new RangeError('index must be 0..65535, got ' + index);
+        }
+        const fileData = data instanceof Uint8Array ? data : new Uint8Array(data);
+        const len = fileData.length;
+        // [0x85, idx_lo, idx_hi, len_b0..b7, file_data…]
+        const out = new Uint8Array(11 + len);
+        out[0] = OPCODES.SET_PATTERN_FILE;
+        out[1] = index & 0xff;
+        out[2] = (index >> 8) & 0xff;
+        // uint64 LE length — upper 4 bytes are 0 (files < 4 GB in practice).
+        out[3] = len & 0xff;
+        out[4] = (len >> 8) & 0xff;
+        out[5] = (len >> 16) & 0xff;
+        out[6] = (len >> 24) & 0xff;
+        out[7] = 0; out[8] = 0; out[9] = 0; out[10] = 0;
+        out.set(fileData, 11);
+        return out;
+    }
+
     // get-pattern-filename (0x82) — filename for the 1-based pattern index on SD.
     function encodeGetPatternFilename(index) {
         requireInt(index, 'index');
@@ -303,6 +352,28 @@ const ArenaWireG6 = (function () {
             throw new RangeError('index must be >= 1 (1-based), got ' + index);
         }
         return frame(OPCODES.GET_PATTERN_FILENAME, u16le(index, 'index')); // 03 82 lo hi
+    }
+
+    // get-pattern-file (0x84) — request raw content of the 1-based pattern.
+    // Use link.sendBulkRead() (not link.send()) to receive the streaming response.
+    function encodeGetPatternFile(index) {
+        requireInt(index, 'index');
+        if (index < 1) throw new RangeError('index must be >= 1 (1-based), got ' + index);
+        return frame(OPCODES.GET_PATTERN_FILE, u16le(index, 'index')); // 03 84 lo hi
+    }
+
+    // delete-all-patterns (0x8F) — delete every file in /patterns.
+    function encodeDeleteAllPatterns() {
+        return frame(OPCODES.DELETE_ALL_PATTERNS); // 01 8F
+    }
+
+    // delete-pattern-file (0x86) — delete the pattern at 1-based index.
+    // index=0 deletes /patterns/pattern.temp if it exists.
+    function encodeDeletePatternFile(index) {
+        requireInt(index, 'index');
+        if (index < 0 || index > 0xffff)
+            throw new RangeError('index out of range [0, 65535], got ' + index);
+        return frame(OPCODES.DELETE_PATTERN_FILE, u16le(index, 'index')); // 03 86 lo hi
     }
 
     // ───────────────────────────── decoders ───────────────────────────────
@@ -377,6 +448,13 @@ const ArenaWireG6 = (function () {
         return r.payload[0] | (r.payload[1] << 8);
     }
 
+    // set-pattern-filename (0x83) response: uint16 LE new 1-based index.
+    function decodeSetPatternFilenameResponse(resp) {
+        const r = asResponse(resp);
+        if (!r || !r.ok || r.payload.length < 2) return null;
+        return r.payload[0] | (r.payload[1] << 8);
+    }
+
     // get-pattern-filename (0x82) reply: 1-byte length prefix + ASCII filename chars.
     function decodePatternFilename(resp) {
         const r = asResponse(resp);
@@ -425,6 +503,11 @@ const ArenaWireG6 = (function () {
         getControllerInfo: encodeGetControllerInfo,
         encodeGetFileCount,
         encodeGetPatternFilename,
+        encodeSetPatternFilename,
+        encodeGetPatternFile,
+        encodeSetPatternFile,
+        encodeDeletePatternFile,
+        encodeDeleteAllPatterns,
 
         // Decoders
         decodeResponse,
@@ -433,7 +516,8 @@ const ArenaWireG6 = (function () {
         decodeFramesSent,
         decodeIp,
         decodeFileCount,
-        decodePatternFilename
+        decodePatternFilename,
+        decodeSetPatternFilenameResponse
     };
 })();
 

--- a/js/arena-wire-g6.js
+++ b/js/arena-wire-g6.js
@@ -54,6 +54,7 @@ const ArenaWireG6 = (function () {
         SET_PATTERN_FILE: 0x85,     // [0x85, idx_lo, idx_hi, len64 LE, data…] upload file (bulk stream)
         DELETE_PATTERN_FILE: 0x86,  // [03 86 idx_lo idx_hi] delete 1-based pattern; idx=0 deletes pattern.temp
         DELETE_ALL_PATTERNS: 0x8F,  // [01 8F] delete all files in /patterns
+        GET_SD_ARCHIVE: 0x8A,       // [01 8A] stream full SD as ZIP; only in ALL_OFF state
         STOP_DISPLAY: 0x30,
         STREAM_FRAME: 0x32, // host-streamed full frame ("FR"+blocks; see encodeStreamFrame)
         SET_ETHERNET_IP: 0xC0, // reserved — not yet implemented
@@ -376,6 +377,12 @@ const ArenaWireG6 = (function () {
         return frame(OPCODES.DELETE_PATTERN_FILE, u16le(index, 'index')); // 03 86 lo hi
     }
 
+    // get-sd-archive (0x8A) — trigger full SD content as a ZIP download.
+    // Only accepted when the display is in ALL_OFF (waiting) state.
+    function encodeGetSdArchive() {
+        return frame(OPCODES.GET_SD_ARCHIVE); // 01 8A
+    }
+
     // ───────────────────────────── decoders ───────────────────────────────
 
     /**
@@ -508,6 +515,7 @@ const ArenaWireG6 = (function () {
         encodeSetPatternFile,
         encodeDeletePatternFile,
         encodeDeleteAllPatterns,
+        encodeGetSdArchive,
 
         // Decoders
         decodeResponse,

--- a/js/arena-wire-g6.js
+++ b/js/arena-wire-g6.js
@@ -48,8 +48,8 @@ const ArenaWireG6 = (function () {
         RESET_FRAMES_SENT: 0x1a, // zeroes the frames-sent counter
         STOP_DISPLAY: 0x30,
         STREAM_FRAME: 0x32, // host-streamed full frame ("FR"+blocks; see encodeStreamFrame)
-        GET_ETHERNET_IP: 0x66,
-        GET_CONTROLLER_INFO: 0x67, // returns {version, capability_bitmap}
+        GET_ETHERNET_IP: 0xC0,
+        GET_CONTROLLER_INFO: 0xC1, // returns {version, capability_bitmap}
         SET_FRAME_POSITION: 0x70, // Mode 3: host-commanded frame index
         ALL_ON: 0xff
     };
@@ -69,7 +69,7 @@ const ArenaWireG6 = (function () {
         CLOSED_LOOP: 4 // analog-in × gain, computed on the controller
     };
 
-    // Capability bitmap bits in the get-controller-info (0x67) reply
+    // Capability bitmap bits in the get-controller-info (0xC1) reply
     // (controller_info.py / main.js, g6_03-controller.md § 5).
     const CAPABILITY_BITS = [
         [0, 'g6_mode'],
@@ -266,11 +266,11 @@ const ArenaWireG6 = (function () {
     }
 
     function encodeGetIp() {
-        return frame(OPCODES.GET_ETHERNET_IP); // 01 66
+        return frame(OPCODES.GET_ETHERNET_IP); // 01 C0
     }
 
     function encodeGetControllerInfo() {
-        return frame(OPCODES.GET_CONTROLLER_INFO); // 01 67
+        return frame(OPCODES.GET_CONTROLLER_INFO); // 01 C1
     }
 
     // ───────────────────────────── decoders ───────────────────────────────
@@ -309,7 +309,7 @@ const ArenaWireG6 = (function () {
     }
 
     /**
-     * get-controller-info (0x67) reply -> {version, capability, capabilities[]}.
+     * get-controller-info (0xC1) reply -> {version, capability, capabilities[]}.
      * Payload is {version_byte, capability_bitmap}.
      */
     function decodeControllerInfo(resp) {
@@ -338,7 +338,7 @@ const ArenaWireG6 = (function () {
         return (m[0] | (m[1] << 8) | (m[2] << 16) | (m[3] << 24)) >>> 0;
     }
 
-    // get-ip (0x66) reply carries the dotted-quad address as ASCII bytes.
+    // get-ip (0xC0) reply carries the dotted-quad address as ASCII bytes.
     function decodeIp(resp) {
         const r = asResponse(resp);
         if (!r || !r.ok || r.payload.length === 0) return null;

--- a/js/pattern-set.js
+++ b/js/pattern-set.js
@@ -10,9 +10,9 @@
  * Follows the MATLAB SD convention (maDisplayTools/utils/prepare_sd_card.m) so a
  * web-built SD is interchangeable with a MATLAB-built one and verifiable the same
  * way:
- *   - pattern files renamed `pat%04d.pat` (1-based; human name lives in the manifest)
+ *   - pattern files renamed `NNN_<name>.pat` (1-based; human name lives in MANIFEST.txt)
  *   - MANIFEST.bin : uint16 count + uint32 unix timestamp, LITTLE-ENDIAN (Teensy native)
- *   - MANIFEST.txt : human-readable map, CRLF line endings
+ *   - MANIFEST.txt : human-readable map + Pattern Set ID, CRLF line endings
  *   - timestamps   : iso `yyyy-mm-ddTHH:MM:SS` (local), unix `uint32`, file `yyyymmdd_HHMMSS`
  *   - `set_id`     == the `yyyymmdd_HHMMSS` string (the binding key, generated at export)
  *
@@ -267,6 +267,27 @@
     }
 
     // ── manifest writers ───────────────────────────────────────────────────────
+
+    // FNV-1a 32-bit over sorted SD filenames, each followed by '\n'.
+    // Matches the Teensy firmware's patternSetId() in SdManager.cpp.
+    var _imul = Math.imul || function (a, b) {
+        var ah = (a >>> 16) & 0xffff, al = a & 0xffff;
+        var bh = (b >>> 16) & 0xffff, bl = b & 0xffff;
+        return ((al * bh + ah * bl) << 16) | (al * bl);
+    };
+    function computePatternSetId(sdNames) {
+        var h = 2166136261;
+        for (var i = 0; i < sdNames.length; i++) {
+            for (var j = 0; j < sdNames[i].length; j++) {
+                h = (h ^ sdNames[i].charCodeAt(j)) >>> 0;
+                h = _imul(h, 16777619) >>> 0;
+            }
+            h = (h ^ 10) >>> 0;
+            h = _imul(h, 16777619) >>> 0;
+        }
+        return ('00000000' + h.toString(16).toUpperCase()).slice(-8);
+    }
+
     /** MANIFEST.bin: uint16 count + uint32 unix timestamp, little-endian. */
     function buildManifestBin(count, unix) {
         var buf = new ArrayBuffer(6);
@@ -276,45 +297,22 @@
         return new Uint8Array(buf);
     }
 
-    /** MANIFEST.txt: human-readable map, CRLF (matches prepare_sd_card.m). */
+    /** MANIFEST.txt: human-readable map + Pattern Set ID, CRLF (matches prepare_sd_card.m). */
     function buildManifestTxt(set, ts, opts) {
         opts = opts || {};
         var sdDrive = opts.sdDrive || '(copy to the SD card root)';
+        var sdNames = set.items.map(function (it) { return it.sd_name; });
         var lines = [];
         lines.push('Timestamp: ' + ts.iso);
         lines.push('SD Drive: ' + sdDrive);
         lines.push('Pattern Count: ' + set.items.length);
+        lines.push('Pattern Set ID: ' + computePatternSetId(sdNames));
         lines.push('');
         lines.push('Mapping:');
         for (var i = 0; i < set.items.length; i++) {
             lines.push(set.items[i].sd_name + ' <- ' + set.items[i].name);
         }
         return lines.join('\r\n') + '\r\n';
-    }
-
-    /** manifest.json: the web index for the LAB-95/96 pickers (same instant as the .bin). */
-    function buildManifestJson(set, ts) {
-        var patterns = {};
-        for (var i = 0; i < set.items.length; i++) {
-            var it = set.items[i];
-            patterns[it.name] = {
-                index: it.index,
-                sd_name: it.sd_name,
-                arenaConfig: set.arenaConfig,
-                preview: it.preview,
-                matlabPath: it.matlabPath || null
-            };
-        }
-        return {
-            tool: TOOL,
-            version: MANIFEST_VERSION,
-            set_id: ts.file,
-            created_iso: ts.iso,
-            created_unix: ts.unix,
-            arenaConfig: set.arenaConfig,
-            source: set.source,
-            patterns: patterns
-        };
     }
 
     function buildReadme(set, ts) {
@@ -333,7 +331,7 @@
         lines.push('      patterns/');
         lines.push('        ' + ex1);
         lines.push('        ' + ex2 + '  ...');
-        lines.push('      MANIFEST.bin   MANIFEST.txt   manifest.json   README.txt');
+        lines.push('      MANIFEST.bin   MANIFEST.txt   README.txt');
         lines.push('');
         lines.push('  - Do NOT drop a wrapper folder on the card -- "patterns" sits at the root.');
         lines.push('  - Do NOT rename the .pat files -- the NNN_ prefix sets the pattern_ID');
@@ -352,7 +350,7 @@
     /**
      * Produce everything for a bundle ZIP / SD image in one call (used by the
      * designer modal and the Node default-set generator). Validates first.
-     * @returns { ts, set_id, manifestBin, manifestTxt, manifestJson, readme,
+     * @returns { ts, set_id, manifestBin, manifestTxt, readme,
      *            patterns: [{ name: sd_name, bytes: ArrayBuffer }] }
      */
     function buildBundle(set, opts) {
@@ -383,7 +381,6 @@
             set_id: ts.file,
             manifestBin: buildManifestBin(set.items.length, ts.unix),
             manifestTxt: buildManifestTxt(set, ts, opts),
-            manifestJson: buildManifestJson(set, ts),
             readme: buildReadme(set, ts),
             patterns: set.items.map(function (it) {
                 return { name: it.sd_name, bytes: it.bytes };
@@ -391,10 +388,10 @@
         };
     }
 
-    // ── read API (LAB-95/96 pickers) ────────────────────────────────────────────
-    /** Parse a MANIFEST.txt back into { timestamp, count, patterns:[{sd_name,index,name}] }. */
+    // ── read API ────────────────────────────────────────────────────────────────
+    /** Parse a MANIFEST.txt back into { timestamp, count, pattern_set_id, patterns:[{sd_name,index,name}] }. */
     function parseManifestTxt(text) {
-        var out = { timestamp: null, count: null, patterns: [] };
+        var out = { timestamp: null, count: null, pattern_set_id: null, patterns: [] };
         var lines = String(text).split(/\r\n|\n|\r/);
         var inMap = false;
         for (var i = 0; i < lines.length; i++) {
@@ -403,6 +400,8 @@
                 out.timestamp = line.replace(/^Timestamp:\s*/, '').trim();
             } else if (/^Pattern Count:\s*/.test(line)) {
                 out.count = parseInt(line.replace(/^Pattern Count:\s*/, ''), 10);
+            } else if (/^Pattern Set ID:\s*/.test(line)) {
+                out.pattern_set_id = line.replace(/^Pattern Set ID:\s*/, '').trim();
             } else if (/^Mapping:\s*$/.test(line)) {
                 inMap = true;
             } else if (inMap) {
@@ -417,16 +416,6 @@
             }
         }
         return out;
-    }
-
-    function loadManifestJson(json) {
-        return typeof json === 'string' ? JSON.parse(json) : json;
-    }
-
-    /** Resolve a pattern name → 1-based SD index from a manifest.json object. */
-    function resolveIndex(manifest, name) {
-        if (!manifest || !manifest.patterns || !manifest.patterns[name]) return null;
-        return manifest.patterns[name].index;
     }
 
     var PatternSet = {
@@ -447,16 +436,14 @@
         validateGeometry: validateGeometry,
         reencodeForDuty: reencodeForDuty,
         makeTimestamps: makeTimestamps,
+        computePatternSetId: computePatternSetId,
         // manifests / bundle
         buildManifestBin: buildManifestBin,
         buildManifestTxt: buildManifestTxt,
-        buildManifestJson: buildManifestJson,
         buildReadme: buildReadme,
         buildBundle: buildBundle,
         // read API
-        parseManifestTxt: parseManifestTxt,
-        loadManifestJson: loadManifestJson,
-        resolveIndex: resolveIndex
+        parseManifestTxt: parseManifestTxt
     };
 
     // Dual export — browser global + Node (CommonJS). Deliberately NO bare top-level

--- a/serial_raw_monitor.html
+++ b/serial_raw_monitor.html
@@ -132,11 +132,11 @@
                 for (const b of chunk) scan.push(b);
                 if (scan.length > 512) scan = scan.slice(scan.length - 512);
                 for (let i = 0; i + 4 < scan.length; i++) {
-                    if (scan[i] === 0x00 && scan[i + 1] === 0x67) {
+                    if (scan[i] === 0x00 && scan[i + 1] === 0xC1) {
                         const len = scan[i - 1], ver = scan[i + 2], cap = scan[i + 3];
                         log(
                             `✓ controller-info reply found in stream: len=0x${(len ?? 0)
-                                .toString(16)} status=00 echo=0x67 → version ${ver}, cap 0x${cap
+                                .toString(16)} status=00 echo=0xC1 → version ${ver}, cap 0x${cap
                                 .toString(16).padStart(2, '0')}`,
                             'hit'
                         );

--- a/tests/generate-default-pattern-set.js
+++ b/tests/generate-default-pattern-set.js
@@ -4,8 +4,8 @@
  *
  * Writes patterns/g6_2x10/ in the MATLAB SD convention (via js/pattern-set.js):
  *   patterns/g6_2x10/
- *     MANIFEST.bin   MANIFEST.txt   manifest.json   README.txt
- *     patterns/pat0001.pat pat0002.pat …
+ *     MANIFEST.bin   MANIFEST.txt   README.txt
+ *     patterns/NNN_<name>.pat …
  *
  * This folder is BOTH a ready copy-to-SD bundle AND the "Built-in library" source
  * the Experiment Designer's Pattern Set builder fetches (relative ./patterns/g6_2x10/).
@@ -168,10 +168,6 @@ for (const f of fs.readdirSync(PAT_DIR)) {
 }
 fs.writeFileSync(path.join(OUT_DIR, 'MANIFEST.bin'), Buffer.from(bundle.manifestBin));
 fs.writeFileSync(path.join(OUT_DIR, 'MANIFEST.txt'), bundle.manifestTxt);
-fs.writeFileSync(
-    path.join(OUT_DIR, 'manifest.json'),
-    JSON.stringify(bundle.manifestJson, null, 2) + '\n'
-);
 fs.writeFileSync(path.join(OUT_DIR, 'README.txt'), bundle.readme);
 for (const p of bundle.patterns) {
     fs.writeFileSync(path.join(PAT_DIR, p.name), Buffer.from(p.bytes));

--- a/tests/test-arena-link.js
+++ b/tests/test-arena-link.js
@@ -170,10 +170,10 @@ function setup(opts) {
 }
 
 // Canonical request encoders + matching response frames.
-const REQ_INFO = '01 C1';
-const REQ_SPI = '01 18';
-const RESP_INFO = Uint8Array.from([0x04, 0x00, 0xC1, 0x02, 0x11]); // echo 0xC1
-const RESP_SPI = Uint8Array.from([0x04, 0x00, 0x18, 0x14, 0x00]); // echo 0x18
+const REQ_INFO = '01 C2';
+const REQ_SPI = '01 C6';
+const RESP_INFO = Uint8Array.from([0x04, 0x00, 0xC2, 0x02, 0x11]); // echo 0xC2
+const RESP_SPI = Uint8Array.from([0x04, 0x00, 0xC6, 0x14, 0x00]); // echo 0xC6
 
 async function main() {
     console.log('=== feature detection ===');
@@ -215,7 +215,7 @@ async function main() {
         await link.connect();
         const p = link.send(Wire.encodeGetControllerInfo()); // expects echo 0x67
         await flush();
-        reader.push(RESP_SPI); // echo 0x18 — wrong
+        reader.push(RESP_SPI); // echo 0xC6 — wrong
         await checkRejects('mismatched echo rejects as desync', p, /desync/);
         await link.close();
     }
@@ -228,9 +228,9 @@ async function main() {
         await flush();
         reader.push([0x04, 0x00]); // first half of the frame
         await flush();
-        reader.push([0xC1, 0x02, 0x11]); // second half
+        reader.push([0xC2, 0x02, 0x11]); // second half
         const frame = await p;
-        checkBytes('split frame reassembled', frame, '04 00 C1 02 11');
+        checkBytes('split frame reassembled', frame, '04 00 C2 02 11');
         await link.close();
     }
 

--- a/tests/test-arena-link.js
+++ b/tests/test-arena-link.js
@@ -170,9 +170,9 @@ function setup(opts) {
 }
 
 // Canonical request encoders + matching response frames.
-const REQ_INFO = '01 67';
+const REQ_INFO = '01 C1';
 const REQ_SPI = '01 18';
-const RESP_INFO = Uint8Array.from([0x04, 0x00, 0x67, 0x02, 0x11]); // echo 0x67
+const RESP_INFO = Uint8Array.from([0x04, 0x00, 0xC1, 0x02, 0x11]); // echo 0xC1
 const RESP_SPI = Uint8Array.from([0x04, 0x00, 0x18, 0x14, 0x00]); // echo 0x18
 
 async function main() {
@@ -201,7 +201,7 @@ async function main() {
         checkBytes('request written to port', writer.writes[0], REQ_INFO);
         reader.push(RESP_INFO);
         const frame = await p;
-        checkBytes('resolves with response frame', frame, '04 00 67 02 11');
+        checkBytes('resolves with response frame', frame, '04 00 C1 02 11');
         const info = Wire.decodeControllerInfo(Wire.decodeResponse(frame));
         checkBool('frame decodes (version=2)', info && info.version === 2);
         await link.close();
@@ -228,9 +228,9 @@ async function main() {
         await flush();
         reader.push([0x04, 0x00]); // first half of the frame
         await flush();
-        reader.push([0x67, 0x02, 0x11]); // second half
+        reader.push([0xC1, 0x02, 0x11]); // second half
         const frame = await p;
-        checkBytes('split frame reassembled', frame, '04 00 67 02 11');
+        checkBytes('split frame reassembled', frame, '04 00 C1 02 11');
         await link.close();
     }
 

--- a/tests/test-arena-wire-g6.js
+++ b/tests/test-arena-wire-g6.js
@@ -246,5 +246,27 @@ const ipAscii = '10.0.0.5';
 const ipBytes = [ipAscii.length + 2, 0x00, 0xC1, ...Array.from(ipAscii, (c) => c.charCodeAt(0))];
 check('decodeIp', Wire.decodeIp(Uint8Array.from(ipBytes)), '10.0.0.5');
 
+console.log('\n=== set-pattern-filename (0x83) opcode-first framing ===');
+// Short name: [0x83, idx_lo, idx_hi, name_len, chars...] — NO leading length byte.
+// "a.pat" (5 chars), idx=0 → [83 00 00 05 61 2e 70 61 74]
+checkBytes(
+    'encodeSetPatternFilename idx=0 short',
+    Wire.encodeSetPatternFilename(0, 'a.pat'),
+    '83 00 00 05 61 2e 70 61 74'
+);
+// 50-char name (the failing case): length would have been 0x36 > 0x32 in the old framing.
+// With opcode-first, the first byte is always 0x83 regardless of name length.
+const longName = '0019_right_window_yaw_stepsize0.46875_final_G6.pat'; // 50 chars
+const longFrame = Wire.encodeSetPatternFilename(0, longName);
+check('encodeSetPatternFilename long: first byte is opcode 0x83', longFrame[0], 0x83);
+check('encodeSetPatternFilename long: length byte absent (frame.length = 4+name)', longFrame.length, 54);
+check('encodeSetPatternFilename long: name_len byte = 50', longFrame[3], 50);
+checkThrows('encodeSetPatternFilename 64-char name throws', () =>
+    Wire.encodeSetPatternFilename(0, 'a'.repeat(64))
+);
+checkThrows('encodeSetPatternFilename empty name throws', () =>
+    Wire.encodeSetPatternFilename(0, '')
+);
+
 console.log(`\n=== Summary ===\n${totalChecks - failures} / ${totalChecks} checks passed`);
 process.exit(failures > 0 ? 1 : 0);

--- a/tests/test-arena-wire-g6.js
+++ b/tests/test-arena-wire-g6.js
@@ -174,14 +174,14 @@ checkThrows('stream wrong size 100 throws', () => Wire.encodeStreamFrame(new Uin
 checkThrows('stream wrong size 4063 throws', () => Wire.encodeStreamFrame(new Uint8Array(4063)));
 
 console.log('\n=== decodeResponse framing ===');
-// get-controller-info reply: [len=4, status=0, echo=0xC1, version=2, cap=0x11].
+// get-controller-info reply: [len=4, status=0, echo=0xC2, version=2, cap=0x11].
 // length byte = 4 = status + echo + 2 payload bytes.
-const ciFrame = Uint8Array.from([0x04, 0x00, 0xC1, 0x02, 0x11]);
+const ciFrame = Uint8Array.from([0x04, 0x00, 0xC2, 0x02, 0x11]);
 const ci = Wire.decodeResponse(ciFrame);
 checkBool('decodeResponse returns object', !!ci);
 check('  .length', ci.length, 4);
 check('  .status', ci.status, 0);
-check('  .echoCmd', ci.echoCmd, 0xC1);
+check('  .echoCmd', ci.echoCmd, 0xC2);
 check('  .ok', ci.ok, true);
 checkBytes('  .payload', ci.payload, '02 11');
 
@@ -195,12 +195,12 @@ checkBool('empty frame -> null', Wire.decodeResponse(new Uint8Array([])) === nul
 checkBool('length<2 -> null', Wire.decodeResponse(Uint8Array.from([0x01, 0x00])) === null);
 checkBool(
     'incomplete frame -> null',
-    Wire.decodeResponse(Uint8Array.from([0x05, 0x00, 0xC1, 0x02])) === null,
+    Wire.decodeResponse(Uint8Array.from([0x05, 0x00, 0xC2, 0x02])) === null,
     'claims 5 bytes, only 3 present'
 );
 // Regression: a plain number[] must NOT throw (TypedArray.slice rejects a
 // non-typed-array receiver — decodeResponse normalizes to Uint8Array first).
-const ciArr = Wire.decodeResponse([0x04, 0x00, 0xC1, 0x02, 0x11]);
+const ciArr = Wire.decodeResponse([0x04, 0x00, 0xC2, 0x02, 0x11]);
 checkBool('decodeResponse(number[]) does not throw', !!ciArr);
 checkBytes('decodeResponse(number[]) payload', ciArr.payload, '02 11');
 
@@ -218,32 +218,32 @@ checkBool(
 // A non-OK controller-info reply must not be decoded as valid metadata.
 checkBool(
     'decodeControllerInfo rejects status!=0',
-    Wire.decodeControllerInfo(Uint8Array.from([0x04, 0x01, 0xC1, 0x02, 0x11])) === null
+    Wire.decodeControllerInfo(Uint8Array.from([0x04, 0x01, 0xC2, 0x02, 0x11])) === null
 );
 
-// SPI clock reply: [len=4, status=0, echo=0x18, 20, 0] -> 20 MHz.
-check('decodeSpiClock', Wire.decodeSpiClock(Uint8Array.from([0x04, 0x00, 0x18, 0x14, 0x00])), 20);
+// SPI clock reply: [len=4, status=0, echo=0xC6, 20, 0] -> 20 MHz.
+check('decodeSpiClock', Wire.decodeSpiClock(Uint8Array.from([0x04, 0x00, 0xC6, 0x14, 0x00])), 20);
 checkBool(
     'decodeSpiClock rejects status!=0',
-    Wire.decodeSpiClock(Uint8Array.from([0x04, 0x01, 0x18, 0x14, 0x00])) === null
+    Wire.decodeSpiClock(Uint8Array.from([0x04, 0x01, 0xC6, 0x14, 0x00])) === null
 );
 
 // frames-sent reply: u32 LE. 0x12345678 -> 78 56 34 12.
 check(
     'decodeFramesSent',
-    Wire.decodeFramesSent(Uint8Array.from([0x06, 0x00, 0x19, 0x78, 0x56, 0x34, 0x12])),
+    Wire.decodeFramesSent(Uint8Array.from([0x06, 0x00, 0x33, 0x78, 0x56, 0x34, 0x12])),
     0x12345678
 );
 // High-bit-set value confirms unsigned (>>> 0) handling: 0xFFFFFFFF.
 check(
     'decodeFramesSent unsigned',
-    Wire.decodeFramesSent(Uint8Array.from([0x06, 0x00, 0x19, 0xff, 0xff, 0xff, 0xff])),
+    Wire.decodeFramesSent(Uint8Array.from([0x06, 0x00, 0x33, 0xff, 0xff, 0xff, 0xff])),
     4294967295
 );
 
 // get-ip reply: ASCII payload "10.0.0.5".
 const ipAscii = '10.0.0.5';
-const ipBytes = [ipAscii.length + 2, 0x00, 0xC0, ...Array.from(ipAscii, (c) => c.charCodeAt(0))];
+const ipBytes = [ipAscii.length + 2, 0x00, 0xC1, ...Array.from(ipAscii, (c) => c.charCodeAt(0))];
 check('decodeIp', Wire.decodeIp(Uint8Array.from(ipBytes)), '10.0.0.5');
 
 console.log(`\n=== Summary ===\n${totalChecks - failures} / ${totalChecks} checks passed`);

--- a/tests/test-arena-wire-g6.js
+++ b/tests/test-arena-wire-g6.js
@@ -174,14 +174,14 @@ checkThrows('stream wrong size 100 throws', () => Wire.encodeStreamFrame(new Uin
 checkThrows('stream wrong size 4063 throws', () => Wire.encodeStreamFrame(new Uint8Array(4063)));
 
 console.log('\n=== decodeResponse framing ===');
-// get-controller-info reply: [len=4, status=0, echo=0x67, version=2, cap=0x11].
+// get-controller-info reply: [len=4, status=0, echo=0xC1, version=2, cap=0x11].
 // length byte = 4 = status + echo + 2 payload bytes.
-const ciFrame = Uint8Array.from([0x04, 0x00, 0x67, 0x02, 0x11]);
+const ciFrame = Uint8Array.from([0x04, 0x00, 0xC1, 0x02, 0x11]);
 const ci = Wire.decodeResponse(ciFrame);
 checkBool('decodeResponse returns object', !!ci);
 check('  .length', ci.length, 4);
 check('  .status', ci.status, 0);
-check('  .echoCmd', ci.echoCmd, 0x67);
+check('  .echoCmd', ci.echoCmd, 0xC1);
 check('  .ok', ci.ok, true);
 checkBytes('  .payload', ci.payload, '02 11');
 
@@ -195,12 +195,12 @@ checkBool('empty frame -> null', Wire.decodeResponse(new Uint8Array([])) === nul
 checkBool('length<2 -> null', Wire.decodeResponse(Uint8Array.from([0x01, 0x00])) === null);
 checkBool(
     'incomplete frame -> null',
-    Wire.decodeResponse(Uint8Array.from([0x05, 0x00, 0x67, 0x02])) === null,
+    Wire.decodeResponse(Uint8Array.from([0x05, 0x00, 0xC1, 0x02])) === null,
     'claims 5 bytes, only 3 present'
 );
 // Regression: a plain number[] must NOT throw (TypedArray.slice rejects a
 // non-typed-array receiver — decodeResponse normalizes to Uint8Array first).
-const ciArr = Wire.decodeResponse([0x04, 0x00, 0x67, 0x02, 0x11]);
+const ciArr = Wire.decodeResponse([0x04, 0x00, 0xC1, 0x02, 0x11]);
 checkBool('decodeResponse(number[]) does not throw', !!ciArr);
 checkBytes('decodeResponse(number[]) payload', ciArr.payload, '02 11');
 
@@ -218,7 +218,7 @@ checkBool(
 // A non-OK controller-info reply must not be decoded as valid metadata.
 checkBool(
     'decodeControllerInfo rejects status!=0',
-    Wire.decodeControllerInfo(Uint8Array.from([0x04, 0x01, 0x67, 0x02, 0x11])) === null
+    Wire.decodeControllerInfo(Uint8Array.from([0x04, 0x01, 0xC1, 0x02, 0x11])) === null
 );
 
 // SPI clock reply: [len=4, status=0, echo=0x18, 20, 0] -> 20 MHz.
@@ -243,7 +243,7 @@ check(
 
 // get-ip reply: ASCII payload "10.0.0.5".
 const ipAscii = '10.0.0.5';
-const ipBytes = [ipAscii.length + 2, 0x00, 0x66, ...Array.from(ipAscii, (c) => c.charCodeAt(0))];
+const ipBytes = [ipAscii.length + 2, 0x00, 0xC0, ...Array.from(ipAscii, (c) => c.charCodeAt(0))];
 check('decodeIp', Wire.decodeIp(Uint8Array.from(ipBytes)), '10.0.0.5');
 
 console.log(`\n=== Summary ===\n${totalChecks - failures} / ${totalChecks} checks passed`);

--- a/tests/test-pattern-set.js
+++ b/tests/test-pattern-set.js
@@ -189,22 +189,16 @@ console.log('\n=== timestamp formats ===');
     check('unix', ts.unix, Math.floor(d.getTime() / 1000));
 }
 
-// ── 7. manifest.json shape + bundle ──────────────────────────────────────────────
-console.log('\n=== manifest.json + buildBundle ===');
+// ── 7. buildBundle ───────────────────────────────────────────────────────────────
+console.log('\n=== buildBundle ===');
 {
     const set = fresh2x10Set(2);
     const bundle = PS.buildBundle(set);
-    const mj = bundle.manifestJson;
-    check('set_id == file timestamp', mj.set_id, bundle.ts.file);
-    check('manifest tool', mj.tool, 'webDisplayTools/pattern-set');
-    check('manifest arenaConfig', mj.arenaConfig, 'G6_2x10');
-    const firstName = set.items[0].name;
-    check('patterns[name].index', mj.patterns[firstName].index, 1);
-    check('patterns[name].sd_name', mj.patterns[firstName].sd_name, set.items[0].sd_name);
-    check('resolveIndex', PS.resolveIndex(mj, firstName), 1);
     check('bundle exposes 2 pattern files', bundle.patterns.length, 2);
     check('bundle file 1 name', bundle.patterns[0].name, set.items[0].sd_name);
-    checkBool('bundle README mentions SD root', bundle.readme.indexOf('SD card') !== -1);
+    checkBool('bundle README mentions SD card', bundle.readme.indexOf('SD card') !== -1);
+    checkBool('bundle has no manifestJson', !('manifestJson' in bundle));
+    checkBool('MANIFEST.txt has Pattern Set ID', bundle.manifestTxt.indexOf('Pattern Set ID:') !== -1);
     checkThrows('buildBundle refuses an empty set', () =>
         PS.buildBundle(PS.createPatternSet({ arenaConfig: 'G6_2x10' }))
     );


### PR DESCRIPTION
the arena_console here demonstrates the full SD card round-trip for .pat files described in LAB-79. The console can now push a pattern to the card, download it, create previews, delete a specific file, and purge the whole patterns folder on the SD card.